### PR TITLE
Make license exceptions additive

### DIFF
--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -158,7 +158,7 @@ pub struct Config {
     /// it exactly matches the specified license files and hashes
     #[serde(default)]
     pub clarify: Vec<Clarification>,
-    /// Allow 1 or more licenses on a per-crate basis, so particular licenses
+    /// Allow 1 or more additional licenses on a per-crate basis, so particular licenses
     /// aren't accepted for every possible crate and must be opted into
     #[serde(default)]
     pub exceptions: Vec<Exception>,


### PR DESCRIPTION
Fixes #135.

Attached is a example that reproduces the case in the linked issue. We see that if the license-exception is triggers successful no warning is emitted. If the license-exception is not needed no error is throw (new behavior). Instead a warning is emitted that this license-exception is not needed.

Example:
```
➜  test3 git:(master) ✗ cat Cargo.toml 
[package]
name = "test3"
version = "0.1.0"
authors = ["Stefano Probst <senden9@gmail.com>"]
edition = "2018"
license = "MIT"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
x11-dl = "=2.18.5"
#x11-dl = "=2.18.4"
➜  test3 git:(master) ✗ ~/git/cargo-deny/target/debug/cargo-deny check
warning: crate license exception was not encountered
    ┌─ /tmp/test3/deny.toml:104:35
    │
104 │     { allow = ["CC0-1.0"], name = "x11-dl" },
    │                                   ^^^^^^^^ no crate source matched these criteria

advisories ok, bans ok, licenses ok, sources ok
➜  test3 git:(master) ✗ vim Cargo.toml
➜  test3 git:(master) ✗ cat Cargo.toml 
[package]
name = "test3"
version = "0.1.0"
authors = ["Stefano Probst <senden9@gmail.com>"]
edition = "2018"
license = "MIT"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
#x11-dl = "=2.18.5"
x11-dl = "=2.18.4"
➜  test3 git:(master) ✗ ~/git/cargo-deny/target/debug/cargo-deny check
advisories ok, bans ok, licenses ok, sources ok
➜  test3 git:(master) ✗ 
```

As you can see the warning is "no crate source matched these criteria". This is because other code-paths trigger the same already existing warning. If this is too confusing I could try to insert another code path with a specific warning. 