### PR TITLE
Add feature options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved [#137](https://github.com/EmbarkStudios/cargo-deny/issues/137) by adding a `--format <human|json>` option. All diagnostic and log messages from the `check` subcommand respect this flag.
 
 ### Changed
+- Resolved [#216](https://github.com/EmbarkStudios/cargo-deny/issues/216) by adding support for the `--all-features`, `--features`, and `--no-default-features` flags to specify the exact features to have enabled when gathering the crates in your dependency graph to actually run checks against. This is a **BREAKING CHANGE** as previously crates were gathered with `--all-features`.
 - The `--color` option for the `list` subcommand has been moved to the top level arguments.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved [#216](https://github.com/EmbarkStudios/cargo-deny/issues/216) by adding support for the `--all-features`, `--features`, and `--no-default-features` flags to specify the exact features to have enabled when gathering the crates in your dependency graph to actually run checks against. This is a **BREAKING CHANGE** as previously crates were gathered with `--all-features`.
 - The `--color` option for the `list` subcommand has been moved to the top level arguments.
 
+### Removed
+- The `--context` option , which was deprecated in `0.6.3`, has been removed.
+
 ### Fixed
 - Resolved [#211](https://github.com/EmbarkStudios/cargo-deny/issues/211) by adding a top-level `--color <auto|always|never>` option, if stderr is not a TTY or `never` is passed, no colors will be present in the output stream.
 

--- a/docs/src/cli/common.md
+++ b/docs/src/cli/common.md
@@ -68,8 +68,3 @@ One or more platforms to filter crates with. If a dependency is target specific,
 it will be ignored if it does not match at least 1 of the specified targets.
 This overrides the top-level [`targets = []`](../checks/cfg.md) configuration
 value.
-
-#### `--context` (deprecated)
-
-The directory used as the context for the deny, if not specified, the current
-working directory is used instead. Must contain a Cargo.toml file.

--- a/docs/src/cli/common.md
+++ b/docs/src/cli/common.md
@@ -7,6 +7,21 @@ subcommand.
 
 The path to a `Cargo.toml` file which is used as the context for operations.
 
+#### `--all-features` (single crate or workspace)
+
+Enables all features when determining which crates to consider. Works for both
+single crates and workspaces.
+
+#### `--no-default-features` (single crate only)
+
+Disables the `default` feature for a crate when determing which crates to
+consider.
+
+#### `--features` (single crate only)
+
+Space-separated list of features to enable when determining which crates to
+consider.
+
 #### `--workspace`
 
 Forces all workspace crates to be used as roots in the crate graph that we

--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -54,6 +54,9 @@ pub struct KrateContext {
     pub workspace: bool,
     pub exclude: Vec<String>,
     pub targets: Vec<String>,
+    pub no_default_features: bool,
+    pub all_features: bool,
+    pub features: Vec<String>,
 }
 
 impl KrateContext {
@@ -93,7 +96,15 @@ impl KrateContext {
 
         let mut mdc = krates::Cmd::new();
 
-        mdc.all_features();
+        if self.no_default_features {
+            mdc.no_default_features();
+        }
+
+        if self.all_features {
+            mdc.all_features();
+        }
+
+        mdc.features(self.features);
         mdc.manifest_path(self.manifest_path);
 
         use krates::{Builder, DepKind};

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -90,11 +90,6 @@ fn parse_level(s: &str) -> Result<log::LevelFilter, Error> {
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case", max_term_width = 80)]
 pub(crate) struct GraphContext {
-    /// The directory used as the root context (deprecated)
-    ///
-    /// If not specified, the current working directory is used instead. The directory must contain a Cargo.toml file
-    #[structopt(long, parse(from_os_str))]
-    pub(crate) context: Option<PathBuf>,
     /// The path of a Cargo.toml to use as the context for the operation.
     ///
     /// By default, the Cargo.toml in the current working directory is used.
@@ -264,32 +259,26 @@ fn real_main() -> Result<(), Error> {
         None => {
             // For now, use the context path provided by the user, but
             // we've deprected it and it will go away at some point
-            let context_dir = args
-                .ctx
-                .context
-                .or_else(|| std::env::current_dir().ok())
-                .context("unable to determine current working directory")?;
+            let cwd =
+                std::env::current_dir().context("unable to determine current working directory")?;
 
-            if !context_dir.exists() {
-                bail!(
-                    "current working directory {} was not found",
-                    context_dir.display()
-                );
+            if !cwd.exists() {
+                bail!("current working directory {} was not found", cwd.display());
             }
 
-            if !context_dir.is_dir() {
+            if !cwd.is_dir() {
                 bail!(
                     "current working directory {} is not a directory",
-                    context_dir.display()
+                    cwd.display()
                 );
             }
 
-            let man_path = context_dir.join("Cargo.toml");
+            let man_path = cwd.join("Cargo.toml");
 
             if !man_path.exists() {
                 bail!(
                     "the directory {} doesn't contain a Cargo.toml file",
-                    context_dir.display()
+                    cwd.display()
                 );
             }
 

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -117,6 +117,15 @@ pub(crate) struct GraphContext {
     /// If a dependency is target specific, it will be ignored if it does not match 1 or more of the specified targets. This option overrides the top-level `targets = []` configuration value.
     #[structopt(short, long)]
     pub(crate) target: Vec<String>,
+    /// Activate all available features
+    #[structopt(long)]
+    pub(crate) all_features: bool,
+    /// Do not activate the `default` feature
+    #[structopt(long)]
+    pub(crate) no_default_features: bool,
+    /// Space-separated list of features to activate
+    #[structopt(long)]
+    pub(crate) features: Vec<String>,
 }
 
 /// Lints your project's crate graph
@@ -303,6 +312,9 @@ fn real_main() -> Result<(), Error> {
         workspace: args.ctx.workspace,
         exclude: args.ctx.exclude,
         targets: args.ctx.target,
+        no_default_features: args.ctx.no_default_features,
+        all_features: args.ctx.all_features,
+        features: args.ctx.features,
     };
 
     let log_ctx = crate::common::LogContext {


### PR DESCRIPTION
Add `--all-features`, `--features`, and `--no-default-features`. This is a breaking change as the default behavior is no longer `--all-features`.

Removed deprecated `--context`

Resolves: #216