### PR TITLE
Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+- Resolved [#116](https://github.com/EmbarkStudios/cargo-deny/issues/116) by adding the `[licenses.default]` field, which allows you to configure how to handle licenses that don't match any other predicate
+- Resolved [#117](https://github.com/EmbarkStudios/cargo-deny/issues/117) by allowing the `list` subcommand to also use the normal configuration used by the `check` subcommand. Only the `targets` field is used, to determine which crates have their licenses listed.
+
 ## [0.6.1] - 2020-01-24
 ### Added
 - Added `[advisories.yanked]` field in [PR#114](https://github.com/EmbarkStudios/cargo-deny/pull/114) for linting yanked crates.

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,8 +1,7 @@
 # [cargo-deny](https://github.com/EmbarkStudios/cargo-deny)
 
-cargo-deny is a cargo plugin that lets you lint your project's dependency
-graph to ensure all your dependencies conform to your expectations and
-requirements.
+cargo-deny is a cargo plugin that lets you lint your project's dependency graph 
+to ensure all your dependencies conform to your expectations and requirements.
 
 ## Quickstart
 
@@ -15,24 +14,24 @@ cargo install cargo-deny && cargo deny init && cargo deny check
 
 ## Command Line Interface
 
-cargo-deny is primarily intended to be used as a CLI, see
-[Command Line Tool](cli/index.html) for the available commands and their options.
+cargo-deny is intended to be used as a [Command Line Tool](cli/index.html),
+see the link for the available commands and options.
 
 ## Checks
 
-cargo-deny supports several classes of checks, see the
-[Checks](checks/index.html) for the available checks and their configuration
-options.
+cargo-deny supports several classes of checks, see [Checks](checks/index.html) 
+for the available checks and their configuration options.
 
 ## API
 
 cargo-deny is primarily meant to be used as a cargo plugin, but a majority of
-its functionality is within a library whose docs you view on
+its functionality is within a library whose docs you may view on
 [docs.rs](https://docs.rs/cargo-deny)
 
 ## GitHub Action
 
-For GitHub projects one can run cargo-deny automatically as part of continous integration using a GitHub Action:
+For GitHub projects, one can run cargo-deny automatically as part of continous 
+integration using a GitHub Action:
 
 ```yaml
 name: CI
@@ -45,4 +44,6 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v0
 ```
 
-For more information, see [`cargo-deny-action`](https://github.com/EmbarkStudios/cargo-deny-action) repository.
+For more information, see 
+[`cargo-deny-action`](https://github.com/EmbarkStudios/cargo-deny-action) 
+repository.

--- a/docs/src/checks/README.md
+++ b/docs/src/checks/README.md
@@ -16,7 +16,8 @@ Checks for specific crates in your graph, as well as duplicates.
 ## [advisories](advisories/index.html)
 
 Checks advisory databases for crates with security vulnerabilities, or that
-have been marked as `Unmaintained`.
+have been marked as `Unmaintained`, or which have been yanked from their source
+registry.
 
 ## [sources](sources/index.html)
 

--- a/docs/src/checks/advisories/README.md
+++ b/docs/src/checks/advisories/README.md
@@ -12,10 +12,9 @@ cargo deny check advisories
 ## Use Case - Detecting security vulnerabilities
 
 Security vulnerabilities are generally considered "not great" by most people, 
-luckily rust has a great
-[advisory database](https://github.com/RustSec/advisory-db) which cargo-deny 
-can use to check that you don't have any crates with (known) security 
-vulnerabilities.
+luckily, Rust has a great [advisory 
+database](https://github.com/RustSec/advisory-db) which cargo-deny can use to 
+check that you don't have any crates with (known) security vulnerabilities.
 
 The database can be changed to use your own as well, as long as it follows the
 same format.

--- a/docs/src/checks/bans/README.md
+++ b/docs/src/checks/bans/README.md
@@ -32,7 +32,7 @@ The larger your project and number of external dependencies, the likelihood that
 you will have multiple versions of the same crate rises. This is due to two
 fundamental aspects of the Rust ecosystem.
 
-1. Cargo's dependency resolution, tries to solve all  the version constraints 
+1. Cargo's dependency resolution tries to solve all the version constraints 
 to a crate to the same version, but is totally ok with using [multiple 
 versions](https://stephencoakley.com/2019/04/24/how-rust-solved-dependency-hell)
 if it is unable to.
@@ -42,14 +42,16 @@ mention different philosophies on dependecies and how often (or not) they should
 be updated, so it is inevitable that crates will not always agree on which
 version of another crate they want to use.
 
-This tradeoff of allowing multiple version so of the same crate is one of the
+This tradeoff of allowing multiple version of the same crate is one of the
 reasons that cargo is such a pleasant experience for many people new to Rust,
 but as with all tradeoffs, it does come with costs.
 
-1. More packages must be fetched, which tends to impact CI more than devs.
-1. Compile times increase, which impacts CI and devs.
-1. Target directory size increases, which can impact devs.
-1. Final binary size will also tend to increase, which can impact users.
+1. More packages must be **fetched**, which especially impacts CI, as well as 
+devs.
+1. **Compile times** increase, which impacts CI and devs.
+1. **Target directory size** increases, which can impact devs, or static CI 
+environments.
+1. Final **binary size** will also tend to increase, which can impact users.
 
 Normally, you will not really notice that you have multiple versions of the
 same crate unless you constantly watch your build log, but as mentioned above,
@@ -57,16 +59,18 @@ it **does** introduce papercuts into your workflows.
 
 The intention of duplicate detection in cargo-deny is not to "correct" cargo's
 behavior, but rather to draw your attention to duplicates so that you can make
-and informed decision about how to handle the situation.
+an informed decision about how to handle the situation.
 
 * Maybe you want to open up a PR on a crate to use a version of the duplicate
 that is aligned with the rest of the ecosystem.
 * Maybe the crate has actually already been updated, but the maintainer hasn't
-published a new version yet and you can ask them to publish a new one.
-* Maybe even though the versions are supposedly incompatible according to
-semver, they actually aren't, and you temporarily introduce a `[patch]` to
-force the crate to use a particular version.
+published a new version yet, and you can ask if they can publish a new one.
+* Maybe, even though the versions are supposedly incompatible according to
+semver, they actually aren't, and you can temporarily introduce a `[patch]` to
+force the crate to use a particular version for your entire workspace.
 * Sometimes having the "latest and greatest" is not really that imporant for
-every version, and you can just downgrade to a version that matches one of
-the duplicates instead.
-
+every version, and you can just specify a lower version in your own project that
+matches the transitive contraint(s).
+* And finally, you don't care about a particular case of multiple versions, so
+you just tell cargo-deny to ignore one or more of the specific versions, and the
+situation will eventually resolve itself.

--- a/docs/src/checks/bans/cfg.md
+++ b/docs/src/checks/bans/cfg.md
@@ -63,10 +63,10 @@ care.
 ### The `skip` field (optional)
 
 When denying duplicate versions, it's often the case that there is a window of
-time where you must wait for eg. PRs to be accepted and new version published,
-before 1 or more duplicates are gone. The `skip` field allows you to temporarily
-ignore a crate during duplicate detection so that no errors are emitted, until
-it is no longer need.
+time where you must wait for, for example, PRs to be accepted and new version
+published, before 1 or more duplicates are gone. The `skip` field allows you to
+temporarily ignore a crate during duplicate detection so that no errors are 
+emitted, until it is no longer need.
 
 It is recommended to use specific version constraints for crates in the `skip`
 list, as cargo-deny will emit warnings when any entry in the `skip` list no
@@ -80,7 +80,7 @@ versions of certain crates while in alpha or beta, or on the opposite end of
 the specturm, a crate is using severely outdated dependencies while much of the 
 rest of the ecosystem has moved to more recent versions. In both cases, it can 
 be quite tedious to explicitly `skip` each transitive dependency pulled in by 
-that crate that clashes with your other dependencies, which is where `skip-tree` 
+that crate that clashes with your other dependencies, which is where `skip-tree`
 comes in.
 
 `skip-tree` entries are similar to `skip` in that they are used to specify a 
@@ -91,4 +91,5 @@ the `skip` field.
 
 Note that by default, the `depth` is infinite.
 
-`skip-tree` is a very big hammer at the moment, and should be used with care.
+**NOTE:** `skip-tree` is a very big hammer at the moment, and should be used 
+with care.

--- a/docs/src/checks/cfg.md
+++ b/docs/src/checks/cfg.md
@@ -23,13 +23,13 @@ fuchsia-cprng = "0.1.1"
 
 But unless you are actually targetting `x86_64-fuchsia` or `aarch64-fuchsia`,
 the `fuchsia-cprng` is never actually going to be compiled or linked into your
-project, so checking it pointless for you.
+project, so checking it is pointless for you.
 
-The `targets` field allows you to specify one or more targets which you actually
-build for. Every dependency link to a crate is checked against this list, if
-none of the listed targets satisfy the target constraint, the dependency link
-is ignored. If a crate has no dependency links to it, it is not included in
-the crate graph that checks are executed against.
+The `targets` field allows you to specify one or more targets which you 
+**actually** build for. Every dependency link to a crate is checked against this 
+list, and if none of the listed targets satisfy the target constraint, the 
+dependency link is ignored. If a crate has no dependency links to it, it is not 
+included into the crate graph that the checks are executed against.
 
 #### The `triple` field
 
@@ -45,11 +45,11 @@ configuration check for that target will be limited to only the raw
 Rust `cfg()` expressions support the [`target_feature = 
 "feature-name"`](https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute)
 predicate, but at the moment, the only way to actually pass them when compiling 
-is to use the `RUSTFLAGS` environment variable. The features field allows you
-to specify 1 or more `target_feature`s you plan to build with. At the time of
-this writing, cargo-deny does not attempt to validate that the features you
-specify are actually valid for the target triple, but this is
-[planned](https://github.com/EmbarkStudios/cfg-expr/issues/1).
+is to use the `RUSTFLAGS` environment variable. The `features` field allows you
+to specify 1 or more `target_feature`s you plan to build with, for a particular
+target triple. At the time of this writing, cargo-deny does not attempt to 
+validate that the features you specify are actually valid for the target triple, 
+but this is [planned](https://github.com/EmbarkStudios/cfg-expr/issues/1).
 
 ### The `[licenses]` section
 

--- a/docs/src/checks/licenses/README.md
+++ b/docs/src/checks/licenses/README.md
@@ -29,7 +29,7 @@ cannot be gathered automatically.
 The source of the SPDX expression used to evaluate the crate by is obtained in 
 the following order.
 
-1. If the crate in question has a [Clarification](cfg.md#the-clarify-field)
+1. If the crate in question has a [Clarification](cfg.md#the-clarify-field-optional)
 applied to it, and the source file(s) in the crate's source still match, the
 expression from the clarification will be used.
 1. The [`license`][cargo-md] field from the crate's Cargo.toml manifest will be 
@@ -48,14 +48,15 @@ accepted or rejected is as follows:
 1. A license specified in the `allow` list is **always accepted**.
 1. If the license is considered
 [copyleft](https://en.wikipedia.org/wiki/Copyleft), the
-[`[licenses.copyleft]`](cfg.md#the-copyleft-field) configuration determines its
-status
+[`[licenses.copyleft]`](cfg.md#the-copyleft-field-optional) configuration 
+determines its status
 1. If the license is [OSI Approved](https://opensource.org/licenses) or
 [FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html), the
-[`[licenses.allow-osi-fsf-free]`](cfg.md/#the-allow-osi-fsf-free-field) 
-configuration determines its status
-1. If the license does not match any of the above criteria, it is implicitly 
-**rejected**.
+[`[licenses.allow-osi-fsf-free]`](cfg.md#the-allow-osi-fsf-free-field-optional) 
+configuration determines its status, if it is `neither` the check continues
+1. If the license does not match any of the above criteria, the 
+[`[licenses.default]`](cfg.md#the-default-field-optional) configuration 
+determines its status
 
 [SPDX]: https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/
 [cargo-md]: https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata

--- a/docs/src/checks/licenses/README.md
+++ b/docs/src/checks/licenses/README.md
@@ -2,7 +2,7 @@
 
 The licenses check is used to verify that every crate you use has license terms
 you find acceptable. cargo-deny does this by evaluating the license requirements
-specified by each crate against the [configuration](cfg.md) you've specified to 
+specified by each crate against the [configuration](cfg.md) you've specified, to
 determine if your project meets that crate's license requirements.
 
 ```bash
@@ -14,31 +14,30 @@ cargo deny check licenses
 ### SPDX
 
 cargo-deny uses [SPDX license expressions][SPDX] as the source of truth for the 
-license requirements of a crate. It should be noted however that cargo-deny does
-**not** (currently) exhaustively search the entirety of the source code for 
-every crate to find every possible license that could be attributed to the crate 
-as there are a ton of edge cases to that approach.
+license requirements of a crate. Note however, that cargo-deny does **not** 
+(currently) exhaustively search the entirety of the source code of every crate 
+to find every possible license that could be attributed to the crate, as there 
+are a ton of edge cases to that approach.
 
 cargo-deny rather assumes that each crate correctly defines its license 
-requirements, but it also has a mechanism for manually specifying the license 
-requirements for crates in the rare circumstances cargo-deny cannot be 
-automatically obtained.
+requirements, but it provides a mechanism for manually specifying the license 
+requirements for crates in the, from our experience, rare circumstance that they
+cannot be gathered automatically.
 
 ### Expression Source Precedence
 
-The source of the SPDX expression used to evaluate the crate by is obtained
-in the following order.
+The source of the SPDX expression used to evaluate the crate by is obtained in 
+the following order.
 
 1. If the crate in question has a [Clarification](cfg.md#the-clarify-field)
 applied to it, and the source file(s) in the crate's source still match, the
 expression from the clarification will be used.
-1. The [`license`][cargo-md]
-field from the crate's Cargo.toml manifest will be used if it exists.
-1. The [`license-file`][cargo-md]
-field, as well as **all** other `LICENSE(-*)?` files will be parsed to determine
-the SPDX license identifier, and then all of those identifiers will be joined
-with the `AND` operator, meaning that you must accept all of the licenses
-detected.
+1. The [`license`][cargo-md] field from the crate's Cargo.toml manifest will be 
+used if it exists.
+1. The [`license-file`][cargo-md] field, as well as **all** other `LICENSE(-*)?` 
+files will be parsed to determine the SPDX license identifier, and then all of 
+those identifiers will be joined with the `AND` operator, meaning that you must 
+accept **all** of the licenses detected.
 
 ### Evaluation Precedence
 

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -11,8 +11,8 @@ Contains all of the configuration for `cargo deny check license`.
 ### The `unlicensed` field (optional)
 
 Determines what happens when a crate has not explicitly specified its license 
-terms, and no license information could be easily detected via `LICENSE*` files 
-in the crate's source.
+terms, and no license information could be confidently detected via `LICENSE*` 
+files in the crate's source.
 
 * `deny` (default) - All unlicensed crates will emit an error and fail the 
 license check
@@ -23,8 +23,8 @@ license check
 
 ### The `allow` and `deny` fields (optional)
 
-The licenses that should be allowed or denied. The license must be a valid 
-SPDX v2.1 identifier, which must either be in version 3.7 of the 
+The licenses that should be allowed or denied. The license must be a valid SPDX 
+v2.1 identifier, which must either be in version 3.7 of the 
 [SPDX License List](https://spdx.org/licenses/), with an optional 
 [exception](https://spdx.org/licenses/exceptions-index.html) specified by 
 `WITH <exception-id>`, or else a user defined license reference denoted by 
@@ -45,10 +45,10 @@ above licenses, to either `allow` or `deny`, you **must not** use the suffixes
 `-only` or `-or-later`, as they can only be used by the license holder 
 themselves to decide under which terms to license their code.
 
-So, for example, if you we wanted to disallow `GPL-2.0` licenses, but allow 
-`GPL-3.0` licenses, we could use the following configuration.
+So, for example, if you wanted to disallow `GPL-2.0` licenses, but allow 
+`GPL-3.0` licenses, you could use the following configuration.
 
-```toml
+```ini
 [licenses]
 allow = [ "GPL-3.0" ]
 deny = [ "GPL-2.0" ]
@@ -56,8 +56,8 @@ deny = [ "GPL-2.0" ]
 
 ### The `exceptions` field (optional)
 
-The license configuration generally applies the entire crate graph, but this 
-means that allowing a specific license applies to all possible crates, even if 
+The license configuration generally applies to the entire crate graph, but this 
+means that allowing any one license applies to all possible crates, even if 
 only 1 crate actually uses that license. The `exceptions` field is meant to 
 allow licenses only for particular crates, to make a clear distinction between 
 licenses which you are fine with everywhere, versus ones which you want to be 
@@ -76,7 +76,7 @@ excepting. Defaults to all versions (`*`).
 
 This is the exact same as the general `allow` field.
 
-```toml
+```ini
 [licenses]
 allow = [
     "Apache-2.0",
@@ -117,7 +117,7 @@ Determines what happens when licenses aren't explicitly allowed or denied, but
 ### The `confidence-threshold` field (optional)
 
 `cargo-deny` uses [askalono](https://github.com/amzn/askalono) to determine the 
-license of a license file. Due to variability in license texts due to things
+license of a LICENSE file. Due to variability in license texts because of things
 like authors, copyright year, and so forth, askalano assigns a confidence score
 to its determination, from `0.0` (no confidence) to `1.0` (perfect match). The 
 confidence threshold value is used to reject the license determination if the
@@ -127,12 +127,12 @@ score does not match or exceed the threshold.
 
 ### The `clarify` field (optional)
 
-In some exceptional cases, the crates do not have easily machine readable 
-license information, and would by default be considered "unlicensed" by 
-cargo-deny. As a (hopefully) temporary patch for using the crate, you can 
-specify a clarification for the crate by manually assigning its SPDX expression,
-based on one or more files in the crate's source. cargo-deny will use that
-expression as long as the source files in the crate don't change.
+In some exceptional cases, a crate will not have easily machine readable license
+information, and would by default be considered "unlicensed" by cargo-deny. As a
+(hopefully) temporary patch for using the crate, you can specify a clarification
+for the crate by manually assigning its SPDX expression, based on one or more 
+files in the crate's source. cargo-deny will use that expression for as long as
+the source files in the crate exactly match the clarification's hashes.
 
 #### The `name` field
 
@@ -190,7 +190,7 @@ private = { ignore = true }
 
 A list of private registries you may publish your workspace crates to. If a
 workspace member **only** publishes to private registries, it will also be 
-ignored if `privite.ignore = true`
+ignored if `private.ignore = true`
 
 ```ini
 [package]

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -114,6 +114,20 @@ Determines what happens when licenses aren't explicitly allowed or denied, but
 * `fsf-only` - The license is accepted if it is FSF Free and not OSI approved
 * `neither` (default) - No special consideration is given the license
 
+### The `default` field (optional)
+
+Determines what happens when a license is encountered that:
+
+1. Isn't in the `allow` or `deny` lists
+1. Isn't `copyleft`
+1. Isn't OSI Approved nor FSF Free/Libre, or `allow-osi-fsf-free = "neither"`
+
+* `warn` - Will emit a warning that the license was detected, but will not fail 
+the license check
+* `deny` (default) - The license is not accepted, but the license check might 
+not fail if the expression still evaluates to true
+* `allow` - The license is accepted
+
 ### The `confidence-threshold` field (optional)
 
 `cargo-deny` uses [askalono](https://github.com/amzn/askalono) to determine the 

--- a/docs/src/checks/sources/README.md
+++ b/docs/src/checks/sources/README.md
@@ -10,17 +10,20 @@ cargo deny check sources
 
 ## Use Case - Only allowing known/trusted sources
 
-Cargo can retrieve crates from a variety of sources, namely registries, 
-git repositories, or local file paths. This is great in general and very 
-flexible for development. But esp. re-routing dependencies to git repositories 
-increases the amount of sources that one would have to trust and may be 
-something a repository want explicitly opt-in to. 
+Cargo can retrieve crates from a variety of sources, namely registries, git 
+repositories, or local file paths. This is great in general and very flexible 
+for development. But, especially when re-routing dependencies to git 
+repositories, increasing the amount of sources that a project has to trust may
+be something a repository wants to explicitly opt-in to.
 
-See [Why npm lockfiles can be a security blindspot for injecting malicious modules](https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/)
+See [Why npm lockfiles can be a security blindspot for injecting malicious 
+modules](https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/)
 for the motivating reason for why this check was added.
 
 ## Use Case - Only using vendored file dependencies
 
-A crate repository may want to only support local file dependencies, such as 
-having all dependencies vendored into the repository for full control and 
-offline building.
+A project may want to only support local file dependencies, such as having all 
+dependencies vendored into the repository for full control and offline building.
+This can be achieved by disallowing all git and registry sources to ensure that
+every dependency is added into your source control rather than via an external
+source.

--- a/docs/src/checks/sources/cfg.md
+++ b/docs/src/checks/sources/cfg.md
@@ -20,8 +20,8 @@ check.
 
 ### The `unknown-git` field (optional)
 
-Determines what happens when a crate from a git repository not in the allow 
-list is encountered.
+Determines what happens when a crate from a git repository not in the 
+`allow-git` list is encountered.
 
 * `deny` - Will emit an error with the URL of the repository, and fail the 
 check.
@@ -31,8 +31,8 @@ check.
 
 ### The `allow-registry` field (optional)
 
-The list of registries that are allowed. If a crate is not found in the list. 
-Then `unknown-registry` setting will determine how it is handled.
+The list of registries that are allowed. If a crate is not found in the list,
+then the `unknown-registry` setting will determine how it is handled.
 
 If not specified, this list will by default contain the
 [crates.io](http://crates.io) registry, equivalent to this:

--- a/docs/src/cli/README.md
+++ b/docs/src/cli/README.md
@@ -1,6 +1,6 @@
 # Command Line Tool
 
-cargo-deny can be used either as a command line tool or a
+cargo-deny can be used either as a command line tool or as a
 [Rust crate](https://crates.io/crates/cargo-deny). Let's focus on the command 
 line tool capabilities first.
 
@@ -12,7 +12,7 @@ to download the appropriate version for your platform.
 
 ## Install From Source
 
-cargo-deny can also be installed from source
+cargo-deny can also be installed from source.
 
 ### Pre-requisites
 
@@ -44,8 +44,7 @@ you have installed cargo-deny!
 The **[git version](https://github.com/EmbarkStudios/cargo-deny)** contains all
 the latest bug-fixes and features, that will be released in the next version on
 **Crates.io**, if you can't wait until the next release. You can build the git
-version yourself. Open your terminal and navigate to the directory of your
-choice. We need to clone the git repository and then build it with Cargo.
+version yourself.
 
 ```bash
 cargo install --git https://github.com/EmbarkStudios/cargo-deny cargo-deny

--- a/docs/src/cli/check.md
+++ b/docs/src/cli/check.md
@@ -11,7 +11,7 @@ configuration.
 The check(s) to perform. By default, **all** checks will be performed, unless 
 one or more specific checks are specified.
 
-See [checks](../checks/index.html) for the possible checks available.
+See [checks](../checks/index.html) for the list of available checks.
 
 ## Flags
 

--- a/docs/src/cli/common.md
+++ b/docs/src/cli/common.md
@@ -24,5 +24,6 @@ Possible values:
 #### `-t, --target`
 
 One or more platforms to filter crates with. If a dependency is target specific,
-it will be ignored if it does match 1 or more of the specified targets. This 
-overrides the top-level [`targets = []`](../checks/cfg.md) configuration value.
+it will be ignored if it does not match at least 1 of the specified targets. 
+This overrides the top-level [`targets = []`](../checks/cfg.md) configuration 
+value.

--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -21,8 +21,8 @@ cargo deny init path/to/config.toml
 
 ### Template
 
-A `deny.toml` file will be created in the current working directory that is
-a direct copy of [this template](https://github.com/EmbarkStudios/cargo-deny/blob/master/resources/template.toml).
+A `deny.toml` file will be created in the current working directory that is a 
+direct copy of [this template](https://github.com/EmbarkStudios/cargo-deny/blob/master/resources/template.toml).
 
 ```ini
 {{#include ../../../resources/template.toml}}

--- a/docs/src/cli/list.md
+++ b/docs/src/cli/list.md
@@ -5,14 +5,6 @@ prints out the license information for each crate.
 
 ## Options
 
-### `--color`
-
-Output coloring, only applies to `human` format 
-
-* `auto` (default) - Only colors if stdout is a TTY
-* `always` - Always emits colors
-* `never` - Never emits colors
-
 ### `-f, --format`
 
 The format of the output
@@ -20,6 +12,21 @@ The format of the output
 * `human` (default) - Simple format where each crate or license is its own line
 * `json`
 * `tsv`
+
+### `--color`
+
+Output coloring, only applies to the `human` format.
+
+* `auto` (default) - Only colors if stdout is a TTY
+* `always` - Always emits colors
+* `never` - Never emits colors
+
+Colors:
+
+- SPDX identifier - ![blue](https://placehold.it/15/5dade2/000000?text=+)
+- Crate with 1 license - ![white](https://placehold.it/15/717d7e/000000?text=+)
+- Crate with 2 or more licenses - ![yellow](https://placehold.it/15/f1c40f/000000?text=+)
+- Crate with 0 licenses - ![yellow](https://placehold.it/15/e74c3c/000000?text=+)
 
 ### `-l, --layout`
 

--- a/src/cargo-deny/list.rs
+++ b/src/cargo-deny/list.rs
@@ -34,6 +34,11 @@ arg_enum! {
 
 #[derive(StructOpt, Debug)]
 pub struct Args {
+    /// Path to the config to use
+    ///
+    /// Defaults to <context>/deny.toml if not specified
+    #[structopt(short, long, parse(from_os_str), default_value = "deny.toml")]
+    config: PathBuf,
     /// Minimum confidence threshold for license text
     ///
     /// When determining the license from file contents, a confidence score is assigned according to how close the contents are to the canonical license text. If the confidence score is below this threshold, they license text will ignored, which might mean the crate is treated as unlicensed.
@@ -74,18 +79,100 @@ pub struct Args {
     layout: Layout,
 }
 
+#[derive(serde::Deserialize)]
+struct Config {
+    #[serde(default)]
+    targets: Vec<crate::common::Target>,
+}
+
+struct ValidConfig {
+    targets: Vec<(String, Vec<String>)>,
+}
+
+impl ValidConfig {
+    fn load(cfg_path: PathBuf, files: &mut codespan::Files<String>) -> Result<Self, Error> {
+        let cfg_contents = if cfg_path.exists() {
+            std::fs::read_to_string(&cfg_path)
+                .with_context(|| format!("failed to read config from {}", cfg_path.display()))?
+        } else {
+            return Ok(Self {
+                targets: Vec::new(),
+            });
+        };
+
+        let cfg: Config = toml::from_str(&cfg_contents).with_context(|| {
+            format!("failed to deserialize config from '{}'", cfg_path.display())
+        })?;
+
+        let id = files.add(cfg_path.to_string_lossy(), cfg_contents);
+
+        use cargo_deny::diag::Diagnostic;
+
+        let validate = || -> Result<(Vec<Diagnostic>, Self), Vec<Diagnostic>> {
+            let mut diagnostics = Vec::new();
+            let targets = crate::common::load_targets(cfg.targets, &mut diagnostics, id);
+
+            Ok((diagnostics, Self { targets }))
+        };
+
+        let print = |diags: Vec<Diagnostic>| {
+            use codespan_reporting::term;
+
+            if diags.is_empty() {
+                return;
+            }
+
+            let writer =
+                term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
+            let config = term::Config::default();
+            let mut writer = writer.lock();
+            for diag in &diags {
+                term::emit(&mut writer, &config, &files, &diag).unwrap();
+            }
+        };
+
+        match validate() {
+            Ok((diags, vc)) => {
+                print(diags);
+                Ok(vc)
+            }
+            Err(diags) => {
+                print(diags);
+
+                anyhow::bail!(
+                    "failed to validate configuration file {}",
+                    cfg_path.display()
+                );
+            }
+        }
+    }
+}
+
 #[allow(clippy::cognitive_complexity)]
 pub fn cmd(args: Args, targets: Vec<String>, context_dir: PathBuf) -> Result<(), Error> {
     use licenses::LicenseInfo;
-
     use std::{collections::BTreeMap, fmt::Write};
+
+    let mut files = codespan::Files::new();
+    let cfg = ValidConfig::load(
+        crate::common::make_absolute_path(args.config.clone(), &context_dir),
+        &mut files,
+    )?;
 
     let (krates, store) = rayon::join(
         || {
-            crate::common::gather_krates(
-                context_dir,
-                targets.into_iter().map(|t| (t, Vec::new())).collect(),
-            )
+            let targets = if !targets.is_empty() {
+                targets.into_iter().map(|name| (name, Vec::new())).collect()
+            } else if !cfg.targets.is_empty() {
+                cfg.targets
+                    .iter()
+                    .map(|(name, features)| (name.clone(), features.clone()))
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
+            crate::common::gather_krates(context_dir, targets)
         },
         crate::common::load_license_store,
     );

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -137,6 +137,10 @@ pub struct Config {
     /// Determines what happens when a copyleft license is detected
     #[serde(default = "crate::lint_warn")]
     pub copyleft: LintLevel,
+    /// Determines what happens when a license doesn't match any previous
+    /// predicates
+    #[serde(default = "crate::lint_deny")]
+    pub default: LintLevel,
     /// The minimum confidence threshold we allow when determining the license
     /// in a text file, on a 0.0 (none) to 1.0 (maximum) scale
     #[serde(default = "confidence_threshold")]
@@ -164,6 +168,7 @@ impl Default for Config {
             unlicensed: LintLevel::Deny,
             allow_osi_fsf_free: BlanketAgreement::default(),
             copyleft: LintLevel::Warn,
+            default: LintLevel::Deny,
             confidence_threshold: confidence_threshold(),
             deny: Vec::new(),
             allow: Vec::new(),
@@ -303,6 +308,7 @@ impl Config {
                 private: self.private,
                 unlicensed: self.unlicensed,
                 copyleft: self.copyleft,
+                default: self.default,
                 allow_osi_fsf_free: self.allow_osi_fsf_free,
                 confidence_threshold: self.confidence_threshold,
                 clarifications,
@@ -341,6 +347,7 @@ pub struct ValidConfig {
     pub unlicensed: LintLevel,
     pub copyleft: LintLevel,
     pub allow_osi_fsf_free: BlanketAgreement,
+    pub default: LintLevel,
     pub confidence_threshold: f32,
     pub denied: Vec<Licensee>,
     pub allowed: Vec<Licensee>,
@@ -370,6 +377,7 @@ mod test {
         assert_eq!(validated.private.registries, vec!["sekrets".to_owned()]);
         assert_eq!(validated.unlicensed, LintLevel::Warn);
         assert_eq!(validated.copyleft, LintLevel::Deny);
+        assert_eq!(validated.default, LintLevel::Warn);
         assert_eq!(validated.allow_osi_fsf_free, BlanketAgreement::Both);
         assert_eq!(
             validated.allowed,

--- a/tests/cfg/licenses.toml
+++ b/tests/cfg/licenses.toml
@@ -2,6 +2,7 @@
 unlicensed = "warn"
 allow-osi-fsf-free = "both"
 copyleft = "deny"
+default = "warn"
 confidence-threshold = 0.95
 deny = [
     "Nokia",


### PR DESCRIPTION
* General clean-up of docs
* The `list` subcommand can now load the config that the `check` subcommand uses, only `targets` is used
* Add the `[licenses.default]` field to allow specifying the default behaviour for a license that doesn't match any other predicate. Defaults to `deny` which preserves the current behaviour.

Resolves: #116 
Resolves: #117 