### PR TITLE
Allow wildcard dependencies by default

### DIFF
--- a/deny.template.toml
+++ b/deny.template.toml
@@ -145,7 +145,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "warn"
+wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted

--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -95,7 +95,7 @@ pub struct Config {
     #[serde(default)]
     pub skip_tree: Vec<Spanned<TreeSkip>>,
     /// How to handle wildcard dependencies
-    #[serde(default = "crate::lint_warn")]
+    #[serde(default = "crate::lint_allow")]
     pub wildcards: LintLevel,
 }
 
@@ -108,7 +108,7 @@ impl Default for Config {
             allow: Vec::new(),
             skip: Vec::new(),
             skip_tree: Vec::new(),
-            wildcards: LintLevel::Warn,
+            wildcards: LintLevel::Allow,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,10 @@ impl Default for LintLevel {
     }
 }
 
+const fn lint_allow() -> LintLevel {
+    LintLevel::Allow
+}
+
 const fn lint_warn() -> LintLevel {
     LintLevel::Warn
 }


### PR DESCRIPTION
At least until #241 has been resolved, because right now every project using cargo-deny will get warnings by default on all of their valid local file dependencies. Which is not a that good of a default.

Once we've fixed that issue we should however switch this back to warn on wildcards, it is a good opinionated default (if it works fully)