### PR TITLE
Remove `-h` option in docs for check command

### DIFF
--- a/docs/src/cli/check.md
+++ b/docs/src/cli/check.md
@@ -21,7 +21,7 @@ Disables fetching of advisory databases, if they would be loaded. If disabled,
 and there is not already an existing advisory database locally, an error will 
 occur
 
-### `-h, --hide-inclusion-graph`
+### `--hide-inclusion-graph`
 
 Hides the inclusion graph when printing out info for a crate.
 


### PR DESCRIPTION
According to the documentation, there should be a short option `-h` for the check command that hides the inclusion graph. The problem is that `-h` already is used as a short hand for `--help`.

This caused some minor confusion for me until I realized what was happening (longer than I'm willing to admit 😅) so thought I would send a PR to fix it. This PR simply removes the `-h` option from the docs.