### PR TITLE
Add "unknown advisory" detection

### DIFF
--- a/src/advisories/mod.rs
+++ b/src/advisories/mod.rs
@@ -436,7 +436,7 @@ pub fn check(
                     (
                         Check::Advisories,
                         Diagnostic::warning()
-                            .with_message("advisory is not actually in the database at all")
+                            .with_message("this advisory is not in any RustSec database")
                             .with_labels(vec![Label::primary(
                                 ctx.cfg.file_id,
                                 ignored.span.clone(),


### PR DESCRIPTION
Fixes #64.
Warn if a advisory should be ignored that does not exist at all.

Example:
```
➜  test2 git:(master) ✗ ~/git/cargo-deny/target/debug/cargo-deny check advisories
warning: this advisory is not in any RustSec database
   ┌─ /tmp/test2/deny.toml:49:5
   │
49 │     "RUSTSEC-0000-0000",
   │     ^^^^^^^^^^^^^^^^^^^ unknown advisory

warning: advisory was not encountered
   ┌─ /tmp/test2/deny.toml:48:5
   │
48 │     "RUSTSEC-2020-0036",
   │     ^^^^^^^^^^^^^^^^^^^ no crate matched advisory criteria

advisories ok
```