### PR TITLE
Clarify SPDX identifiers

### DIFF
--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -19,6 +19,15 @@ allow = [
     # A custom license identifier
     "LicenseRef-Embark-Custom",
 ]
+
+# Custom license refs can be specified for crates which don't use a license
+# in the SPDX list
+[[licenses.clarify]]
+name = "a-crate"
+expression = "LicenseRef-Embark-Custom"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
 ```
 
 License identifiers can also be coupled with an optional [exception](https://spdx.org/licenses/exceptions-index.html) by appending `WITH <exception-id>` to the license identifier. Licenses coupled with exceptions are considered distinct from the same license without the exception.

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -8,11 +8,33 @@ Contains all of the configuration for `cargo deny check license`.
 {{#include ../../../../tests/cfg/licenses.toml}}
 ```
 
+## SPDX Identifiers
+
+All identifiers used in the license configuration section are expected to be valid SPDX v2.1 short identifiers, either from version 3.7 of the [SPDX License List](https://spdx.org/licenses/), or use a [custom identifier](https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/#format-for-spdx-license-identifier) by prefixing it with `LicenseRef-`.
+
+```ini
+allow = [
+    # The Apache license identifier
+    "Apache-2.0",
+    # A custom license identifier
+    "LicenseRef-Embark-Custom",
+]
+```
+
+License identifiers can also be coupled with an optional [exception](https://spdx.org/licenses/exceptions-index.html) by appending `WITH <exception-id>` to the license identifier. Licenses coupled with exceptions are considered distinct from the same license without the exception.
+
+```ini
+allow = [
+    # The Apache license identifier
+    "Apache-2.0",
+    # The Apache license + LLVM-exception
+    "Apache-2.0 WITH LLVM-exception",
+]
+```
+
 ### The `unlicensed` field (optional)
 
-Determines what happens when a crate has not explicitly specified its license
-terms, and no license information could be confidently detected via `LICENSE*`
-files in the crate's source.
+Determines what happens when a crate has not explicitly specified its license terms, and no license information could be confidently detected via `LICENSE*` files in the crate's source.
 
 * `deny` (default) - All unlicensed crates will emit an error and fail the
 license check
@@ -23,30 +45,19 @@ license check
 
 ### The `allow` and `deny` fields (optional)
 
-The licenses that should be allowed or denied. The license must be a valid SPDX
-v2.1 identifier, which must either be in version 3.7 of the
-[SPDX License List](https://spdx.org/licenses/), with an optional
-[exception](https://spdx.org/licenses/exceptions-index.html) specified by
-`WITH <exception-id>`, or else a user defined license reference denoted by
-`LicenseRef-<idstring>` for a license not in the SPDX License List.
+The licenses that should be allowed or denied, note that the same license cannot
+appear in both the `allow` and `deny` lists.
 
-**NOTE:** The same license cannot appear in both the `allow` and `deny` lists.
-
-#### GNU licenses
+#### Note on GNU licenses
 
 * GPL
 * AGPL
 * LGPL
 * GFDL
 
-The GNU licenses are, of course, different from all the other licenses in the
-SPDX list which makes them annoying to deal with. When supplying one of the
-above licenses, to either `allow` or `deny`, you **must not** use the suffixes
-`-only` or `-or-later`, as they can only be used by the license holder
-themselves to decide under which terms to license their code.
+The GNU licenses are, of course, different from all the other licenses in the SPDX list which makes them annoying to deal with. When supplying one of the above licenses, to either `allow` or `deny`, you **must not** use the suffixes `-only` or `-or-later`, as they can only be used by the license holder themselves to decide under which terms to license their code.
 
-So, for example, if you wanted to disallow `GPL-2.0` licenses, but allow
-`GPL-3.0` licenses, you could use the following configuration.
+So, for example, if you wanted to disallow `GPL-2.0` licenses, but allow `GPL-3.0` licenses, you could use the following configuration.
 
 ```ini
 [licenses]
@@ -56,12 +67,7 @@ deny = [ "GPL-2.0" ]
 
 ### The `exceptions` field (optional)
 
-The license configuration generally applies to the entire crate graph, but this
-means that allowing any one license applies to all possible crates, even if
-only 1 crate actually uses that license. The `exceptions` field is meant to
-allow licenses only for particular crates, to make a clear distinction between
-licenses which you are fine with everywhere, versus ones which you want to be
-more selective about, and not have implicitly allowed in the future.
+The license configuration generally applies to the entire crate graph, but this means that allowing any one license applies to all possible crates, even if only 1 crate actually uses that license. The `exceptions` field is meant to allow licenses only for particular crates, to make a clear distinction between licenses which you are fine with everywhere, versus ones which you want to be more selective about, and not have implicitly allowed in the future.
 
 #### The `exceptions.name` field
 
@@ -69,8 +75,7 @@ The name of the crate that you are adding an exception for
 
 #### The `exceptions.version` field (optional)
 
-An optional version constraint specifying the range of crate versions you are
-excepting. Defaults to all versions (`*`).
+An optional version constraint specifying the range of crate versions you are excepting. Defaults to all versions (`*`).
 
 #### The `allow` field
 
@@ -92,8 +97,7 @@ exceptions = [
 
 ### The `copyleft` field (optional)
 
-Determines what happens when a license that is considered
-[copyleft](https://en.wikipedia.org/wiki/Copyleft) is encountered.
+Determines what happens when a license that is considered [copyleft](https://en.wikipedia.org/wiki/Copyleft) is encountered.
 
 * `warn` (default) - Will emit a warning that a copyleft license was detected,
 but will not fail the license check
@@ -103,10 +107,7 @@ might not fail if the expression still evaluates to true
 
 ### The `allow-osi-fsf-free` field (optional)
 
-Determines what happens when licenses aren't explicitly allowed or denied, but
-**are** marked as [OSI Approved](https://opensource.org/licenses) or
-[FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html) in version
-3.7 of the [SPDX License List](https://spdx.org/licenses/).
+Determines what happens when licenses aren't explicitly allowed or denied, but **are** marked as [OSI Approved](https://opensource.org/licenses) or [FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html) in version 3.7 of the [SPDX License List](https://spdx.org/licenses/).
 
 * `both` - The license is accepted if it is both OSI approved and FSF Free
 * `either` - The license is accepted if it is either OSI approved or FSF Free
@@ -130,23 +131,13 @@ not fail if the expression still evaluates to true
 
 ### The `confidence-threshold` field (optional)
 
-`cargo-deny` uses [askalono](https://github.com/amzn/askalono) to determine the
-license of a LICENSE file. Due to variability in license texts because of things
-like authors, copyright year, and so forth, askalano assigns a confidence score
-to its determination, from `0.0` (no confidence) to `1.0` (perfect match). The
-confidence threshold value is used to reject the license determination if the
-score does not match or exceed the threshold.
+`cargo-deny` uses [askalono](https://github.com/amzn/askalono) to determine the license of a LICENSE file. Due to variability in license texts because of things like authors, copyright year, and so forth, askalano assigns a confidence score to its determination, from `0.0` (no confidence) to `1.0` (perfect match). The confidence threshold value is used to reject the license determination if the score does not match or exceed the threshold.
 
 `0.0` - `1.0` (default `0.8`)
 
 ### The `clarify` field (optional)
 
-In some exceptional cases, a crate will not have easily machine readable license
-information, and would by default be considered "unlicensed" by cargo-deny. As a
-(hopefully) temporary patch for using the crate, you can specify a clarification
-for the crate by manually assigning its SPDX expression, based on one or more
-files in the crate's source. cargo-deny will use that expression for as long as
-the source files in the crate exactly match the clarification's hashes.
+In some exceptional cases, a crate will not have easily machine readable license information, and would by default be considered "unlicensed" by cargo-deny. As a (hopefully) temporary patch for using the crate, you can specify a clarification for the crate by manually assigning its SPDX expression, based on one or more files in the crate's source. cargo-deny will use that expression for as long as the source files in the crate exactly match the clarification's hashes.
 
 ```ini
 [[licenses.clarify]]
@@ -163,18 +154,15 @@ The name of the crate that you are clarifying
 
 #### The `version` field (optional)
 
-An optional version constraint specifying the range of crate versions you are
-clarifying. Defaults to all versions (`*`).
+An optional version constraint specifying the range of crate versions you are clarifying. Defaults to all versions (`*`).
 
 #### The `expression` field
 
-The [SPDX license expression][SPDX-expr] you are specifying as the license
-requirements for the crate.
+The [SPDX license expression][SPDX-expr] you are specifying as the license requirements for the crate.
 
 #### The `license-files` field
 
-Contains one or more files that will be checked to ensure the license
-expression still applies to a version of the crate.
+Contains one or more files that will be checked to ensure the license expression still applies to a version of the crate.
 
 ##### The `path` field
 
@@ -182,19 +170,15 @@ The crate relative path to a file to be used as a source of truth.
 
 ##### The `hash` field
 
-An opaque hash calculated from the file contents. This hash can be obtained
-from the output of the license check when cargo-deny can't determine the license
-of the file in question.
+An opaque hash calculated from the file contents. This hash can be obtained from the output of the license check when cargo-deny can't determine the license of the file in question.
 
 ### The `private` field (optional)
 
-It's often not useful or wanted to check for licenses in your own private
-workspace crates. So the private field allows you to do so.
+It's often not useful or wanted to check for licenses in your own private workspace crates. So the private field allows you to do so.
 
 #### The `ignore` field
 
-If `true`, workspace members will not have their license expression checked if
-they are not published.
+If `true`, workspace members will not have their license expression checked if they are not published.
 
 ```ini
 [package]


### PR DESCRIPTION
This tries to proactively address future issues similar to #51 and #325 by clarifying SPDX identifiers a bit, and giving examples for both license exceptions, and custom license identifiers.