### PR TITLE
Enable Embark standard set of additional Clippy lints

### DIFF
--- a/src/advisories/diags.rs
+++ b/src/advisories/diags.rs
@@ -98,7 +98,7 @@ impl<'a> crate::CheckCtx<'a, super::cfg::ValidConfig> {
             )
         };
 
-        let mut notes = get_notes_from_advisory(&advisory);
+        let mut notes = get_notes_from_advisory(advisory);
 
         if let Some(versions) = versions {
             if versions.patched.is_empty() {

--- a/src/advisories/fix.rs
+++ b/src/advisories/fix.rs
@@ -73,7 +73,7 @@ impl super::Report {
 
                 warning.versions.as_ref().and_then(|vs| {
                     warning.advisory.as_ref().map(|adv| Patchable {
-                        advisory: &adv,
+                        advisory: adv,
                         patched: &vs.patched,
                         krate: &warning.package,
                     })
@@ -110,7 +110,7 @@ impl super::Report {
             // (workspace/local crates) that depend on the vulnerable crate version
             // 3. For each crate in the chain, check to see if has a version
             // available that ultimately includes a patched version of the vulnerable crate
-            let (ind, vuln_krate) = super::krate_for_pkg(krates, &patchable.krate).unwrap();
+            let (ind, vuln_krate) = super::krate_for_pkg(krates, patchable.krate).unwrap();
 
             let mut pack = Pack::with_kid(Check::Advisories, vuln_krate.id.clone());
 
@@ -119,7 +119,7 @@ impl super::Report {
             if patchable.patched.is_empty() {
                 pack.push(diags::NoAvailablePatches {
                     affected_krate_coord: krate_spans.get_coord(ind.index()),
-                    advisory: &patchable.advisory,
+                    advisory: patchable.advisory,
                 });
                 diags.push(pack);
                 continue;
@@ -161,7 +161,7 @@ impl super::Report {
             if required.is_empty() {
                 pack.push(diags::NoAvailablePatchedVersions {
                     affected_krate_coord: krate_spans.get_coord(ind.index()),
-                    advisory: &patchable.advisory,
+                    advisory: patchable.advisory,
                 });
                 diags.push(pack);
                 continue;
@@ -342,7 +342,7 @@ impl super::Report {
     ) -> Result<Vec<Version>, NoVersionReason> {
         let mut res = None;
 
-        index.read_krate(&parent, |ik| {
+        index.read_krate(parent, |ik| {
             match ik {
                 Some(parent_krate) => {
                     // Grab all of the versions of the parent crate that have a version requirement that accepts
@@ -359,7 +359,7 @@ impl super::Report {
                                 dep.kind != Some(krates::cm::DependencyKind::Development)
                                     && dep.name == child.name
                             }) {
-                                if !required.iter().any(|vs| dep.req.matches(&vs)) {
+                                if !required.iter().any(|vs| dep.req.matches(vs)) {
                                     return None;
                                 }
                             }

--- a/src/advisories/mod.rs
+++ b/src/advisories/mod.rs
@@ -11,7 +11,7 @@ pub trait AuditReporter {
     fn report(&mut self, report: serde_json::Value);
 }
 
-/// For when you just want to satisfy AuditReporter without doing anything
+/// For when you just want to satisfy `AuditReporter` without doing anything
 pub struct NoneReporter;
 impl AuditReporter for NoneReporter {
     fn report(&mut self, _report: serde_json::Value) {}
@@ -67,8 +67,7 @@ pub fn check<R>(
 
     let mut send_diag =
         |pkg: &Package, advisory: &Metadata, versions: Option<&Versions>| match krate_for_pkg(
-            &ctx.krates,
-            pkg,
+            ctx.krates, pkg,
         ) {
             Some((i, krate)) => {
                 // This is a workaround for https://github.com/steveklabnik/semver/issues/172,
@@ -130,13 +129,13 @@ pub fn check<R>(
         .iter_warnings()
         .filter_map(|(_, wi)| wi.advisory.as_ref().map(|wia| (wi, wia)))
     {
-        send_diag(&warning.package, &advisory, warning.versions.as_ref());
+        send_diag(&warning.package, advisory, warning.versions.as_ref());
     }
 
     match yanked {
         Ok(yanked) => {
             for pkg in yanked {
-                match krate_for_pkg(&ctx.krates, &pkg) {
+                match krate_for_pkg(ctx.krates, pkg) {
                     Some((ind, krate)) => {
                         sink.push(ctx.diag_for_yanked(krate, ind));
                     }

--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -177,7 +177,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
         }
 
         for a in &allowed {
-            if let Ok(si) = skipped.binary_search(&a) {
+            if let Ok(si) = skipped.binary_search(a) {
                 add_diag((a, "allow"), (&skipped[si], "skip"));
             }
         }

--- a/src/bans/mod.rs
+++ b/src/bans/mod.rs
@@ -212,7 +212,6 @@ pub fn check(
         highlight,
         tree_skipped,
         wildcards,
-        ..
     } = ctx.cfg;
 
     let krate_spans = &ctx.krate_spans;

--- a/src/index/bare.rs
+++ b/src/index/bare.rs
@@ -1,4 +1,4 @@
-//! This is a copy of https://github.com/frewsxcv/rust-crates-index/pull/41 so
+//! This is a copy of <https://github.com/frewsxcv/rust-crates-index/pull/41> so
 //! that we can make releases of cargo-deny until/if it is merged and released
 
 use super::IndexKrate;
@@ -72,7 +72,10 @@ impl<'a> BareIndexRepo<'a> {
             let commit = repo.find_commit(head)?;
             let tree = commit.tree()?;
 
-            unsafe { std::mem::transmute::<git2::Tree<'_>, git2::Tree<'static>>(tree) }
+            #[allow(unsafe_code)] // TODO: Can we get rid of this transmute?
+            unsafe {
+                std::mem::transmute::<git2::Tree<'_>, git2::Tree<'static>>(tree)
+            }
         };
 
         Ok(Self {
@@ -110,7 +113,7 @@ impl<'a> BareIndexRepo<'a> {
     }
 
     fn krate_from_blob(&self, path: &str) -> Result<IndexKrate, Error> {
-        let entry = self.tree.as_ref().unwrap().get_path(&Path::new(path))?;
+        let entry = self.tree.as_ref().unwrap().get_path(Path::new(path))?;
         let object = entry.to_object(&self.repo)?;
         let blob = object.as_blob().context("unable to get blob contents")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,46 @@
-#![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
+// Standard Embark lints
+#![deny(unsafe_code)]
+#![warn(
+    clippy::all,
+    clippy::doc_markdown,
+    clippy::dbg_macro,
+    clippy::todo,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::pub_enum_variant_names,
+    clippy::mem_forget,
+    clippy::unused_self,
+    clippy::filter_map_next,
+    clippy::needless_continue,
+    clippy::explicit_into_iter_loop,
+    clippy::needless_borrow,
+    clippy::match_wildcard_for_single_variants,
+    clippy::if_let_mutex,
+    clippy::mismatched_target_os,
+    clippy::await_holding_lock,
+    clippy::match_on_vec_items,
+    clippy::imprecise_flops,
+    clippy::suboptimal_flops,
+    clippy::lossy_float_literal,
+    clippy::let_unit_value,
+    clippy::debug_assert_with_mut_call,
+    clippy::ref_option_ref,
+    clippy::map_flatten,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::fn_params_excessive_bools,
+    clippy::exit,
+    clippy::inefficient_to_string,
+    clippy::linkedlist,
+    clippy::string_to_string,
+    clippy::macro_use_imports,
+    clippy::option_option,
+    clippy::verbose_file_reads,
+    clippy::unnested_or_patterns,
+    clippy::map_unwrap_or,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style
+)]
 #![cfg_attr(docsrs, feature(external_doc))]
 
 //! # ❌ cargo-deny
@@ -244,17 +285,14 @@ impl Krate {
     /// Returns true if the crate is marked as `publish = false`, or
     /// it is only published to the specified private registries
     pub(crate) fn is_private(&self, private_registries: &[&str]) -> bool {
-        self.publish
-            .as_ref()
-            .map(|v| {
-                if v.is_empty() {
-                    true
-                } else {
-                    v.iter()
-                        .all(|reg| private_registries.contains(&reg.as_str()))
-                }
-            })
-            .unwrap_or(false)
+        self.publish.as_ref().map_or(false, |v| {
+            if v.is_empty() {
+                true
+            } else {
+                v.iter()
+                    .all(|reg| private_registries.contains(&reg.as_str()))
+            }
+        })
     }
 }
 

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -245,7 +245,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
         // denied and allowed, that's confusing and probably not intended, so
         // they should pick one
         for (di, d) in denied.iter().enumerate() {
-            if let Ok(ai) = allowed.binary_search(&d) {
+            if let Ok(ai) = allowed.binary_search(d) {
                 diags.push(
                     Diagnostic::error()
                         .with_message("a license id was specified in both `allow` and `deny`")

--- a/src/licenses/gather.rs
+++ b/src/licenses/gather.rs
@@ -279,7 +279,7 @@ impl LicensePack {
                                     // but we want to see what it thinks the license is if the confidence
                                     // is somewhat ok at least
                                     if lic_match.score >= confidence {
-                                        match spdx::license_id(&identified.name) {
+                                        match spdx::license_id(identified.name) {
                                             Some(id) => {
                                                 if lic_count > 0 {
                                                     expr.push_str(" AND ");
@@ -587,7 +587,7 @@ impl Gatherer {
                 let mut license_pack = None;
 
                 // 1
-                if let Some(ref cfg) = cfg {
+                if let Some(cfg) = cfg {
                     for clarification in iter_clarifications(&cfg.clarifications, krate) {
                         let lp = match license_pack {
                             Some(ref lp) => lp,
@@ -601,7 +601,7 @@ impl Gatherer {
                         // the set of detected licenses, if they do, we use the clarification's
                         // license expression as the license requirements for this crate
                         let clarifications_match = clarification.license_files.iter().all(|clf| {
-                            match lp.license_files_match(&clf) {
+                            match lp.license_files_match(clf) {
                                 Ok(_) => true,
                                 Err(reason) => {
                                     if let MismatchReason::FileNotFound = reason {

--- a/src/licenses/mod.rs
+++ b/src/licenses/mod.rs
@@ -291,7 +291,7 @@ pub fn check(
             && krate_lic_nfo.krate.is_private(&private_registries)
         {
             pack.push(diags::SkippedPrivateWorkspaceCrate {
-                krate: &krate_lic_nfo.krate,
+                krate: krate_lic_nfo.krate,
             });
             sink.push(pack);
             continue;
@@ -302,8 +302,8 @@ pub fn check(
                 pack.push(evaluate_expression(
                     &ctx.cfg,
                     &krate_lic_nfo,
-                    &expr,
-                    &nfo,
+                    expr,
+                    nfo,
                     &mut hits,
                 ));
             }
@@ -315,7 +315,7 @@ pub fn check(
                 };
 
                 pack.push(diags::Unlicensed {
-                    krate: &krate_lic_nfo.krate,
+                    krate: krate_lic_nfo.krate,
                     severity,
                     breadcrumbs: krate_lic_nfo.labels.into_iter().collect(),
                 });

--- a/src/manifest/dependency.rs
+++ b/src/manifest/dependency.rs
@@ -113,8 +113,7 @@ impl Dependency {
     pub fn set_features(mut self, features: Option<Vec<String>>) -> Dependency {
         self.features = features.map(|f| {
             f.iter()
-                .map(|x| x.split(' ').map(String::from))
-                .flatten()
+                .flat_map(|x| x.split(' ').map(String::from))
                 .filter(|s| !s.is_empty())
                 .collect::<Vec<String>>()
         });
@@ -137,7 +136,7 @@ impl Dependency {
     /// that is, either the alias (rename field if Some),
     /// or the official package name (name field).
     pub fn name_in_manifest(&self) -> &str {
-        &self.rename().unwrap_or(&self.name)
+        self.rename().unwrap_or(&self.name)
     }
 
     /// Set the value of registry for the dependency
@@ -170,7 +169,7 @@ impl Dependency {
     /// Get the alias for the dependency (if any)
     pub fn rename(&self) -> Option<&str> {
         match &self.rename {
-            Some(rename) => Some(&rename),
+            Some(rename) => Some(rename),
             None => None,
         }
     }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -19,7 +19,7 @@ fn merge_inline_table(old_dep: &mut toml_edit::Item, new: &toml_edit::Item) {
 }
 
 fn str_or_1_len_table(item: &toml_edit::Item) -> bool {
-    item.is_str() || item.as_table_like().map(|t| t.len() == 1).unwrap_or(false)
+    item.is_str() || item.as_table_like().map_or(false, |t| t.len() == 1)
 }
 
 fn merge_dependencies(old_dep: &mut toml_edit::Item, new: &dep::Dependency) {
@@ -148,7 +148,7 @@ impl Manifest {
                     .unwrap_or(name);
 
                 if let Some(update_dep) = deps.iter().find(|dep| dep.name == dep_name) {
-                    self.update_table_named_entry(&table_path, &name, update_dep)?;
+                    self.update_table_named_entry(&table_path, name, update_dep)?;
                 }
             }
         }


### PR DESCRIPTION
This enables the additional Clippy lints that we use at Embark with additional restrictions and more opinionated than the default. And fixes the code to work with it, pretty basic changes.

Later when we have https://github.com/EmbarkStudios/rust-ecosystem/issues/22 we'll try and define these lints in a separate file and use it in all of our repos