### PR TITLE
Add license exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,9 @@ Now each license has to be explicitly approved, either by listing them in `licen
 ### Added
 - Initial implementation release
 
-[Unreleased]: https://github.com/EmbarkStudios/cargo-deny/compare/0.4.2...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/cargo-deny/compare/0.5.1...HEAD
+[0.5.1]: https://github.com/EmbarkStudios/cargo-deny/compare/0.5.0...0.5.1
+[0.5.0]: https://github.com/EmbarkStudios/cargo-deny/compare/0.4.2...0.5.0
 [0.4.2]: https://github.com/EmbarkStudios/cargo-deny/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/EmbarkStudios/cargo-deny/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/EmbarkStudios/cargo-deny/compare/0.3.0...0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- next-header -->
 
-## [0.5.2] - 2019-12-20
+## [Unreleased] - ReleaseDate
 ### Added
 - Resolved [#53](https://github.com/EmbarkStudios/cargo-deny/issues/53) by adding `[licenses.exceptions]`, which lets you allow 1 or more licenses only for a particular crate. Thanks for reporting [@iliana](https://github.com/iliana)!
 
@@ -103,6 +103,7 @@ Now each license has to be explicitly approved, either by listing them in `licen
 ### Added
 - Initial implementation release
 
+<!-- next-url -->
 [Unreleased]: https://github.com/EmbarkStudios/cargo-deny/compare/0.5.1...HEAD
 [0.5.1]: https://github.com/EmbarkStudios/cargo-deny/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/EmbarkStudios/cargo-deny/compare/0.4.2...0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2019-12-20
+### Added
+- Resolved [#53](https://github.com/EmbarkStudios/cargo-deny/issues/53) by adding `[licenses.exceptions]`, which lets you allow 1 or more licenses only for a particular crate. Thanks for reporting [@iliana](https://github.com/iliana)!
+
 ## [0.5.1] - 2019-12-19
 ### Fixed
 - Fixed issue where both `--manifest-path` and working directory were set when executing `cargo-metadata`, causing it to fail if a executed in a subdirectory.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,36 @@ allow = [ "GPL-3.0" ]
 deny = [ "GPL-2.0" ]
 ```
 
+#### The `exceptions` field (optional)
+
+The license configuration generally applies the entire crate graph, but this means that, allowing a specific license applies to all possible crates, even if only 1 crate actually uses that license. The `exceptions` field is meant to allow licenses only for particular crates, so as to make a clear distinction between licenses are fine with everywhere, versus ones which you want to be more selective about, and not have implicitly allowed in the future.
+
+##### The `name` field
+
+The name of the crate that you are adding an exception for
+
+##### The `version` field (optional)
+
+An optional version constraint specifying the range of crate versions you are excepting. Defaults to all versions (`*`).
+
+##### The `allow` field
+
+This is the exact same as the general `allow` field.
+
+```toml
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+]
+exceptions = [
+    # This is the only crate that cannot be licensed with either Apache-2.0
+    # or MIT, so we just add an exception for it, meaning we'll get a warning
+    # if we add another crate that also requires this license
+    { name = "cloudabi", allow = ["BSD-2-Clause"] },
+]
+```
+
 #### The `copyleft` field (optional)
 
 Determines what happens when a license that is considered [copyleft](https://en.wikipedia.org/wiki/Copyleft) is encountered.

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,8 @@ copyleft = "deny"
 confidence-threshold = 0.93
 allow = [
     "Apache-2.0",
-    "BSD-2-Clause",
     "MIT",
-    "Zlib",
+]
+exceptions = [
+    { name = "cloudabi", allow = ["BSD-2-Clause"] },
 ]

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,11 @@
+pre-release-commit-message = "Release {{version}}"
+no-dev-version = true
+tag-message = "Release {{version}}"
+tag-name = "{{version}}"
+pre-release-replacements = [
+  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}" },
+  { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n## [Unreleased] - ReleaseDate" },
+  { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/EmbarkStudios/cargo-deny/compare/{{tag_name}}...HEAD" },
+]

--- a/src/cargo-deny/init.rs
+++ b/src/cargo-deny/init.rs
@@ -17,7 +17,6 @@ const CONTENTS: &[u8] = include_bytes!("../../resources/template.toml");
 pub fn cmd(args: Args, context_dir: PathBuf) -> Result<(), Error> {
     let cfg_file = args
         .config
-        .clone()
         .or_else(|| Some(DENY_TOML.into()))
         .map(|path| make_absolute_path(path, &context_dir))
         .context("unable to determine config path")?;

--- a/src/cargo-deny/list.rs
+++ b/src/cargo-deny/list.rs
@@ -248,12 +248,10 @@ pub fn cmd(args: Args, context_dir: PathBuf) -> Result<(), Error> {
                 Layout::Crate => {
                     for (id, krate) in crate_layout.crates {
                         if color {
-                            let color = if krate.licenses.len() > 1 {
-                                Color::Yellow
-                            } else if krate.licenses.len() == 1 {
-                                Color::White
-                            } else {
-                                Color::Red
+                            let color = match krate.licenses.len() {
+                                1 => Color::White,
+                                0 => Color::Red,
+                                _ => Color::Yellow,
                             };
 
                             let parts = get_parts(&id);


### PR DESCRIPTION
Sometimes when allowing licenses, the blanket `licenses.allow` can be a bit much when that license is only used by 1 or 2 crates in your graph, but would mean that adding a dependency on another crate in the future would implicitly be allowed by that same allowance, when you instead might want to evaluate the crate and its license more closely.

We now have a `[licenses.exceptions]` field which allows you to specify 1 or more licenses that are allowed for a particular crate (including version), which will be used instead of the global license configuration if that crate is found.

For example, https://github.com/EmbarkStudios/cargo-deny/commit/b76870c08e917cb7f0fcdb77b1e272a9890a6e71 shows how only one crate needed to be licensed under `BSD-2-Clause`, so we could explicitly allow it just for the one crate.

Resolves: #53 