### PR TITLE
Add GitHub Action doc references and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 `cargo-deny` is a cargo plugin for linting your dependencies. See the [book 📖](https://embarkstudios.github.io/cargo-deny/) for in-depth documentation.
 
+To run on CI as a GitHub Action, see [`cargo-deny-action`](https://github.com/EmbarkStudios/cargo-deny-action).
+
 ## [Quickstart](https://embarkstudios.github.io/cargo-deny/)
 
 ```bash

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -29,3 +29,20 @@ options.
 cargo-deny is primarily meant to be used as a cargo plugin, but a majority of
 its functionality is within a library whose docs you view on
 [docs.rs](https://docs.rs/cargo-deny)
+
+## GitHub Action
+
+For GitHub projects one can run cargo-deny automatically as part of continous integration using a GitHub Action:
+
+```yaml
+name: CI
+on: [push, pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: EmbarkStudios/cargo-deny-action@v0
+```
+
+For more information, see [`cargo-deny-action`](https://github.com/EmbarkStudios/cargo-deny-action) repository.


### PR DESCRIPTION
Noticed we didn't have any references to the GitHub Action or repo, which is how most crates likely will run cargo-deny, so added some initial docs for it.

Feel free to change or reformulate.