### PR TITLE
Implement multiple advisory databases

### DIFF
--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -231,9 +231,13 @@ pub(crate) fn cmd(
 
         if check_advisories {
             s.spawn(|_| {
-                advisory_db = Some(advisories::load_db(
-                    cfg.advisories.db_url.as_ref().map(AsRef::as_ref),
-                    cfg.advisories.db_path.as_ref().cloned(),
+                advisory_db = Some(advisories::load_dbs(
+                    cfg.advisories.db_urls.iter().map(AsRef::as_ref).collect(),
+                    cfg.advisories
+                        .db_paths
+                        .iter()
+                        .map(|p| p.to_path_buf())
+                        .collect(),
                     if args.disable_fetch {
                         advisories::Fetch::Disallow
                     } else {

--- a/src/cargo-deny/fetch.rs
+++ b/src/cargo-deny/fetch.rs
@@ -142,9 +142,9 @@ pub fn cmd(
         if fetch_db {
             s.spawn(|_| {
                 // This function already logs internally
-                db = Some(advisories::load_db(
-                    cfg.advisories.db_url.as_ref().map(AsRef::as_ref),
-                    cfg.advisories.db_path.as_ref().cloned(),
+                db = Some(advisories::load_dbs(
+                    cfg.advisories.db_urls.iter().map(AsRef::as_ref).collect(),
+                    cfg.advisories.db_paths,
                     advisories::Fetch::Allow,
                 ))
             });


### PR DESCRIPTION
Instead of using and creating a single `Database` instance,
you will now create a `DatabaseCollection`, which mirrors the API
of a single `Database`, but queries the results from multiple databases.

Resolves #69 