### PR TITLE
Allow ignoring of private workspace crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `sources` check and configuration, which allows linting of crate sources
 - Resolved [#63](https://github.com/EmbarkStudios/cargo-deny/issues/63) by adding a dependency on [`krates`](https://crates.io/crates/krates), which allows us to easily filter out dependencies that don't match a target specified by the user via the `targets` config value.
 - Resolved [#75](https://github.com/EmbarkStudios/cargo-deny/issues/75), a warning is now printed for license exceptions and allowed licenses, if they aren't encountered when checking crate license information.
+- Resolved [#50](https://github.com/EmbarkStudios/cargo-deny/issues/50), private workspace members (anything that is not published publicly) can now be ignored during the license check.
 
 ### Changed
 - Resolved [#85](https://github.com/EmbarkStudios/cargo-deny/issues/85) by changing the max column width from 120 to 80 and reformatting some of the help text for the CLI.

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -197,4 +197,40 @@ An opaque hash calculated from the file contents. This hash can be obtained
 from the output of the license check when cargo-deny can't determine the license
 of the file in question.
 
+### The `ignore-private` field
+
+If `true`, workspace members will not have their license expression checked if
+they are not published.
+
+```ini
+[package]
+name = "sekret"
+license = "¯\_(ツ)_/¯"
+publish = false
+```
+
+```ini
+[licenses]
+ignore-private = true # The sekret package would be ignored now
+```
+
+### The `private-registries` field
+
+A list of private registries you may publish your workspace crates to. If a
+workspace member **only** publishes to private registries, it will also be 
+ignored if `ignore-private = true`
+
+```ini
+[package]
+name = "sekret"
+license = "¯\_(ツ)_/¯"
+publish = ["sauce"]
+```
+
+```ini
+[licenses]
+ignore-private = true
+private-registries = ["sauce"] # Still ignored!
+```
+
 [SPDX-expr]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub struct Krate {
     pub deps: Vec<cm::Dependency>,
     pub features: HashMap<String, Vec<String>>,
     pub targets: Vec<cm::Target>,
+    pub publish: Option<Vec<String>>,
 }
 
 #[cfg(test)]
@@ -150,6 +151,7 @@ impl Default for Krate {
             features: HashMap::new(),
             manifest_path: PathBuf::new(),
             repository: None,
+            publish: None,
         }
     }
 }
@@ -212,7 +214,26 @@ impl From<cm::Package> for Krate {
                 deps
             },
             features: pkg.features,
+            publish: pkg.publish,
         }
+    }
+}
+
+impl Krate {
+    /// Returns true if the crate is marked as `publish = false`, or
+    /// it is only published to the specified private registries
+    pub(crate) fn is_private(&self, private_registries: &[&str]) -> bool {
+        self.publish
+            .as_ref()
+            .map(|v| {
+                if v.is_empty() {
+                    true
+                } else {
+                    v.iter()
+                        .all(|reg| private_registries.contains(&reg.as_str()))
+                }
+            })
+            .unwrap_or(false)
     }
 }
 

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -109,6 +109,12 @@ pub struct Exception {
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
+    /// If enabled, skips workspace crates that have been set to `publish = false`
+    #[serde(default)]
+    skip_private: bool,
+    /// One or more private registries that you might publish crates to
+    #[serde(default)]
+    pub private_registries: Vec<String>,
     /// Determines what happens when license information cannot be determined
     /// for a crate
     #[serde(default = "crate::lint_deny")]
@@ -143,6 +149,8 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            skip_private: false,
+            private_registries: Vec::new(),
             unlicensed: LintLevel::Deny,
             allow_osi_fsf_free: BlanketAgreement::default(),
             copyleft: LintLevel::Warn,
@@ -159,7 +167,7 @@ impl Config {
     /// Validates the configuration provided by the user.
     ///
     /// 1. Ensures all SPDX identifiers are valid
-    /// 1. Esnures all SPDX expressions are valid
+    /// 1. Ensures all SPDX expressions are valid
     /// 1. Ensures the same license is not both allowed and denied
     pub fn validate(
         self,
@@ -291,6 +299,8 @@ impl Config {
         } else {
             Ok(ValidConfig {
                 file_id: cfg_file,
+                skip_private: self.skip_private,
+                private_registries: self.private_registries,
                 unlicensed: self.unlicensed,
                 copyleft: self.copyleft,
                 allow_osi_fsf_free: self.allow_osi_fsf_free,
@@ -326,6 +336,8 @@ pub type Licensee = crate::Spanned<spdx::Licensee>;
 #[doc(hidden)]
 pub struct ValidConfig {
     pub file_id: codespan::FileId,
+    pub skip_private: bool,
+    pub private_registries: Vec<String>,
     pub unlicensed: LintLevel,
     pub copyleft: LintLevel,
     pub allow_osi_fsf_free: BlanketAgreement,

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -109,9 +109,10 @@ pub struct Exception {
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
-    /// If enabled, skips workspace crates that have been set to `publish = false`
+    /// If enabled, ignores workspace crates that aren't published, or are
+    /// only published to private registries
     #[serde(default)]
-    skip_private: bool,
+    pub ignore_private: bool,
     /// One or more private registries that you might publish crates to
     #[serde(default)]
     pub private_registries: Vec<String>,
@@ -149,7 +150,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            skip_private: false,
+            ignore_private: false,
             private_registries: Vec::new(),
             unlicensed: LintLevel::Deny,
             allow_osi_fsf_free: BlanketAgreement::default(),
@@ -299,7 +300,7 @@ impl Config {
         } else {
             Ok(ValidConfig {
                 file_id: cfg_file,
-                skip_private: self.skip_private,
+                ignore_private: self.ignore_private,
                 private_registries: self.private_registries,
                 unlicensed: self.unlicensed,
                 copyleft: self.copyleft,
@@ -336,7 +337,7 @@ pub type Licensee = crate::Spanned<spdx::Licensee>;
 #[doc(hidden)]
 pub struct ValidConfig {
     pub file_id: codespan::FileId,
-    pub skip_private: bool,
+    pub ignore_private: bool,
     pub private_registries: Vec<String>,
     pub unlicensed: LintLevel,
     pub copyleft: LintLevel,

--- a/src/licenses/mod.rs
+++ b/src/licenses/mod.rs
@@ -1007,55 +1007,57 @@ pub fn check(
     for mut krate_lic_nfo in summary.nfos {
         let mut diagnostics = Vec::new();
 
-        loop {
-            // If the user has set this, check if it's a private workspace
-            // crate and just print out a help message that we skipped it
-            if ctx.cfg.skip_private {
-                if ctx
-                    .krates
-                    .workspace_members()
-                    .any(|wm| wm.id == krate_lic_nfo.krate.id)
-                    && krate_lic_nfo.krate.is_private(&private_registries)
-                {
-                    let i = ctx.krates.nid_for_kid(&krate_lic_nfo.krate.id).unwrap();
-                    diagnostics.push(Diagnostic::new(
-                        Severity::Help,
-                        "skipping private workspace crate",
-                        ctx.label_for_span(i.index(), "workspace crate"),
-                    ));
-                    break;
-                }
+        // If the user has set this, check if it's a private workspace
+        // crate and just print out a help message that we skipped it
+        if ctx.cfg.ignore_private
+            && ctx
+                .krates
+                .workspace_members()
+                .any(|wm| wm.id == krate_lic_nfo.krate.id)
+            && krate_lic_nfo.krate.is_private(&private_registries)
+        {
+            let i = ctx.krates.nid_for_kid(&krate_lic_nfo.krate.id).unwrap();
+            diagnostics.push(Diagnostic::new(
+                Severity::Help,
+                "skipping private workspace crate",
+                ctx.label_for_span(i.index(), "workspace crate"),
+            ));
+
+            let pack = diag::Pack {
+                krate_id: Some(krate_lic_nfo.krate.id.clone()),
+                diagnostics,
+            };
+
+            sender.send(pack).unwrap();
+            continue;
+        }
+
+        match &krate_lic_nfo.lic_info {
+            LicenseInfo::SPDXExpression { expr, nfo } => {
+                diagnostics.push(evaluate_expression(
+                    &ctx.cfg,
+                    &krate_lic_nfo,
+                    &expr,
+                    &nfo,
+                    &mut hits,
+                ));
             }
+            LicenseInfo::Unlicensed => {
+                let severity = match ctx.cfg.unlicensed {
+                    LintLevel::Allow => Severity::Note,
+                    LintLevel::Warn => Severity::Warning,
+                    LintLevel::Deny => Severity::Error,
+                };
 
-            match &krate_lic_nfo.lic_info {
-                LicenseInfo::SPDXExpression { expr, nfo } => {
-                    diagnostics.push(evaluate_expression(
-                        &ctx.cfg,
-                        &krate_lic_nfo,
-                        &expr,
-                        &nfo,
-                        &mut hits,
-                    ));
-                }
-                LicenseInfo::Unlicensed => {
-                    let severity = match ctx.cfg.unlicensed {
-                        LintLevel::Allow => Severity::Note,
-                        LintLevel::Warn => Severity::Warning,
-                        LintLevel::Deny => Severity::Error,
-                    };
-
-                    diagnostics.push(
-                        Diagnostic::new(
-                            severity,
-                            format!("{} is unlicensed", krate_lic_nfo.krate.id),
-                            krate_lic_nfo.labels.pop().unwrap(),
-                        )
-                        .with_secondary_labels(krate_lic_nfo.labels.iter().cloned()),
-                    );
-                }
+                diagnostics.push(
+                    Diagnostic::new(
+                        severity,
+                        format!("{} is unlicensed", krate_lic_nfo.krate.id),
+                        krate_lic_nfo.labels.pop().unwrap(),
+                    )
+                    .with_secondary_labels(krate_lic_nfo.labels.iter().cloned()),
+                );
             }
-
-            break;
         }
 
         if !diagnostics.is_empty() {


### PR DESCRIPTION
This adds the ability to ignore private workspace crates during the license check. This is done to handle the case when you have non-public code that you aren't (currently, or maybe ever) publishing, and thus have not chosen a license for it.

Resolves #50 