### PR TITLE
Fix for crates using custom relative license-file paths in the Cargo.toml.

### DIFF
--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -379,7 +379,11 @@ impl LicensePack {
         // already found in the root directory
         if let Some(ref lf) = krate.license_file {
             if lic_paths.iter().find(|l| l.ends_with(lf)).is_none() {
-                lic_paths.push(lf.clone());
+                // The `krate.license_file` is relative to the crate, while files found with
+                // `find_license_files()` are absolute. We prepend the directory of the current
+                // crate, to make sure all license file paths will be absolute.
+                let absolute_lf = krate.manifest_path.parent().unwrap().join(lf);
+                lic_paths.push(absolute_lf);
             }
         }
 


### PR DESCRIPTION
There are currently two ways which this crate uses to discover license
files.

The first method searches for paths starting with "LICENSE"
in the root of the current crate.
The second, uses a path specified by a crate author (in the Cargo.toml,
under the package table, a license-file can be specified).

The paths collected by the first method are absolute.
The path collected by the second is, however, relative to the crate.

The program however expects the paths to be absolute. For example,
in 'get_expression()', paths will be made relative by using the
'strip_prefix' method on the path. If the path is already relative,
as was the case before this commit, the program crashes.

Now perhaps the bug can also be fixed by making all paths relative,
however since I'm not well acquainted with the code base it is difficult
to make such a judgement, and as such this fix seemed safer to me.

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Changes the license-file as specified by a crate author to be used internally as an absolute path instead of a relative path.

I'd like them included because I use these kinds of paths in my [sic](https://github.com/foresterre/sic) program and would like to keep using them. I discover the bug while attempting to run cargo-deny on the CI. 

### Related Issues

issue: #45
