### PR TITLE
Cleanup sources check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,4 +387,21 @@ pub fn hash(data: &[u8]) -> u32 {
     xx.finish() as u32
 }
 
-pub struct CrateVersion<'a>(pub &'a semver::Version);
+/// Common context for the various checks. Some checks
+/// require additional information though.
+pub struct CheckCtx<'ctx, T> {
+    /// The configuration for the check
+    pub cfg: T,
+    /// The krates graph to check
+    pub krates: &'ctx Krates,
+    /// The spans for each unique crate in a synthesized "lock file"
+    pub krate_spans: &'ctx diag::KrateSpans,
+    /// The codespan file id for the synthesized krate_spans
+    pub spans_id: codespan::FileId,
+}
+
+impl<'ctx, T> CheckCtx<'ctx, T> {
+    pub(crate) fn label_for_span(&self, krate_index: usize, msg: impl Into<String>) -> diag::Label {
+        diag::Label::new(self.spans_id, self.krate_spans[krate_index].clone(), msg)
+    }
+}

--- a/src/licenses/mod.rs
+++ b/src/licenses/mod.rs
@@ -972,7 +972,7 @@ fn evaluate_expression(
 }
 
 pub fn check(
-    cfg: &ValidConfig,
+    ctx: crate::CheckCtx<'_, ValidConfig>,
     summary: Summary<'_>,
     sender: crossbeam::channel::Sender<crate::diag::Pack>,
 ) {
@@ -981,10 +981,10 @@ pub fn check(
 
         match &krate_lic_nfo.lic_info {
             LicenseInfo::SPDXExpression { expr, nfo } => {
-                diagnostics.push(evaluate_expression(&cfg, &krate_lic_nfo, &expr, &nfo));
+                diagnostics.push(evaluate_expression(&ctx.cfg, &krate_lic_nfo, &expr, &nfo));
             }
             LicenseInfo::Unlicensed => {
-                let severity = match cfg.unlicensed {
+                let severity = match ctx.cfg.unlicensed {
                     LintLevel::Allow => Severity::Note,
                     LintLevel::Warn => Severity::Warning,
                     LintLevel::Deny => Severity::Error,

--- a/src/sources/cfg.rs
+++ b/src/sources/cfg.rs
@@ -4,19 +4,19 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
+    /// How to handle registries that weren't listed
     #[serde(default = "crate::lint_warn")]
     pub unknown_registry: LintLevel,
-
+    /// How to handle git sources that weren't listed
     #[serde(default = "crate::lint_warn")]
     pub unknown_git: LintLevel,
-
-    //    #[serde(default = "crate::lint_warn")]
-    //    pub missing_git_revision: LintLevel,
+    /// The list of registries that crates can be sourced from.
+    /// Defaults to the crates.io registry if not specified.
     #[serde(default = "default_allow_registry")]
     pub allow_registry: Vec<String>,
-
+    /// The list of git repositories that crates can be sourced from.
     #[serde(default)]
-    pub allow_git: Vec<String>,
+    pub allow_git: Vec<toml::Spanned<String>>,
 }
 
 fn default_allow_registry() -> Vec<String> {
@@ -34,26 +34,77 @@ impl Default for Config {
     }
 }
 
+use crate::diag::{Diagnostic, Label};
+
 impl Config {
     pub fn validate(
         self,
         cfg_file: codespan::FileId,
-    ) -> Result<ValidConfig, Vec<crate::diag::Diagnostic>> {
+        contents: &str,
+    ) -> Result<ValidConfig, Vec<Diagnostic>> {
+        let mut diags = Vec::new();
+
+        let mut allowed_sources =
+            Vec::with_capacity(self.allow_registry.len() + self.allow_git.len());
+        for ar in self.allow_registry {
+            // Attempt to find the url in the toml contents
+            let span = match contents.find(&ar) {
+                Some(ari) => (ari - 1) as u32..(ari + ar.len() + 1) as u32,
+                None => 0..0,
+            };
+
+            match url::Url::parse(&ar) {
+                Ok(url) => {
+                    allowed_sources.push(SourceSpan { url, span });
+                }
+                Err(pe) => {
+                    diags.push(Diagnostic::new_error(
+                        "failed to parse url",
+                        Label::new(cfg_file, span, pe.to_string()),
+                    ));
+                }
+            }
+        }
+
+        for ag in self.allow_git {
+            let span = ag.start() as u32..ag.end() as u32;
+            match url::Url::parse(ag.get_ref()) {
+                Ok(url) => {
+                    allowed_sources.push(SourceSpan { url, span });
+                }
+                Err(pe) => {
+                    diags.push(Diagnostic::new_error(
+                        "failed to parse url",
+                        Label::new(cfg_file, span, pe.to_string()),
+                    ));
+                }
+            }
+        }
+
+        if !diags.is_empty() {
+            return Err(diags);
+        }
+
         Ok(ValidConfig {
             file_id: cfg_file,
             unknown_registry: self.unknown_registry,
             unknown_git: self.unknown_git,
-            allow_registry: self.allow_registry,
-            allow_git: self.allow_git,
+            allowed_sources,
         })
     }
 }
 
+#[doc(hidden)]
+pub struct SourceSpan {
+    pub url: url::Url,
+    pub span: std::ops::Range<u32>,
+}
+
+#[doc(hidden)]
 pub struct ValidConfig {
     pub file_id: codespan::FileId,
 
     pub unknown_registry: LintLevel,
     pub unknown_git: LintLevel,
-    pub allow_registry: Vec<String>,
-    pub allow_git: Vec<String>,
+    pub allowed_sources: Vec<SourceSpan>,
 }

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -79,14 +79,14 @@ fn detects_vulnerabilities(ctx: &Ctx) -> Result<(), Error> {
 
     let (_, vuln_res) = rayon::join(
         || {
-            advisories::check(
+            let ctx2 = cargo_deny::CheckCtx {
                 cfg,
-                &ctx.krates,
-                (&ctx.spans.0, ctx.spans.1),
-                &ctx.db,
-                &ctx.lock,
-                tx,
-            );
+                krates: &ctx.krates,
+                krate_spans: &ctx.spans.0,
+                spans_id: ctx.spans.1,
+            };
+
+            advisories::check(ctx2, &ctx.db, &ctx.lock, tx);
         },
         || {
             let mut res = Err(anyhow::anyhow!("failed to receive unmaintained"));
@@ -133,14 +133,14 @@ fn detects_unmaintained(ctx: &Ctx) -> Result<(), Error> {
 
     let (_, vuln_res) = rayon::join(
         || {
-            advisories::check(
+            let ctx2 = cargo_deny::CheckCtx {
                 cfg,
-                &ctx.krates,
-                (&ctx.spans.0, ctx.spans.1),
-                &ctx.db,
-                &ctx.lock,
-                tx,
-            );
+                krates: &ctx.krates,
+                krate_spans: &ctx.spans.0,
+                spans_id: ctx.spans.1,
+            };
+
+            advisories::check(ctx2, &ctx.db, &ctx.lock, tx);
         },
         || {
             let mut res = Err(anyhow::anyhow!("failed to receive unmaintained"));
@@ -187,14 +187,14 @@ fn downgrades(ctx: &Ctx) -> Result<(), Error> {
 
     let (_, vuln_res) = rayon::join(
         || {
-            advisories::check(
+            let ctx2 = cargo_deny::CheckCtx {
                 cfg,
-                &ctx.krates,
-                (&ctx.spans.0, ctx.spans.1),
-                &ctx.db,
-                &ctx.lock,
-                tx,
-            );
+                krates: &ctx.krates,
+                krate_spans: &ctx.spans.0,
+                spans_id: ctx.spans.1,
+            };
+
+            advisories::check(ctx2, &ctx.db, &ctx.lock, tx);
         },
         || {
             let mut got_ammonia_vuln = false;


### PR DESCRIPTION
* Add a CheckCtx to make checks a bit nicer to call
* Add error reporting if a string provided in `[sources]` is not a valid url
* Change reporting of disallowed sources to highlight just the source part instead of the entire package line
* Add warnings for allowed sources that aren't actually encountered

Resolves: #88 