### PR TITLE
Add evil crates to deny by default.

### DIFF
--- a/deny.template.toml
+++ b/deny.template.toml
@@ -159,6 +159,9 @@ deny = [
     # Each entry the name of a crate and a version range. If version is
     # not specified, all versions will be matched.
     #{ name = "ansi_term", version = "=0.11.0" },
+
+    { name = "plutonium" },   # Crate intended to hide unsafe usage.
+    { name = "fake-static" }, # Crate intended to demonstrate soundness bug in safe code.
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [


### PR DESCRIPTION
Propose to disallow certain crates by default. These crates should never appear in any even vaguely sane dependency graph. There might be other candidates.

An alternative is to deal with this through the advisory. It seems a better approach, but AFAICT that requires a manual opt in with `cargo deny check advisories` which is unfortunate.

Advisories (not yet merged at time of this writing):
- https://github.com/RustSec/advisory-db/pull/268
- https://github.com/RustSec/advisory-db/issues/207