### PR TITLE
Fix link to the cargo-deny init template in the cargo-deny book

### DIFF
--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -21,9 +21,9 @@ cargo deny init path/to/config.toml
 
 ### Template
 
-A `deny.toml` file will be created in the current working directory that is a 
-direct copy of [this template](https://github.com/EmbarkStudios/cargo-deny/blob/main/resources/template.toml).
+A `deny.toml` file will be created in the current working directory that is a
+direct copy of [this template](https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml).
 
 ```ini
-{{#include ../../../resources/template.toml}}
+{{#include ../../../deny.template.toml}}
 ```


### PR DESCRIPTION
The cargo-deny template file created by calling `cargo deny init` at some point moved from `resources/` to the root of the repo. The book links to the `init` template twice, but after this change, the links to the template in the book were not corrected, causing an inclusion failure as reported by mdbook. It can also be seen here: https://embarkstudios.github.io/cargo-deny/cli/init.html#template

This PR fixes the links by correcting the [init.md](https://github.com/EmbarkStudios/cargo-deny/blob/1d6052fc1f7761d42e65c70b3b9190423e74cd2d/docs/src/cli/init.md) file in the sources of the book to point to the [new](https://github.com/EmbarkStudios/cargo-deny/blob/1d6052fc1f7761d42e65c70b3b9190423e74cd2d/src/cargo-deny/init.rs#L14) [location](https://github.com/EmbarkStudios/cargo-deny/blob/1d6052fc1f7761d42e65c70b3b9190423e74cd2d/deny.template.toml) of the template file. 

```
# before fix
2020-08-29 18:31:21 [INFO] (mdbook::book): Book building has started
2020-08-29 18:31:21 [ERROR] (mdbook::preprocess::links): Error updating "{{#include ../../../resources/template.toml}}", Could not read file for link {{#include ../../../resources/template.toml}} (/ws/cargo-deny/docs/src/cli/../../../resources/template.toml)
2020-08-29 18:31:21 [WARN] (mdbook::preprocess::links): Caused By: The system cannot find the file specified. (os error 2)
2020-08-29 18:31:21 [INFO] (mdbook::book): Running the html backend
2020-08-29 18:31:22 [INFO] (mdbook::cmd::serve): Serving on: http://localhost:3000
2020-08-29 18:31:22 [INFO] (warp::server): Server::run; addr=V6([::1]:3000)
2020-08-29 18:31:22 [INFO] (warp::server): listening on http://[::1]:3000
2020-08-29 18:31:22 [INFO] (mdbook::cmd::watch): Listening for changes...
# after fix
2020-08-29 18:35:12 [INFO] (mdbook::cmd::serve): Files changed: ["/ws/cargo-deny/docs/src/cli/init.md"]
2020-08-29 18:35:12 [INFO] (mdbook::cmd::serve): Building book...
2020-08-29 18:35:12 [INFO] (mdbook::book): Book building has started
2020-08-29 18:35:12 [INFO] (mdbook::book): Running the html backend
``` 