### PR TITLE
Add MSRV to README/CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -38,7 +38,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -76,7 +76,7 @@ jobs:
     env:
       TARGET: x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -114,7 +114,7 @@ jobs:
     name: Build the book
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: |
           set -e
           curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
@@ -129,7 +129,7 @@ jobs:
     name: Publish Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -143,6 +143,25 @@ jobs:
         with:
           command: publish
           args: --dry-run
+
+  msrv-check:
+    name: Minimum Stable Rust Version Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.43.0"
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-targets
 
   release:
     name: Release
@@ -177,7 +196,7 @@ jobs:
         run: |
           sudo apt-get install -y musl-tools
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [PR#238](https://github.com/EmbarkStudios/cargo-deny/pull/238) resolved [#225](https://github.com/EmbarkStudios/cargo-deny/issues/225) by adding a `wrappers` field to `[bans.deny]` entries, which allows the banned crate to be used only if it is a direct dependency of one of the wrapper crates. Thanks [@Stupremee](https://github.com/Stupremee)!
 
+### Fixed
+- [#265](https://github.com/EmbarkStudios/cargo-deny/issues/265) A transitive dependency (`smol_str`) forced the usage of the latest Rust stable version (1.46) which was unintended. We now state the MSRV in the README and check for it in CI so that changing the MSRV is a conscious decision.
+
 ## [0.7.3] - 2020-08-06
 ### Added
 - [PR#237](https://github.com/EmbarkStudios/cargo-deny/pull/237) added the ability to allow git sources from entire `github.com`, `gitlab.com`, or `bitbucket.org` organizations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "smol_str",
  "spdx",
  "structopt",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ semver = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.4"
+# Versions of smol_str > 0.1.16 include code that only works on latest stable
+# (1.46+) which is far too aggressive for what is just a transitive dependency
+smol_str = { version = "=0.1.16" }
 spdx = "0.3"
 structopt = "0.3"
 toml = "0.5"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Latest version](https://img.shields.io/crates/v/cargo-deny.svg)](https://crates.io/crates/cargo-deny)
 [![Docs](https://img.shields.io/badge/The%20Book-📕-brightgreen.svg)](https://embarkstudios.github.io/cargo-deny/)
 [![API Docs](https://docs.rs/cargo-deny/badge.svg)](https://docs.rs/cargo-deny)
+[![MSRV](https://img.shields.io/badge/Rust-1.43-blue?color=fc8d62&logo=rust)](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html)
 [![SPDX Version](https://img.shields.io/badge/SPDX%20Version-3.7-blue.svg)](https://spdx.org/licenses/)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.dev)


### PR DESCRIPTION
As pointed out in #265, trying to do `cargo install` requires the latest stable rust version (1.46 as of now) due to the transitive dependency on `smol_str`. This PR pins that dependency to `0.1.16` which doesn't require latest stable.

This PR also adds a badge to the README stating the Minimum Stable Rust Version that this crate (and all targets) can be built with, as well as adds a CI check to ensure we don't accidentally change the minimum version during development.

Resolves: #265 