### PR TITLE
Cleanup output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+- A one line summary of the state of each check is now output at the very end of the `check` subcommand unless the `--log-level` is `off`. If the `--log-level` is `info` or higher, a summary of the state, errors, warnings, and notes for each check are outputted on their own line instead.
+- Added the `-s | --show-stats` flag to the `check` subcommand, which will print out the more detailed summary, regardless of the `--log-level`.
+
 ### Changed
 - Updated crates.
 - Updated `cfg-expr`, which should allow for filtering of crates for *most* custom targets that aren't built-in to rustc.

--- a/src/advisories/mod.rs
+++ b/src/advisories/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     Krate, Krates, LintLevel,
 };
 use anyhow::{Context, Error};
-use log::info;
+use log::debug;
 pub use rustsec::{advisory::Id, lockfile::Lockfile, Database};
 use rustsec::{repository as repo, Repository};
 use std::path::{Path, PathBuf};
@@ -44,7 +44,7 @@ pub fn load_db(
 
     let advisory_db_repo = match fetch {
         Fetch::Allow => {
-            info!("Fetching advisory database from '{}'", advisory_db_url);
+            debug!("Fetching advisory database from '{}'", advisory_db_url);
 
             Repository::fetch(
                 advisory_db_url,
@@ -54,7 +54,7 @@ pub fn load_db(
             .context("failed to fetch advisory database")?
         }
         Fetch::Disallow => {
-            info!(
+            debug!(
                 "Opening advisory database at '{}'",
                 advisory_db_path.display()
             );
@@ -63,14 +63,14 @@ pub fn load_db(
         }
     };
 
-    info!(
+    debug!(
         "loading advisory database from {}",
         advisory_db_path.display()
     );
 
     let res = Database::load(&advisory_db_repo).context("failed to load advisory database");
 
-    info!(
+    debug!(
         "finished loading advisory database from {}",
         advisory_db_path.display()
     );
@@ -225,7 +225,7 @@ pub fn check(
                         match lint_level {
                             LintLevel::Warn => Severity::Warning,
                             LintLevel::Deny => Severity::Error,
-                            LintLevel::Allow => Severity::Note,
+                            LintLevel::Allow => Severity::Help,
                         },
                         msg,
                     )
@@ -291,7 +291,7 @@ pub fn check(
                         let mut pack = diag::Pack::with_kid(krate.id.clone());
                         pack.push(
                             Diagnostic::new(match ctx.cfg.yanked.value {
-                                LintLevel::Allow => Severity::Note,
+                                LintLevel::Allow => Severity::Help,
                                 LintLevel::Deny => Severity::Error,
                                 LintLevel::Warn => Severity::Warning,
                             })

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -3,7 +3,7 @@ use cargo_deny::{advisories, bans, diag::Diagnostic, licenses, sources, CheckCtx
 use clap::arg_enum;
 use log::error;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Instant};
 use structopt::StructOpt;
 
 arg_enum! {
@@ -308,7 +308,11 @@ pub fn cmd(
 
             s.spawn(move |_| {
                 log::info!("checking licenses...");
+                let start = Instant::now();
                 licenses::check(ctx, summary, lic_tx);
+                let end = Instant::now();
+
+                log::info!("licenses checked in {}ms", (end - start).as_millis());
             });
         }
 
@@ -355,7 +359,11 @@ pub fn cmd(
 
             s.spawn(|_| {
                 log::info!("checking bans...");
+                let start = Instant::now();
                 bans::check(ctx, output_graph, ban_tx);
+                let end = Instant::now();
+
+                log::info!("bans checked in {}ms", (end - start).as_millis());
             });
         }
 
@@ -372,7 +380,11 @@ pub fn cmd(
 
             s.spawn(|_| {
                 log::info!("checking sources...");
+                let start = Instant::now();
                 sources::check(ctx, sources_tx);
+                let end = Instant::now();
+
+                log::info!("sources checked in {}ms", (end - start).as_millis());
             });
         }
 
@@ -388,7 +400,11 @@ pub fn cmd(
 
             s.spawn(move |_| {
                 log::info!("checking advisories...");
+                let start = Instant::now();
                 advisories::check(ctx, &db, lockfile, tx);
+                let end = Instant::now();
+
+                log::info!("advisories checked in {}ms", (end - start).as_millis());
             });
         }
     });

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -41,6 +41,9 @@ pub struct Args {
     /// When running the `advisories` check, the configured advisory database will be fetched and opened. If this flag is passed, the database won't be fetched, but an error will occur if it doesn't already exist locally.
     #[structopt(short, long)]
     disable_fetch: bool,
+    /// Show stats for all the checks, regardless of the log-level
+    #[structopt(short, long = "show-stats")]
+    pub show_stats: bool,
     /// The check(s) to perform
     #[structopt(
         possible_values = &WhichCheck::variants(),
@@ -163,7 +166,7 @@ pub fn cmd(
     log_level: log::LevelFilter,
     args: Args,
     krate_ctx: crate::common::KrateContext,
-) -> Result<(), Error> {
+) -> Result<AllStats, Error> {
     let mut files = codespan::Files::new();
     let mut cfg = ValidConfig::load(krate_ctx.get_config_path(args.config.clone()), &mut files)?;
 
@@ -287,12 +290,28 @@ pub fn cmd(
         log::LevelFilter::Trace => Some(Severity::Help),
     };
 
-    let mut has_errors = None;
+    let mut stats = AllStats::default();
+
+    if check_advisories {
+        stats.advisories = Some(Stats::default());
+    }
+
+    if check_bans {
+        stats.bans = Some(Stats::default());
+    }
+
+    if check_licenses {
+        stats.licenses = Some(Stats::default());
+    }
+
+    if check_sources {
+        stats.sources = Some(Stats::default());
+    }
 
     rayon::scope(|s| {
         // Asynchronously displays messages sent from the checks
         s.spawn(|_| {
-            has_errors = print_diagnostics(rx, inc_grapher, max_severity, files);
+            print_diagnostics(rx, inc_grapher, max_severity, files, &mut stats);
         });
 
         if let Some(summary) = license_summary {
@@ -409,9 +428,31 @@ pub fn cmd(
         }
     });
 
-    match has_errors {
-        Some(errs) => Err(errs),
-        None => Ok(()),
+    Ok(stats)
+}
+
+#[derive(Default)]
+pub struct Stats {
+    pub errors: u32,
+    pub warnings: u32,
+    pub notes: u32,
+    pub helps: u32,
+}
+
+#[derive(Default)]
+pub struct AllStats {
+    pub advisories: Option<Stats>,
+    pub bans: Option<Stats>,
+    pub licenses: Option<Stats>,
+    pub sources: Option<Stats>,
+}
+
+impl AllStats {
+    pub fn total_errors(&self) -> u32 {
+        self.advisories.as_ref().map_or(0, |s| s.errors)
+            + self.bans.as_ref().map_or(0, |s| s.errors)
+            + self.licenses.as_ref().map_or(0, |s| s.errors)
+            + self.sources.as_ref().map_or(0, |s| s.errors)
     }
 }
 
@@ -420,21 +461,33 @@ fn print_diagnostics(
     mut inc_grapher: Option<cargo_deny::diag::Grapher<'_>>,
     max_severity: Option<cargo_deny::diag::Severity>,
     files: codespan::Files<String>,
-) -> Option<Error> {
-    use codespan_reporting::term;
+    stats: &mut AllStats,
+) {
+    use cargo_deny::diag::Check;
+    use codespan_reporting::{diagnostic::Severity, term};
 
     let writer = term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
     let config = term::Config::default();
 
-    let mut error_count = 0;
-
     for pack in rx {
         let mut lock = writer.lock();
 
+        let check_stats = match pack.check {
+            Check::Advisories => stats.advisories.as_mut().unwrap(),
+            Check::Bans => stats.bans.as_mut().unwrap(),
+            Check::Licenses => stats.licenses.as_mut().unwrap(),
+            Check::Sources => stats.sources.as_mut().unwrap(),
+        };
+
         for diag in pack.into_iter() {
             let mut inner = diag.diag;
-            if inner.severity >= codespan_reporting::diagnostic::Severity::Error {
-                error_count += 1;
+
+            match inner.severity {
+                Severity::Error => check_stats.errors += 1,
+                Severity::Warning => check_stats.warnings += 1,
+                Severity::Note => check_stats.notes += 1,
+                Severity::Help => check_stats.helps += 1,
+                Severity::Bug => {}
             }
 
             match max_severity {
@@ -458,11 +511,5 @@ fn print_diagnostics(
             // not be displayed until after this thread exited
             term::emit(&mut lock, &config, &files, &inner).unwrap();
         }
-    }
-
-    if error_count > 0 {
-        Some(anyhow::anyhow!("encountered {} errors", error_count))
-    } else {
-        None
     }
 }

--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use cargo_deny::licenses::LicenseStore;
 
 pub(crate) fn load_license_store() -> Result<LicenseStore, anyhow::Error> {
-    log::info!("loading license store...");
+    log::debug!("loading license store...");
     LicenseStore::from_cache()
 }
 

--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -86,6 +86,7 @@ impl KrateContext {
         cfg_targets: Vec<(krates::Target, Vec<String>)>,
     ) -> Result<cargo_deny::Krates, anyhow::Error> {
         log::info!("gathering crates for {}", self.manifest_path.display());
+        let start = std::time::Instant::now();
 
         let mut mdc = krates::Cmd::new();
 
@@ -133,7 +134,12 @@ impl KrateContext {
         });
 
         if let Ok(ref krates) = graph {
-            log::info!("gathered {} crates", krates.len());
+            let end = std::time::Instant::now();
+            log::info!(
+                "gathered {} crates in {}ms",
+                krates.len(),
+                (end - start).as_millis()
+            );
         }
 
         Ok(graph?)

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -26,21 +26,31 @@ impl From<Diagnostic> for Diag {
     }
 }
 
+pub enum Check {
+    Advisories,
+    Bans,
+    Licenses,
+    Sources,
+}
+
 pub struct Pack {
+    pub check: Check,
     diags: Vec<Diag>,
     kid: Option<Kid>,
 }
 
 impl Pack {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(check: Check) -> Self {
         Self {
+            check,
             diags: Vec::new(),
             kid: None,
         }
     }
 
-    pub(crate) fn with_kid(kid: Kid) -> Self {
+    pub(crate) fn with_kid(check: Check, kid: Kid) -> Self {
         Self {
+            check,
             diags: Vec::new(),
             kid: Some(kid),
         }
@@ -72,12 +82,13 @@ impl IntoIterator for Pack {
     }
 }
 
-impl<T> From<T> for Pack
+impl<T> From<(Check, T)> for Pack
 where
     T: Into<Diag>,
 {
-    fn from(t: T) -> Self {
+    fn from((check, t): (Check, T)) -> Self {
         Self {
+            check,
             diags: vec![t.into()],
             kid: None,
         }

--- a/src/licenses/mod.rs
+++ b/src/licenses/mod.rs
@@ -775,7 +775,7 @@ impl Gatherer {
 }
 
 use bitvec::prelude::*;
-use diag::{Diagnostic, Label, Severity};
+use diag::{Check, Diagnostic, Label, Severity};
 
 struct Hits {
     allowed: BitVec<Local, usize>,
@@ -1021,7 +1021,7 @@ pub fn check(
         .collect();
 
     for krate_lic_nfo in summary.nfos {
-        let mut pack = diag::Pack::with_kid(krate_lic_nfo.krate.id.clone());
+        let mut pack = diag::Pack::with_kid(Check::Licenses, krate_lic_nfo.krate.id.clone());
 
         // If the user has set this, check if it's a private workspace
         // crate and just print out a help message that we skipped it
@@ -1083,10 +1083,13 @@ pub fn check(
     {
         sender
             .send(
-                Diagnostic::warning()
-                    .with_message("crate license exception was not encountered")
-                    .with_labels(vec![Label::primary(ctx.cfg.file_id, exc.name.span)
-                        .with_message("no crate source matched these criteria")])
+                (
+                    Check::Licenses,
+                    Diagnostic::warning()
+                        .with_message("crate license exception was not encountered")
+                        .with_labels(vec![Label::primary(ctx.cfg.file_id, exc.name.span)
+                            .with_message("no crate source matched these criteria")]),
+                )
                     .into(),
             )
             .unwrap();
@@ -1102,10 +1105,13 @@ pub fn check(
     {
         sender
             .send(
-                Diagnostic::warning()
-                    .with_message("license was not encountered")
-                    .with_labels(vec![Label::primary(ctx.cfg.file_id, allowed.span)
-                        .with_message("no crate used this license")])
+                (
+                    Check::Licenses,
+                    Diagnostic::warning()
+                        .with_message("license was not encountered")
+                        .with_labels(vec![Label::primary(ctx.cfg.file_id, allowed.span)
+                            .with_message("no crate used this license")]),
+                )
                     .into(),
             )
             .unwrap();

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -2,7 +2,7 @@ mod cfg;
 pub use cfg::{Config, ValidConfig};
 
 use crate::{
-    diag::{Diagnostic, Label, Pack, Severity},
+    diag::{Check, Diagnostic, Label, Pack, Severity},
     LintLevel,
 };
 
@@ -63,7 +63,7 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sender: crossbeam::channel::
 
                 span.start = span.start + last_space + 1;
 
-                let mut pack = Pack::with_kid(krate.id.clone());
+                let mut pack = Pack::with_kid(Check::Sources, krate.id.clone());
                 pack.push(
                     Diagnostic::new(match lint_level {
                         LintLevel::Warn => Severity::Warning,
@@ -91,10 +91,13 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sender: crossbeam::channel::
     {
         sender
             .send(
-                Diagnostic::warning()
-                    .with_message("allowed source was not encountered")
-                    .with_labels(vec![Label::primary(ctx.cfg.file_id, src.span)
-                        .with_message("no crate source matched these criteria")])
+                (
+                    Check::Sources,
+                    Diagnostic::warning()
+                        .with_message("allowed source was not encountered")
+                        .with_labels(vec![Label::primary(ctx.cfg.file_id, src.span)
+                            .with_message("no crate source matched these criteria")]),
+                )
                     .into(),
             )
             .unwrap();

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -204,8 +204,8 @@ fn downgrades() {
                     let diag = diag.diag;
                     if diag.code == Some("RUSTSEC-2019-0001".to_owned()) {
                         ensure!(
-                            diag.severity == diag::Severity::Note,
-                            dbg!(dbg!(diag.severity) == diag::Severity::Note)
+                            diag.severity == diag::Severity::Help,
+                            dbg!(dbg!(diag.severity) == diag::Severity::Help)
                         );
                         ensure!(
                             diag.message == "Uncontrolled recursion leads to abort in HTML serialization",
@@ -223,8 +223,8 @@ fn downgrades() {
 
                     if diag.code == Some("RUSTSEC-2016-0004".to_owned()) {
                         ensure!(
-                            diag.severity == diag::Severity::Note,
-                            dbg!(dbg!(diag.severity) == diag::Severity::Note)
+                            diag.severity == diag::Severity::Help,
+                            dbg!(dbg!(diag.severity) == diag::Severity::Help)
                         );
                         ensure!(
                             diag.message == "libusb is unmaintained; use rusb instead",


### PR DESCRIPTION
- Downgraded several `info` messages to `debug` to remove spam.
- Added timings for each type of check
- Added a summary line printed at the end (except if the log level is Off) to show the success or failure of each check that was Requesting
- Added a `-s|--show-stats` flag to the `check` subcommand that will display the number of errors, warnings, and info/notes/debug helps for each check. Printed regardless of the log-level.

Resolves: https://github.com/EmbarkStudios/cargo-deny-action/issues/17