### PR TITLE
Allow running with `cargo deny`

### DIFF
--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -63,7 +63,15 @@ Possible values:
 
 fn real_main() -> Result<(), Error> {
     use slog::Drain;
-    let args = Opts::from_args();
+    let args = Opts::from_iter({
+        let mut raw: Vec<String> = std::env::args().collect();
+        // Running this as a cargo subcommand gives us our name as an argument,
+        // so we'll discard that before parsing.
+        if raw.get(1).map(String::as_str) == Some("deny") {
+            raw.remove(1);
+        }
+        raw
+    });
 
     let drain = match args.msg_format {
         MessageFormat::Human => {


### PR DESCRIPTION
You currently can't run `cargo-deny` with `cargo deny`, since [that passes "deny" as the 2nd arg](https://doc.rust-lang.org/cargo/reference/external-tools.html#custom-subcommands) and the parser doesn't like that.

This PR removes the 2nd arg if it's "deny", which is the same solution I've been using in my cargo tools.