### PR TITLE
Update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,25 +18,15 @@ jobs:
           toolchain: stable
           override: true
 
-      # make sure all code has been formatted with rustfmt
-      - run: rustup component add rustfmt
-      - name: check rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check --color always
+      # make sure all code has been formatted with rustfmt and linted with clippy
+      - run: rustup component add rustfmt clippy
+      - name: rustfmt
+        run: cargo fmt -- --check --color always
 
       # run clippy to verify we have no warnings
-      - run: rustup component add clippy
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: Test
@@ -50,26 +40,13 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: cargo test build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --tests
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo build --tests
+      - run: cargo test
       # Run the tests we usually don't want to run when
       # testing locally
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -- --ignored
+      - run: cargo test -- --ignored
 
   self:
     name: Check Users
@@ -94,25 +71,16 @@ jobs:
         run: |
           sudo apt-get install -y musl-tools
       - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-          args: --target ${{ matrix.target }}
+        run: cargo fetch --target ${{ matrix.target }}
       - name: cargo install
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          # Install in debug mode since this part is sloooooow and
-          # release doesn't really matter much for runtime
-          # Also, build and run with musl, this lets us ensure that
-          # musl still works, which is important for the linux binaries
-          # we release, but wasn't exercised until now
-          args: --path . --debug --target ${{ matrix.target }} --features standalone
+        # Install in debug mode since this part is sloooooow and
+        # release doesn't really matter much for runtime
+        # Also, build and run with musl, this lets us ensure that
+        # musl still works, which is important for the linux binaries
+        # we release, but wasn't exercised until now
+        run: cargo install --path . --debug --target ${{ matrix.target }} --features standalone
       - name: self check
-        uses: actions-rs/cargo@v1
-        with:
-          command: deny
-          args: -L debug --all-features check
+        run: cargo deny -L debug --all-features check
       - name: check external users
         run: ./scripts/check_external.sh
 
@@ -141,15 +109,9 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: cargo publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --dry-run
+        run: cargo publish --dry-run
 
   msrv-check:
     name: Minimum Stable Rust Version Check
@@ -158,17 +120,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.44.1"
+          toolchain: "1.46.0"
           override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets
+        run: cargo check --all-targets
 
   release:
     name: Release
@@ -205,15 +161,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-          args: --target ${{ matrix.target }}
+        run: cargo fetch --target ${{ matrix.target }}
       - name: Release build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }}
       - name: Package
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- Updated dependencies, notably `cargo` and `rustsec`.
+- Increase MSRV to `1.46.0` due to bump of `smol_str`/`rustsec`.
+- Updated SPDX license list supported from 3.8 to 3.11 due to update of `spdx`.
+- Add use of the `--locked` flag in all `cargo install` instructions, to avoid the default (broken) behavior as shown in [#331](https://github.com/EmbarkStudios/cargo-deny/issues/331).
+
 ## [0.8.7] - 2021-02-18
 ### Fixed
 - Resolved [#331](https://github.com/EmbarkStudios/cargo-deny/issues/331) by updating `bitvec` and `funty`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,18 +344,18 @@ dependencies = [
 
 [[package]]
 name = "codespan"
-version = "0.9.5"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebaf6bb6a863ad6aa3a18729e9710c53d75df03306714d9cc1f7357a00cd789"
+checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
 ]
 
 [[package]]
 name = "codespan-reporting"
-version = "0.9.5"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 dependencies = [
  "jobserver",
 ]
@@ -393,12 +393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,14 +487,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
  "crossbeam-utils",
  "lazy_static",
+ "loom",
  "memoffset",
  "scopeguard",
 ]
@@ -517,13 +511,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -688,9 +683,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -716,6 +711,19 @@ checksum = "08c1f5787fe85505d1f7777268db5103d80a7a374d2316a7ce262e57baf8f208"
 dependencies = [
  "memchr",
  "termcolor",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -847,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1018,6 +1026,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,9 +1114,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
 
 [[package]]
 name = "opener"
@@ -1130,9 +1149,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.13.0+1.1.1i"
+version = "111.14.0+1.1.1j"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
 dependencies = [
  "cc",
 ]
@@ -1430,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1478,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -1543,9 +1574,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "sized-chunks"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca43dc3574a38d4090f492dd3ef0d589fc434916a5b40ffc75057595002141a"
+checksum = "65e65d6a9f13cd78f361ea5a2cf53a45d67cdda421ba0316b9be101560f3d207"
 dependencies = [
  "bitmaps",
  "typenum",
@@ -1671,9 +1702,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0313546c01d59e29be4f09687bcb4fb6690cec931cc3607b6aec7a0e417f4cc6"
+checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
 dependencies = [
  "filetime",
  "libc",
@@ -1719,18 +1750,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1860,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "rustsec"
 version = "0.23.0"
-source = "git+https://github.com/EmbarkStudios/rustsec-crate?rev=f8ec004#f8ec00441be84b3124ec7e3192bba40b49c62210"
+source = "git+https://github.com/EmbarkStudios/rustsec-crate?rev=527290c#527290cda4f444e3c4c2559a2b8305dd82124a13"
 dependencies = [
  "cargo-lock",
  "crates-index",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee5a98e506fb7231a304c3a1bd7c132a55016cf65001e0282480665870dfcb9"
+checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,8 +1409,7 @@ dependencies = [
 [[package]]
 name = "rustsec"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7989ff58001a2be1c17945e53d32fcad5cf33c638a4b1239d6e1c9aff7a5d2f8"
+source = "git+https://github.com/EmbarkStudios/rustsec-crate?rev=77cb5f3#77cb5f34f58a01eec97a1e9a7b2775e869814833"
 dependencies = [
  "cargo-lock",
  "crates-index",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "ascii"
@@ -92,9 +92,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -133,18 +133,18 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytesize"
@@ -154,9 +154,9 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.50.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e85a774d067a36bd0874fdb068e2e70aa6b1a7a22a5de9dc100219c7421e2eb"
+checksum = "bb7d89cbdcbeada632f64aa9f692e265852b0eb6ccdf3b1814716cc62101eeb6"
 dependencies = [
  "anyhow",
  "atty",
@@ -165,7 +165,7 @@ dependencies = [
  "clap",
  "core-foundation",
  "crates-io",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "crypto-hash",
  "curl",
  "curl-sys",
@@ -240,7 +240,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "smol_str",
  "spdx",
  "structopt",
  "tempfile",
@@ -252,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad00408e56f778335802ea240b8d70bebf6ea6c43c7508ebb6259431b5f16c2"
+checksum = "e6f16e7adc20969298b1e137ac21ab3a7e7a9412fec71f963ff2fdc41663d70f"
 dependencies = [
  "semver 0.11.0",
  "serde",
@@ -273,29 +272,31 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a5f7b42f606b7f23674f6f4d877628350682bc40687d3fae65679a58d55345"
+checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
 dependencies = [
+ "cargo-platform",
  "semver 0.11.0",
+ "semver-parser 0.10.2",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
 
 [[package]]
 name = "cfg-expr"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0c100231f8a29c84a357798453c739519cd6b34c0b3f574f8701eec39b6572"
+checksum = "0e7295b602ecd3f5c3b30983c61e1244910d78a87df2c217c7392a97ab004baa"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -322,7 +323,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "serde",
  "time",
  "winapi",
 ]
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "core-foundation"
@@ -416,9 +416,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crates-index"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ae75100b8f15499dd7340cb39da61afe7d27bee726038a09d143600901331e"
+checksum = "7f24823d553339d125040d989d2a593a01b034fe5ac17714423bcd2c3d168878"
 dependencies = [
  "git2",
  "glob",
@@ -467,7 +467,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -488,18 +488,18 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -507,34 +507,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -567,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.38+curl-7.73.0"
+version = "0.4.40+curl-7.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498ecfb4f59997fd40023d62a9f1e506e768b2baeb59a1d311eb9751cdcd7e3f"
+checksum = "2ffafc1c35958318bd7fdd0582995ce4c72f4f461a8e70499ccee83a619fd562"
 dependencies = [
  "cc",
  "libc",
@@ -583,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "cvss"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c425c059aef1e9cc614482211c4bd78664299ca91d4353db994f9966a1e7161d"
+checksum = "b2ecd8322bca85301b52d821806315c282c7e5f85f03b0609e68d4189bda8f58"
 dependencies = [
  "serde",
 ]
@@ -604,9 +592,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
  "humantime",
@@ -648,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -666,9 +654,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -732,13 +720,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -749,9 +737,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "git2"
-version = "0.13.12"
+version = "0.13.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
 dependencies = [
  "bitflags",
  "libc",
@@ -801,18 +789,18 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -843,15 +831,25 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -860,11 +858,11 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
+checksum = "b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -883,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ca8957e71f04a205cb162508f9326aea04676c8dfd0711220190d6b83664f3f"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -892,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -911,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
@@ -926,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "krates"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e097391fdf5a89ca49523c9a6248ff96b8ce9f44e12eb966e27a7f93ea33914c"
+checksum = "84fc12ce2d430236046217dd76d6b6c63193c441f029d9006fb10ef87ec51723"
 dependencies = [
  "cargo_metadata",
  "cfg-expr",
@@ -950,15 +948,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.14+1.1.0"
+version = "0.12.18+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
 dependencies = [
  "cc",
  "libc",
@@ -970,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.4+1.41.0"
+version = "0.1.6+1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
+checksum = "0af55541a8827e138d59ec9e5877fb6095ece63fb6f4da45e7491b4fbd262855"
 dependencies = [
  "cc",
  "libc",
@@ -980,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
+checksum = "e0186af0d8f171ae6b9c4c90ec51898bad5d08a2d5e470903a50d9ad8959cbee"
 dependencies = [
  "cc",
  "libc",
@@ -1006,17 +1004,17 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1033,9 +1031,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg",
 ]
@@ -1091,9 +1089,15 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+
+[[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opener"
@@ -1106,12 +1110,12 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1126,18 +1130,18 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.12.0+1.1.1h"
+version = "111.13.0+1.1.1i"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858a4132194f8570a7ee9eb8629e85b23cbc4565f2d4a162e87556e5956abf61"
+checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -1180,9 +1184,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "platforms"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc77a3fc329982cbf3ea772aa265b742a550998bad65747c630406ee52dac425"
+checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 dependencies = [
  "serde",
 ]
@@ -1228,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1243,25 +1247,24 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.2",
  "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1269,17 +1272,23 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1288,7 +1297,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1311,22 +1320,25 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1336,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -1351,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -1396,23 +1408,25 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.22.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5982d0d4f57176e3e8d62452a5d6dab98906ee5ab4ad1cb63c0877f0a16ab0e"
+checksum = "7989ff58001a2be1c17945e53d32fcad5cf33c638a4b1239d6e1c9aff7a5d2f8"
 dependencies = [
  "cargo-lock",
- "chrono",
  "crates-index",
  "cvss",
  "fs-err",
  "git2",
  "home",
+ "humantime",
+ "humantime-serde",
  "platforms",
  "semver 0.11.0",
  "serde",
  "smol_str",
  "thiserror",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -1462,7 +1476,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.1",
+ "semver-parser 0.10.2",
  "serde",
 ]
 
@@ -1474,27 +1488,27 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1512,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
@@ -1529,9 +1543,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "sized-chunks"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+checksum = "bca43dc3574a38d4090f492dd3ef0d589fc434916a5b40ffc75057595002141a"
 dependencies = [
  "bitmaps",
  "typenum",
@@ -1545,9 +1559,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smartstring"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5579edba9651e6b9ccf0d516c4457521a149dadeb77e88b03eb1ae3183fe180a"
+checksum = "1ada87540bf8ef4cf8a1789deb175626829bb59b1fefd816cf7f7f55efcdbae9"
 dependencies = [
  "serde",
  "static_assertions",
@@ -1555,27 +1569,26 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
+checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
 
 [[package]]
 name = "socket2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi",
 ]
 
 [[package]]
 name = "spdx"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f874c9aa7762aa10401e2ae004d977e7b6156074668eb4ce78dd0cb28255"
+checksum = "4e6b6cc773b635ad64a05f00367c6f66d06a8708f7360f67c41d446dacdd0a0f"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1605,9 +1618,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1616,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1629,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1652,19 +1665,18 @@ dependencies = [
 
 [[package]]
 name = "tap"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
+checksum = "0313546c01d59e29be4f09687bcb4fb6690cec931cc3607b6aec7a0e417f4cc6"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -1675,11 +1687,11 @@ checksum = "4ee5a98e506fb7231a304c3a1bd7c132a55016cf65001e0282480665870dfcb9"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -1689,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -1707,18 +1719,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1727,35 +1739,43 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -1804,18 +1824,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -1848,6 +1868,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -1858,9 +1879,9 @@ checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"
@@ -1902,15 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"
@@ -1951,18 +1966,18 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zstd"
-version = "0.5.3+zstd.1.4.5"
+version = "0.5.4+zstd.1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b32eaf771efa709e8308605bbf9319bf485dc1503179ec0469b611937c0cd8"
+checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "2.0.5+zstd.1.4.5"
+version = "2.0.6+zstd.1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfb642e0d27f64729a639c52db457e0ae906e7bc6f5fe8f5c453230400f1055"
+checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -1970,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.17+zstd.1.4.5"
+version = "1.4.18+zstd.1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
+checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
 dependencies = [
  "cc",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "rustsec"
 version = "0.23.0"
-source = "git+https://github.com/EmbarkStudios/rustsec-crate?rev=77cb5f3#77cb5f34f58a01eec97a1e9a7b2775e869814833"
+source = "git+https://github.com/EmbarkStudios/rustsec-crate?rev=f8ec004#f8ec00441be84b3124ec7e3192bba40b49c62210"
 dependencies = [
  "cargo-lock",
  "crates-index",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,8 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.23.0"
-source = "git+https://github.com/EmbarkStudios/rustsec-crate?rev=527290c#527290cda4f444e3c4c2559a2b8305dd82124a13"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86d15edf87746f448f4e68c8b97aaf145fcdc06c96b6af50a7c6832db9a0810"
 dependencies = [
  "cargo-lock",
  "crates-index",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7295b602ecd3f5c3b30983c61e1244910d78a87df2c217c7392a97ab004baa"
+checksum = "2b81b9640fc656040fbf0d3f2bafacadcf17d55f2b0dc89589c1b80b0658fd5a"
 dependencies = [
  "smallvec",
  "target-lexicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,7 @@ url = "2.1"
 [dev-dependencies]
 # Avoid loading license check many times
 lazy_static = "1.4.0"
-# We use this for creating fake crate directories for
-# crawling license files on disk
+# We use this for creating fake crate directories for crawling license files on disk
 tempfile = "3.1.0"
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,4 +100,4 @@ lazy_static = "1.4.0"
 tempfile = "3.1.0"
 
 [patch.crates-io]
-rustsec = { git = "https://github.com/EmbarkStudios/rustsec-crate", rev = "f8ec004" }
+rustsec = { git = "https://github.com/EmbarkStudios/rustsec-crate", rev = "527290c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ cargo = { version = "0.51", optional = true }
 # Timey wimey stuff
 chrono = "0.4"
 # Used for diagnostic reporting
-codespan = { version = "0.9", features = ["reporting"] }
-codespan-reporting = "0.9"
+codespan = "0.11"
+codespan-reporting = "0.11"
 # Brrrrr
 crossbeam = "0.8"
 # We use this for displaying diffs for dry runs of the `fix` subcommand, as

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,4 +100,4 @@ lazy_static = "1.4.0"
 tempfile = "3.1.0"
 
 [patch.crates-io]
-rustsec = { git = "https://github.com/EmbarkStudios/rustsec-crate", rev = "77cb5f3" }
+rustsec = { git = "https://github.com/EmbarkStudios/rustsec-crate", rev = "f8ec004" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ atty = "0.2"
 # Used to track various things during check runs
 bitvec = { version = "0.21", features = ["alloc"] }
 # Allows us to do eg cargo metadata operations without relying on an external cargo
-cargo = { version = "0.50", optional = true }
+cargo = { version = "0.51", optional = true }
 # Timey wimey stuff
 chrono = "0.4"
 # Used for diagnostic reporting
@@ -63,7 +63,7 @@ git2 = { version = "0.13", features = ["vendored-openssl"] }
 # We need to figure out HOME/CARGO_HOME in some cases
 home = "0.5"
 # Provides graphs on top of cargo_metadata
-krates = { version = "0.5", features = ["targets"] }
+krates = { version = "0.6", features = ["targets"] }
 # Log macros
 log = "0.4"
 # Used when parsing binary files in registry index caches
@@ -73,7 +73,7 @@ memchr = "2.3"
 rayon = "1.4"
 #regex = { version = "1.3", default-features = true }
 # Used for interacting with advisory databases
-rustsec = "0.22"
+rustsec = "0.23"
 # Parsing and checking of versions/version requirements
 semver = "0.11"
 # Gee what could it be
@@ -81,9 +81,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # Avoid some heap allocations when we likely won't need them
 smallvec = "1.6"
-# Versions of smol_str > 0.1.16 include code that only works on latest stable
-# (1.46+) which is far too aggressive for what is just a transitive dependency
-smol_str = { version = "=0.1.16" }
 # Used for parsing and checking SPDX license expressions
 spdx = "0.3"
 # Handles all of the argument parsing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,8 @@ krates = { version = "0.6", features = ["targets"] }
 log = "0.4"
 # Used when parsing binary files in registry index caches
 memchr = "2.3"
-#percent-encoding = "2.1"
 # Moar brrrr
 rayon = "1.4"
-#regex = { version = "1.3", default-features = true }
 # Used for interacting with advisory databases
 rustsec = "0.23"
 # Parsing and checking of versions/version requirements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,6 @@ lazy_static = "1.4.0"
 # We use this for creating fake crate directories for
 # crawling license files on disk
 tempfile = "3.1.0"
+
+[patch.crates-io]
+rustsec = { git = "https://github.com/EmbarkStudios/rustsec-crate", rev = "77cb5f3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,3 @@ url = "2.1"
 lazy_static = "1.4.0"
 # We use this for creating fake crate directories for crawling license files on disk
 tempfile = "3.1.0"
-
-[patch.crates-io]
-rustsec = { git = "https://github.com/EmbarkStudios/rustsec-crate", rev = "527290c" }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Please Note: This is a tool that we use (and like!) and it makes sense to us to
 ## [Quickstart](https://embarkstudios.github.io/cargo-deny/)
 
 ```bash
-cargo install cargo-deny && cargo deny init && cargo deny check
+cargo install --locked cargo-deny && cargo deny init && cargo deny check
 ```
 
 ## Usage
@@ -31,7 +31,7 @@ build `cargo-deny` with the `standalone` feature.
 This can be useful in Docker Images.
 
 ```bash
-cargo install cargo-deny
+cargo install --locked cargo-deny
 
 # Or, if you're an Arch user
 yay -S cargo-deny

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Crates.io](https://img.shields.io/crates/v/cargo-deny.svg)](https://crates.io/crates/cargo-deny)
 [![Docs](https://img.shields.io/badge/The%20Book-📕-brightgreen.svg)](https://embarkstudios.github.io/cargo-deny/)
 [![API Docs](https://docs.rs/cargo-deny/badge.svg)](https://docs.rs/cargo-deny)
-[![Minimum Stable Rust Version](https://img.shields.io/badge/Rust-1.44.1-blue?color=fc8d62&logo=rust)](https://blog.rust-lang.org/2020/06/18/Rust.1.44.1.html)
-[![SPDX Version](https://img.shields.io/badge/SPDX%20Version-3.7-blue.svg)](https://spdx.org/licenses/)
+[![Minimum Stable Rust Version](https://img.shields.io/badge/Rust-1.46.0-blue?color=fc8d62&logo=rust)](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html)
+[![SPDX Version](https://img.shields.io/badge/SPDX%20Version-3.11-blue.svg)](https://spdx.org/licenses/)
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/cargo-deny/status.svg)](https://deps.rs/repo/github/EmbarkStudios/cargo-deny)
 [![Build Status](https://github.com/EmbarkStudios/cargo-deny/workflows/CI/badge.svg)](https://github.com/EmbarkStudios/cargo-deny/actions?workflow=CI)
 

--- a/deny.template.toml
+++ b/deny.template.toml
@@ -68,7 +68,7 @@ ignore = [
 unlicensed = "deny"
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
     #"MIT",
     #"Apache-2.0",
@@ -76,7 +76,7 @@ allow = [
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 deny = [
     #"Nokia",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,6 @@ ignore = [
     # askalono uses failure, which is now unmaintained
     "RUSTSEC-2019-0036",
     "RUSTSEC-2020-0036",
-    # cargo uses a a vulnerable version of sized-chunks
-    "RUSTSEC-2020-0041",
     # difference is unmaintained but suits our needs just fine
     "RUSTSEC-2020-0095",
 ]
@@ -28,15 +26,15 @@ deny = [
 skip = [
     # clap uses an older version of ansi_term
     { name = "ansi_term", version = "=0.11.0" },
-    # cargo/ignore use an older version of this
-    { name = "crossbeam-utils", version = "=0.7.2" },
+    # cfg-if reached 1.0 but many crates still depend on the 0.1 version
+    { name = "cfg-if", version = "=0.1.10" },
     # cargo uses crypto-hash, which uses an old version
     { name = "hex", version = "=0.3.2" },
+    # im-rc, used by cargo, uses an old version of rand_core
+    { name = "rand_core", version = "=0.5.1" },
     # cargo uses an older version of semver
     { name = "semver", version = "=0.10.0" },
     { name = "semver-parser", version = "=0.7.0" },
-    # cfg-if reached 1.0 but many crates still depend on the 0.1 version
-    { name = "cfg-if", version = "=0.1.10" },
 ]
 
 [sources]

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -5,8 +5,7 @@ to ensure all your dependencies conform to your expectations and requirements.
 
 ## Quickstart
 
-Installs cargo-deny, initializes your project with a default configuration,
-then runs all of the checks against your project.
+Installs cargo-deny, initializes your project with a default configuration, then runs all of the checks against your project.
 
 ```bash
 cargo install --locked cargo-deny && cargo deny init && cargo deny check
@@ -14,24 +13,19 @@ cargo install --locked cargo-deny && cargo deny init && cargo deny check
 
 ## Command Line Interface
 
-cargo-deny is intended to be used as a [Command Line Tool](cli/index.html),
-see the link for the available commands and options.
+cargo-deny is intended to be used as a [Command Line Tool](cli/index.html), see the link for the available commands and options.
 
 ## Checks
 
-cargo-deny supports several classes of checks, see [Checks](checks/index.html)
-for the available checks and their configuration options.
+cargo-deny supports several classes of checks, see [Checks](checks/index.html) for the available checks and their configuration options.
 
 ## API
 
-cargo-deny is primarily meant to be used as a cargo plugin, but a majority of
-its functionality is within a library whose docs you may view on
-[docs.rs](https://docs.rs/cargo-deny)
+cargo-deny is primarily meant to be used as a cargo plugin, but a majority of its functionality is within a library whose docs you may view on [docs.rs](https://docs.rs/cargo-deny)
 
 ## GitHub Action
 
-For GitHub projects, one can run cargo-deny automatically as part of continous
-integration using a GitHub Action:
+For GitHub projects, one can run cargo-deny automatically as part of continous integration using a GitHub Action:
 
 ```yaml
 name: CI
@@ -44,6 +38,4 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v1
 ```
 
-For more information, see
-[`cargo-deny-action`](https://github.com/EmbarkStudios/cargo-deny-action)
-repository.
+For more information, see [`cargo-deny-action`](https://github.com/EmbarkStudios/cargo-deny-action) repository.

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -9,7 +9,7 @@ Installs cargo-deny, initializes your project with a default configuration,
 then runs all of the checks against your project.
 
 ```bash
-cargo install cargo-deny && cargo deny init && cargo deny check
+cargo install --locked cargo-deny && cargo deny init && cargo deny check
 ```
 
 ## Command Line Interface

--- a/docs/src/checks/README.md
+++ b/docs/src/checks/README.md
@@ -1,9 +1,6 @@
 # Checks
 
-cargo-deny supports several different classes of checks that can be performed
-on your project's crate graph. By default, `cargo deny check` will execute
-**all** of the supported checks, falling back to the default configuration for
-that check if one is not explicitly specified.
+cargo-deny supports several different classes of checks that can be performed on your project's crate graph. By default, `cargo deny check` will execute **all** of the supported checks, falling back to the default configuration for that check if one is not explicitly specified.
 
 ## [licenses](licenses/index.html)
 
@@ -15,9 +12,7 @@ Checks for specific crates in your graph, as well as duplicates.
 
 ## [advisories](advisories/index.html)
 
-Checks advisory databases for crates with security vulnerabilities, or that
-have been marked as `Unmaintained`, or which have been yanked from their source
-registry.
+Checks advisory databases for crates with security vulnerabilities, or that have been marked as `Unmaintained`, or which have been yanked from their source registry.
 
 ## [sources](sources/index.html)
 

--- a/docs/src/checks/advisories/README.md
+++ b/docs/src/checks/advisories/README.md
@@ -1,7 +1,6 @@
 # advisories
 
-The advisories check is used to detect issues for crates by looking in an
-advisory database.
+The advisories check is used to detect issues for crates by looking in an advisory database.
 
 ```bash
 cargo deny check advisories
@@ -11,16 +10,10 @@ cargo deny check advisories
 
 ## Use Case - Detecting security vulnerabilities
 
-Security vulnerabilities are generally considered "not great" by most people, 
-luckily, Rust has a great [advisory 
-database](https://github.com/RustSec/advisory-db) which cargo-deny can use to 
-check that you don't have any crates with (known) security vulnerabilities.
+Security vulnerabilities are generally considered "not great" by most people, luckily, Rust has a great [advisory database](https://github.com/RustSec/advisory-db) which cargo-deny can use to check that you don't have any crates with (known) security vulnerabilities.
 
-The database can be changed to use your own as well, as long as it follows the
-same format.
+You can also use your own advisory databases instead of, or in addition to, the above default, as long as it follows the same format.
 
 ## Use Case - Detecting unmaintained crates
 
-The [advisory database](https://github.com/RustSec/advisory-db) also contains 
-advisories for unmaintained crates, which in most cases users will want to 
-avoid in favor of more actively maintained crates.
+The [advisory database](https://github.com/RustSec/advisory-db) also contains advisories for unmaintained crates, which in most cases users will want to avoid in favor of more actively maintained crates.

--- a/docs/src/checks/advisories/cfg.md
+++ b/docs/src/checks/advisories/cfg.md
@@ -16,85 +16,59 @@ Default: [RustSec Advisory DB](https://github.com/RustSec/advisory-db)
 
 ### The `db-path` field (optional)
 
-Path to the root directory into which one or more advisory databases are cloned
-into
+Path to the root directory into which one or more advisory databases are cloned into
 
-Default: ~/.cargo/advisory-db
+Default: `~/.cargo/advisory-db`
 
 ### The `vulnerability` field (optional)
 
-Determines what happens when a crate with a security vulnerability is
-encountered.
+Determines what happens when a crate with a security vulnerability is encountered.
 
-* `deny` (default) - Will emit an error with details about each vulnerability,
-and fail the check.
+* `deny` (default) - Will emit an error with details about each vulnerability, and fail the check.
 * `warn` - Prints a warning for each vulnerability, but does not fail the check.
-* `allow` - Prints a note about the security vulnerability, but does not
-fail the check.
+* `allow` - Prints a note about the security vulnerability, but does not fail the check.
 
 ### The `unmaintained` field (optional)
 
-Determines what happens when a crate with an `unmaintained` advisory is
-encountered.
+Determines what happens when a crate with an `unmaintained` advisory is encountered.
 
-* `deny` - Will emit an error with details about the unmaintained advisory, and
-fail the check.
-* `warn` (default) - Prints a warning for each unmaintained advisory, but does
-not fail the check.
-* `allow` - Prints a note about the unmaintained advisory, but does not fail
-the check.
+* `deny` - Will emit an error with details about the unmaintained advisory, and fail the check.
+* `warn` (default) - Prints a warning for each unmaintained advisory, but does not fail the check.
+* `allow` - Prints a note about the unmaintained advisory, but does not fail the check.
 
 ### The `unsound` field (optional)
 
-Determines what happens when a crate with an `unsound` advisory is
-encountered.
+Determines what happens when a crate with an `unsound` advisory is encountered.
 
-* `deny` - Will emit an error with details about the unsound advisory, and
-fail the check.
-* `warn` (default) - Prints a warning for each unsound advisory, but does
-not fail the check.
-* `allow` - Prints a note about the unsound advisory, but does not fail
-the check.
+* `deny` - Will emit an error with details about the unsound advisory, and fail the check.
+* `warn` (default) - Prints a warning for each unsound advisory, but does not fail the check.
+* `allow` - Prints a note about the unsound advisory, but does not fail the check.
 
 ### The `yanked` field (optional)
 
-Determines what happens when a crate with a version that has been yanked from
-its source registry is encountered.
+Determines what happens when a crate with a version that has been yanked from its source registry is encountered.
 
-* `deny` - Will emit an error with the crate name and version that was yanked,
-and fail the check.
-* `warn` (default) - Prints a warning with the crate name and version that was
-yanked, but does not fail the check.
+* `deny` - Will emit an error with the crate name and version that was yanked, and fail the check.
+* `warn` (default) - Prints a warning with the crate name and version that was yanked, but does not fail the check.
 * `allow` - Prints a note about the yanked crate, but does not fail the check.
 
 ### The `notice` field (optional)
 
 Determines what happens when a crate with a `notice` advisory is encountered.
 
-**NOTE**: As of 2019-12-17 there are no `notice` advisories in
-the [RustSec Advisory DB](https://github.com/RustSec/advisory-db)
+**NOTE**: As of 2019-12-17 there are no `notice` advisories in the [RustSec Advisory DB](https://github.com/RustSec/advisory-db)
 
-* `deny` - Will emit an error with details about the notice advisory, and fail
-the check.
-* `warn` (default) - Prints a warning for each notice advisory, but does not
-fail the check.
-* `allow` - Prints a note about the notice advisory, but does not fail the
-check.
+* `deny` - Will emit an error with details about the notice advisory, and fail the check.
+* `warn` (default) - Prints a warning for each notice advisory, but does not fail the check.
+* `allow` - Prints a note about the notice advisory, but does not fail the check.
 
 ### The `ignore` field (optional)
 
-Every advisory in the advisory database contains a unique identifier, eg.
-`RUSTSEC-2019-0001`. Putting an identifier in this array will cause the
-advisory to be treated as a note, rather than a warning or error.
+Every advisory in the advisory database contains a unique identifier, eg. `RUSTSEC-2019-0001`. Putting an identifier in this array will cause the advisory to be treated as a note, rather than a warning or error.
 
 ### The `severity-threshold` field (optional)
 
-The threshold for security vulnerabilities to be turned into notes instead of
-warnings or errors, depending upon its
-[CVSS](https://en.wikipedia.org/wiki/Common_Vulnerability_Scoring_System) score.
-So having a high threshold means some vulnerabilities might not fail the check,
-but having a log level `>= info` will mean that a note will be printed instead
-of a warning or error, depending on `[advisories.vulnerability]`.
+The threshold for security vulnerabilities to be turned into notes instead of warnings or errors, depending upon its [CVSS](https://en.wikipedia.org/wiki/Common_Vulnerability_Scoring_System) score. So having a high threshold means some vulnerabilities might not fail the check, but having a log level `>= info` will mean that a note will be printed instead of a warning or error, depending on `[advisories.vulnerability]`.
 
 * `None` (default) - CVSS Score 0.0
 * `Low` - CVSS Score 0.1 - 3.9

--- a/docs/src/checks/advisories/diags.md
+++ b/docs/src/checks/advisories/diags.md
@@ -2,8 +2,7 @@
 
 ### `A001` - security vulnerability detected
 
-A [`vulnerability`](cfg.md#the-vulnerability-field-optional) advisory was
-detected for a crate.
+A [`vulnerability`](cfg.md#the-vulnerability-field-optional) advisory was detected for a crate.
 
 ### `A002` - notice advisory detected
 
@@ -11,30 +10,24 @@ A [`notice`](cfg.md#the-notice-field-optional) advisory was detected for a crate
 
 ### `A003` - unmaintained advisory detected
 
-An [`unmaintained`](cfg.md#the-unmaintained-field-optional) advisory was
-detected for a crate.
+An [`unmaintained`](cfg.md#the-unmaintained-field-optional) advisory was detected for a crate.
 
 ### `A004` - unsound advisory detected
 
-An [`unsound`](cfg.md#the-unsound-field-optional) advisory was detected for a
-crate.
+An [`unsound`](cfg.md#the-unsound-field-optional) advisory was detected for a crate.
 
 ### `A005` - detected yanked crate
 
-A crate using a version that has been [yanked](cfg.md#the-yanked-field-optional)
-from the registry index was detected.
+A crate using a version that has been [yanked](cfg.md#the-yanked-field-optional) from the registry index was detected.
 
 ### `A006` - unable to check for yanked crates
 
-An error occurred trying to read or update the registry index (typically crates.io)
-so cargo-deny was unable to check the current yanked status for any crate.
+An error occurred trying to read or update the registry index (typically crates.io) so cargo-deny was unable to check the current yanked status for any crate.
 
 ### `A007` - advisory was not encountered
 
-An advisory in [`advisories.ignore`](cfg.md#the-ignore-field-optional) didn't
-apply to any crate.
+An advisory in [`advisories.ignore`](cfg.md#the-ignore-field-optional) didn't apply to any crate.
 
 ### `A008` - advisory not found in any advisory database
 
-An advisory in [`advisories.ignore`](cfg.md#the-ignore-field-optional) wasn't
-found in any of the configured advisory databases.
+An advisory in [`advisories.ignore`](cfg.md#the-ignore-field-optional) wasn't found in any of the configured advisory databases.

--- a/docs/src/checks/advisories/fix-diags.md
+++ b/docs/src/checks/advisories/fix-diags.md
@@ -2,8 +2,7 @@
 
 ### `AF001` - advisory has no available patches
 
-An advisory does not reference any patched versions of the crate that fix the
-issue the advisory pertains to.
+An advisory does not reference any patched versions of the crate that fix the issue the advisory pertains to.
 
 ### `AF002` - affected crate has no available patched versions
 
@@ -11,21 +10,15 @@ None of the patched versions for the crate can be found in the registry index.
 
 ### `AF003` - unable to patch crate
 
-A crate could not be patched because it was either not found in the registry
-index, or, more likely, no published version of the crate was semver compatible
-with any of the versions of a dependency that we need update to include a
-patched version of the crate the advisory applies to.
+A crate could not be patched because it was either not found in the registry index, or, more likely, no published version of the crate was semver compatible with any of the versions of a dependency that we need update to include a patched version of the crate the advisory applies to.
 
 ### `AF004` - unpatchable source
 
-The source for a crate was `git` or `local registry` and we are unable to patch
-it.
+The source for a crate was `git` or `local registry` and we are unable to patch it.
 
 ### `AF005` - local crate requirement does not match any required versions
 
-Can't apply a patch to a local Cargo.toml manifest because it none of the
-version(s) that are required for the dependency are semver compatible with the
-version in it. This can be ignored by passing [`--allow-incompatible`](../../cli/fix.md#--allow-incompatible).
+Can't apply a patch to a local Cargo.toml manifest because it none of the version(s) that are required for the dependency are semver compatible with the version in it. This can be ignored by passing [`--allow-incompatible`](../../cli/fix.md#--allow-incompatible).
 
 ### `AF006` - no newer versions are available
 

--- a/docs/src/checks/bans/README.md
+++ b/docs/src/checks/bans/README.md
@@ -1,7 +1,6 @@
 # bans
 
-The bans check is used to deny (or allow) specific crates, as well as detect
-and handle multiple versions of the same crate.
+The bans check is used to deny (or allow) specific crates, as well as detect and handle multiple versions of the same crate.
 
 ```bash
 cargo deny check bans
@@ -11,66 +10,30 @@ cargo deny check bans
 
 ## Use Case - Denying specific crates
 
-Sometimes, certain crates just don't fit in your project, so you have to remove 
-them. However, nothing really stops them from sneaking back in due to innocuous
-changes like doing a `cargo update` and getting it transitively, or even
-forgetting to set 
-`default-features = false, features = ["feature-without-the-thing"]` when the 
-crate is pulled in via the default features of a crate you already depend on, 
-in your entire workspace.
+Sometimes, certain crates just don't fit in your project, so you have to remove them. However, nothing really stops them from sneaking back in due to innocuous changes like doing a `cargo update` and getting it transitively, or even forgetting to set `default-features = false, features = ["feature-without-the-thing"]` when the crate is pulled in via the default features of a crate you already depend on, in your entire workspace.
 
-For example, we previously depended on OpenSSL as it is the "default" for many 
-crates that provide TLS. This was extremely annoying as it required us to have 
-OpenSSL development libraries installed on Windows, for both individuals and CI. 
-We moved all of our dependencies to use the much more streamlined `native-tls` 
-or `ring` crates instead, and now we can make sure that OpenSSL doesn't return 
-from the grave by accident.
+For example, we previously depended on OpenSSL as it is the "default" for many crates that provide TLS. This was extremely annoying as it required us to have OpenSSL development libraries installed on Windows, for both individuals and CI. We moved all of our dependencies to use the much more streamlined `native-tls` or `ring` crates instead, and now we can make sure that OpenSSL doesn't return from the grave by accident.
 
 ## Use Case - Duplicate version detection
 
-The larger your project and number of external dependencies, the likelihood that
-you will have multiple versions of the same crate rises. This is due to two
-fundamental aspects of the Rust ecosystem.
+The larger your project and number of external dependencies, the likelihood that you will have multiple versions of the same crate rises. This is due to two fundamental aspects of the Rust ecosystem.
 
-1. Cargo's dependency resolution tries to solve all the version constraints 
-to a crate to the same version, but is totally ok with using [multiple 
-versions](https://stephencoakley.com/2019/04/24/how-rust-solved-dependency-hell)
-if it is unable to.
-1. Rust has a huge (ever growing) number of crates. Every maintainer has
-different amounts of time and energy they can spend on their crate, not to
-mention different philosophies on dependecies and how often (or not) they should
-be updated, so it is inevitable that crates will not always agree on which
-version of another crate they want to use.
+1. Cargo's dependency resolution tries to solve all the version constraints to a crate to the same version, but is totally ok with using [multiple versions](https://stephencoakley.com/2019/04/24/how-rust-solved-dependency-hell) if it is unable to.
+1. Rust has a huge (ever growing) number of crates. Every maintainer has different amounts of time and energy they can spend on their crate, not to mention different philosophies on dependecies and how often (or not) they should be updated, so it is inevitable that crates will not always agree on which version of another crate they want to use.
 
-This tradeoff of allowing multiple version of the same crate is one of the
-reasons that cargo is such a pleasant experience for many people new to Rust,
-but as with all tradeoffs, it does come with costs.
+This tradeoff of allowing multiple version of the same crate is one of the reasons that cargo is such a pleasant experience for many people new to Rust, but as with all tradeoffs, it does come with costs.
 
-1. More packages must be **fetched**, which especially impacts CI, as well as 
-devs.
+1. More packages must be **fetched**, which especially impacts CI, as well as devs.
 1. **Compile times** increase, which impacts CI and devs.
-1. **Target directory size** increases, which can impact devs, or static CI 
-environments.
+1. **Target directory size** increases, which can impact devs, or static CI environments.
 1. Final **binary size** will also tend to increase, which can impact users.
 
-Normally, you will not really notice that you have multiple versions of the
-same crate unless you constantly watch your build log, but as mentioned above,
-it **does** introduce papercuts into your workflows.
+Normally, you will not really notice that you have multiple versions of the same crate unless you constantly watch your build log, but as mentioned above, it **does** introduce papercuts into your workflows.
 
-The intention of duplicate detection in cargo-deny is not to "correct" cargo's
-behavior, but rather to draw your attention to duplicates so that you can make
-an informed decision about how to handle the situation.
+The intention of duplicate detection in cargo-deny is not to "correct" cargo's behavior, but rather to draw your attention to duplicates so that you can make an informed decision about how to handle the situation.
 
-* Maybe you want to open up a PR on a crate to use a version of the duplicate
-that is aligned with the rest of the ecosystem.
-* Maybe the crate has actually already been updated, but the maintainer hasn't
-published a new version yet, and you can ask if they can publish a new one.
-* Maybe, even though the versions are supposedly incompatible according to
-semver, they actually aren't, and you can temporarily introduce a `[patch]` to
-force the crate to use a particular version for your entire workspace.
-* Sometimes having the "latest and greatest" is not really that imporant for
-every version, and you can just specify a lower version in your own project that
-matches the transitive contraint(s).
-* And finally, you don't care about a particular case of multiple versions, so
-you just tell cargo-deny to ignore one or more of the specific versions, and the
-situation will eventually resolve itself.
+* Maybe you want to open up a PR on a crate to use a version of the duplicate that is aligned with the rest of the ecosystem.
+* Maybe the crate has actually already been updated, but the maintainer hasn't published a new version yet, and you can ask if they can publish a new one.
+* Maybe, even though the versions are supposedly incompatible according to semver, they actually aren't, and you can temporarily introduce a `[patch]` to force the crate to use a particular version for your entire workspace.
+* Sometimes having the "latest and greatest" is not really that imporant for every version, and you can just specify a lower version in your own project that matches the transitive contraint(s).
+* And finally, you don't care about a particular case of multiple versions, so you just tell cargo-deny to ignore one or more of the specific versions, and the situation will eventually resolve itself.

--- a/docs/src/checks/bans/cfg.md
+++ b/docs/src/checks/bans/cfg.md
@@ -10,50 +10,37 @@ Contains all of the configuration for `cargo deny check bans`
 
 ### The `multiple-versions` field (optional)
 
-Determines what happens when multiple versions of the same crate are
-encountered.
+Determines what happens when multiple versions of the same crate are encountered.
 
 * `deny` - Will emit an error for each crate with duplicates and fail the check.
-* `warn` (default) - Prints a warning for each crate with duplicates, but does
-not fail the check.
+* `warn` (default) - Prints a warning for each crate with duplicates, but does not fail the check.
 * `allow` - Ignores duplicate versions of the same crate.
 
 ### The `wildcards` field (optional)
 
-Determines what happens when a dependency is specified with the `*` (wildcard)
-version.
+Determines what happens when a dependency is specified with the `*` (wildcard) version.
 
 * `deny` - Will emit an error for each crate specifed with a wildcard version.
-* `warn` (default) - Prints a warning for each crate with a wildcard version,
-but does not fail the check.
+* `warn` (default) - Prints a warning for each crate with a wildcard version, but does not fail the check.
 * `allow` - Ignores all wildcard version specifications.
 
 ### The `highlight` field (optional)
 
-When multiple versions of the same crate are encountered and `multiple-versions`
-is set to `warn` or `deny`, using the `-g <dir>` option will print out a
-[dotgraph](https://www.graphviz.org/) of each of the versions and how they were
-included into the graph. This field determines how the graph is colored to help
-you quickly spot good candidates for removal or updating.
+When multiple versions of the same crate are encountered and `multiple-versions` is set to `warn` or `deny`, using the `-g <dir>` option will print out a [dotgraph](https://www.graphviz.org/) of each of the versions and how they were included into the graph. This field determines how the graph is colored to help you quickly spot good candidates for removal or updating.
 
-* `lowest-version` - Highlights the path to the lowest duplicate version.
-Highlighted in ![red](https://placehold.it/15/ff0000/000000?text=+)
-* `simplest-path` - Highlights the path to the duplicate version with the
-fewest number of total edges to the root of the graph, which will often be the
-best candidate for removal and/or upgrading. Highlighted in
-![blue](https://placehold.it/15/0000FF/000000?text=+).
-* `all` - Highlights both the `lowest-version` and `simplest-path`. If they are
-the same, they are only highlighted in
-![red](https://placehold.it/15/ff0000/000000?text=+).
+* `lowest-version` - Highlights the path to the lowest duplicate version. Highlighted in ![red](https://placehold.it/15/ff0000/000000?text=+)
+* `simplest-path` - Highlights the path to the duplicate version with the fewest number of total edges to the root of the graph, which will often be the best candidate for removal and/or upgrading. Highlighted in ![blue](https://placehold.it/15/0000FF/000000?text=+).
+* `all` - Highlights both the `lowest-version` and `simplest-path`. If they are the same, they are only highlighted in ![red](https://placehold.it/15/ff0000/000000?text=+).
 
 ![Imgur](https://i.imgur.com/xtarzeU.png)
 
 ### Crate specifier
 
-The `allow`, `deny`, `skip`, and `skip-tree` fields all use a crate identifier
-to specify what crate(s) they want to match against.
+The `allow`, `deny`, `skip`, and `skip-tree` fields all use a crate identifier to specify what crate(s) they want to match against.
 
-`{ name = "some-crate-name-here", version = "<= 0.7.0" }`
+```ini
+{ name = "some-crate-name-here", version = "<= 0.7.0" }
+```
 
 #### The `name` field
 
@@ -61,50 +48,28 @@ The name of the crate.
 
 #### The `version` field (optional)
 
-An optional version constraint specifying the range of crate versions that will
-match. Defaults to all versions (`*`).
+An optional version constraint specifying the range of crate versions that will match. Defaults to all versions (`*`).
 
 #### The `wrappers` field (optional)
 
-For `deny` entries, this field allows specific crates to have a direct
-dependency on the banned crate but denies all transitive dependencies on it.
+For `deny` entries, this field allows specific crates to have a direct dependency on the banned crate but denies all transitive dependencies on it.
 
 ### The `allow` and `deny` fields (optional)
 
-Determines specific crates that are allowed or denied. If the `allow` list has
-one or more entries, then any crate not in that list will be denied, so use with
-care.
+Determines specific crates that are allowed or denied. If the `allow` list has one or more entries, then any crate not in that list will be denied, so use with care.
 
 ### The `skip` field (optional)
 
-When denying duplicate versions, it's often the case that there is a window of
-time where you must wait for, for example, PRs to be accepted and new version
-published, before 1 or more duplicates are gone. The `skip` field allows you to
-temporarily ignore a crate during duplicate detection so that no errors are
-emitted, until it is no longer need.
+When denying duplicate versions, it's often the case that there is a window of time where you must wait for, for example, PRs to be accepted and new version published, before 1 or more duplicates are gone. The `skip` field allows you to temporarily ignore a crate during duplicate detection so that no errors are emitted, until it is no longer need.
 
-It is recommended to use specific version constraints for crates in the `skip`
-list, as cargo-deny will emit warnings when any entry in the `skip` list no
-longer matches a crate in your graph so that you can cleanup your configuration.
+It is recommended to use specific version constraints for crates in the `skip` list, as cargo-deny will emit warnings when any entry in the `skip` list no longer matches a crate in your graph so that you can cleanup your configuration.
 
 ### The `skip-tree` field (optional)
 
-When dealing with duplicate versions, it's often the case that a particular
-crate acts as a nexus point for a cascade effect, by either using bleeding edge
-versions of certain crates while in alpha or beta, or on the opposite end of
-the specturm, a crate is using severely outdated dependencies while much of the
-rest of the ecosystem has moved to more recent versions. In both cases, it can
-be quite tedious to explicitly `skip` each transitive dependency pulled in by
-that crate that clashes with your other dependencies, which is where `skip-tree`
-comes in.
+When dealing with duplicate versions, it's often the case that a particular crate acts as a nexus point for a cascade effect, by either using bleeding edge versions of certain crates while in alpha or beta, or on the opposite end of the specturm, a crate is using severely outdated dependencies while much of the rest of the ecosystem has moved to more recent versions. In both cases, it can be quite tedious to explicitly `skip` each transitive dependency pulled in by that crate that clashes with your other dependencies, which is where `skip-tree` comes in.
 
-`skip-tree` entries are similar to `skip` in that they are used to specify a
-crate name and version range that will be skipped, but they also have an
-additional `depth` field used to specify how many levels from the crate will
-also be skipped. A depth of `0` would be the same as specifying the crate in
-the `skip` field.
+`skip-tree` entries are similar to `skip` in that they are used to specify a crate name and version range that will be skipped, but they also have an additional `depth` field used to specify how many levels from the crate will also be skipped. A depth of `0` would be the same as specifying the crate in the `skip` field.
 
 Note that by default, the `depth` is infinite.
 
-**NOTE:** `skip-tree` is a very big hammer at the moment, and should be used
-with care.
+**NOTE:** `skip-tree` is a very big hammer at the moment, and should be used with care.

--- a/docs/src/checks/bans/diags.md
+++ b/docs/src/checks/bans/diags.md
@@ -2,38 +2,31 @@
 
 ### `B001` - crate is explicitly banned
 
-A crate which is [explicitly banned](cfg.md#the-allow-and-deny-fields-optional)
-was detected.
+A crate which is [explicitly banned](cfg.md#the-allow-and-deny-fields-optional) was detected.
 
 ### `B002` - crate is explicitly allowed
 
-A crate which is [explicitly allowed](cfg.md#the-allow-and-deny-fields-optional)
-was detected.
+A crate which is [explicitly allowed](cfg.md#the-allow-and-deny-fields-optional) was detected.
 
 ### `B003` - crate is implicitly banned
 
-When using [`bans.allow`](cfg.md#the-allow-and-deny-fields-optional), a crate
-was detected that wasn't in that list.
+When using [`bans.allow`](cfg.md#the-allow-and-deny-fields-optional), a crate was detected that wasn't in that list.
 
 ### `B004` - found duplicate entries for crate
 
-One or more [duplicate versions](cfg.md#the-multiple-versions-field-optional) of
-the same crate were detected.
+One or more [duplicate versions](cfg.md#the-multiple-versions-field-optional) of the same crate were detected.
 
 ### `B005` - crate skipped when checking for duplicates
 
-A crate version that matched an entry in
-[`bans.skip`](cfg.md#the-skip-field-optional) was encountered.
+A crate version that matched an entry in [`bans.skip`](cfg.md#the-skip-field-optional) was encountered.
 
 ### `B006` - found wildcard dependency for crate
 
-A crate was included via a [wildcard dependency](cfg.md#the-wildcards-field-optional)
-by one or more crates.
+A crate was included via a [wildcard dependency](cfg.md#the-wildcards-field-optional) by one or more crates.
 
 ### `B007` - skipped crate was not encountered
 
-A crate version in [`bans.skip`](cfg.md#the-skip-field-optional) was not
-encountered.
+A crate version in [`bans.skip`](cfg.md#the-skip-field-optional) was not encountered.
 
 ### `B008` - banned crate allowed by wrapper
 
@@ -41,14 +34,12 @@ A crate in `bans.deny` was allowed since it was referenced by a [`wrappers`](cfg
 
 ### `B009` - direct parent of banned crate was not marked as a wrapper
 
-A crate in `bans.deny` had one or more [`wrappers`](cfg.md#the-wrappers-field-optional)crates, but a crate not in that list had a direct dependency on the banned crate.
+A crate in `bans.deny` had one or more [`wrappers`](cfg.md#the-wrappers-field-optional) crates, but a crate not in that list had a direct dependency on the banned crate.
 
 ### `B010` - skip tree root was not found in the dependency graph
 
-A crate version in [`bans.skip-tree`](cfg.md#the-skip-tree-field-optional) was
-not encountered.
+A crate version in [`bans.skip-tree`](cfg.md#the-skip-tree-field-optional) was not encountered.
 
 ### `B011` - skipping crate due to root skip
 
-A crate was skipped from being checked as a duplicate due to being transitively
-referenced by a crate version in [`bans.skip-tree`](cfg.md#the-skip-tree-field-optional).
+A crate was skipped from being checked as a duplicate due to being transitively referenced by a crate version in [`bans.skip-tree`](cfg.md#the-skip-tree-field-optional).

--- a/docs/src/checks/cfg.md
+++ b/docs/src/checks/cfg.md
@@ -10,8 +10,7 @@ The top level config for cargo-deny, by default called `deny.toml`.
 
 ### The `targets` field (optional)
 
-By default, cargo-deny will consider every single crate that is resolved by
-cargo, including target specific dependencies eg
+By default, cargo-deny will consider every single crate that is resolved by cargo, including target specific dependencies eg
 
 ```ini
 [target.x86_64-pc-windows-msvc.dependencies]
@@ -21,47 +20,23 @@ winapi = "0.3.8"
 fuchsia-cprng = "0.1.1"
 ```
 
-But unless you are actually targetting `x86_64-fuchsia` or `aarch64-fuchsia`,
-the `fuchsia-cprng` is never actually going to be compiled or linked into your
-project, so checking it is pointless for you.
+But unless you are actually targetting `x86_64-fuchsia` or `aarch64-fuchsia`, the `fuchsia-cprng` is never actually going to be compiled or linked into your project, so checking it is pointless for you.
 
-The `targets` field allows you to specify one or more targets which you
-**actually** build for. Every dependency link to a crate is checked against this
-list, and if none of the listed targets satisfy the target constraint, the
-dependency link is ignored. If a crate has no dependency links to it, it is not
-included into the crate graph that the checks are executed against.
+The `targets` field allows you to specify one or more targets which you **actually** build for. Every dependency link to a crate is checked against this list, and if none of the listed targets satisfy the target constraint, the dependency link is ignored. If a crate has no dependency links to it, it is not included into the crate graph that the checks are executed against.
 
 #### The `triple` field
 
-The [target triple](https://forge.rust-lang.org/release/platform-support.html)
-for the target you wish to filter target specific dependencies with. If the
-target triple specified is **not** one of the targets builtin to `rustc`, the
-configuration check for that target will be limited to only the raw
-`[target.<target-triple>.dependencies]` style of target configuration, as
-`cfg()` expressions require us to know the details about the target.
+The [target triple](https://forge.rust-lang.org/release/platform-support.html) for the target you wish to filter target specific dependencies with. If the target triple specified is **not** one of the targets builtin to `rustc`, the configuration check for that target will be limited to only the raw `[target.<target-triple>.dependencies]` style of target configuration, as `cfg()` expressions require us to know the details about the target.
 
 #### The `exclude` field (optional)
 
-Just as with the [`--exclude`](../cli/common.md#--exclude) command line option,
-this field allows you to specify one or more
-[Package ID specifications](https://doc.rust-lang.org/cargo/commands/cargo-pkgid.html)
-that will cause the crate(s) in question to be excluded from the crate graph that
-is used for the operation you are performing.
+Just as with the [`--exclude`](../cli/common.md#--exclude) command line option, this field allows you to specify one or more [Package ID specifications](https://doc.rust-lang.org/cargo/commands/cargo-pkgid.html) that will cause the crate(s) in question to be excluded from the crate graph that is used for the operation you are performing.
 
-Note that excluding a crate is recursive, if any of its transitive dependencies
-are only referenced via the excluded crate, they will also be excluded from the
-crate graph.
+Note that excluding a crate is recursive, if any of its transitive dependencies are only referenced via the excluded crate, they will also be excluded from the crate graph.
 
 #### The `features` field (optional)
 
-Rust `cfg()` expressions support the [`target_feature =
-"feature-name"`](https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute)
-predicate, but at the moment, the only way to actually pass them when compiling
-is to use the `RUSTFLAGS` environment variable. The `features` field allows you
-to specify 1 or more `target_feature`s you plan to build with, for a particular
-target triple. At the time of this writing, cargo-deny does not attempt to
-validate that the features you specify are actually valid for the target triple,
-but this is [planned](https://github.com/EmbarkStudios/cfg-expr/issues/1).
+Rust `cfg()` expressions support the [`target_feature = "feature-name"`](https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute) predicate, but at the moment, the only way to actually pass them when compiling is to use the `RUSTFLAGS` environment variable. The `features` field allows you to specify 1 or more `target_feature`s you plan to build with, for a particular target triple. At the time of this writing, cargo-deny does not attempt to validate that the features you specify are actually valid for the target triple, but this is [planned](https://github.com/EmbarkStudios/cfg-expr/issues/1).
 
 ### The `[licenses]` section
 

--- a/docs/src/checks/licenses/README.md
+++ b/docs/src/checks/licenses/README.md
@@ -1,9 +1,6 @@
 # licenses
 
-The licenses check is used to verify that every crate you use has license terms
-you find acceptable. cargo-deny does this by evaluating the license requirements
-specified by each crate against the [configuration](cfg.md) you've specified, to
-determine if your project meets that crate's license requirements.
+The licenses check is used to verify that every crate you use has license terms you find acceptable. cargo-deny does this by evaluating the license requirements specified by each crate against the [configuration](cfg.md) you've specified, to determine if your project meets that crate's license requirements.
 
 ```bash
 cargo deny check licenses
@@ -13,50 +10,28 @@ cargo deny check licenses
 
 ### SPDX
 
-cargo-deny uses [SPDX license expressions][SPDX] as the source of truth for the 
-license requirements of a crate. Note however, that cargo-deny does **not** 
-(currently) exhaustively search the entirety of the source code of every crate 
-to find every possible license that could be attributed to the crate, as there 
-are a ton of edge cases to that approach.
+cargo-deny uses [SPDX license expressions][SPDX] as the source of truth for the license requirements of a crate. Note however, that cargo-deny does **not** (currently)exhaustively search the entirety of the source code of every crate to find every possible license that could be attributed to the crate, as there are a ton of edge cases to that approach.
 
-cargo-deny rather assumes that each crate correctly defines its license 
-requirements, but it provides a mechanism for manually specifying the license 
-requirements for crates in the, from our experience, rare circumstance that they
-cannot be gathered automatically.
+cargo-deny rather assumes that each crate correctly defines its license requirements, but it provides a mechanism for manually specifying the license requirements for crates in the, from our experience, rare circumstance that they cannot be gathered automatically.
 
 ### Expression Source Precedence
 
-The source of the SPDX expression used to evaluate the crate by is obtained in 
-the following order.
+The source of the SPDX expression used to evaluate the crate by is obtained in the following order.
 
-1. If the crate in question has a [Clarification](cfg.md#the-clarify-field-optional)
-applied to it, and the source file(s) in the crate's source still match, the
-expression from the clarification will be used.
-1. The [`license`][cargo-md] field from the crate's Cargo.toml manifest will be 
-used if it exists.
-1. The [`license-file`][cargo-md] field, as well as **all** other `LICENSE(-*)?` 
-files will be parsed to determine the SPDX license identifier, and then all of 
-those identifiers will be joined with the `AND` operator, meaning that you must 
-accept **all** of the licenses detected.
+1. If the crate in question has a [Clarification](cfg.md#the-clarify-field-optional) applied to it, and the source file(s) in the crate's source still match, the expression from the clarification will be used.
+1. The [`license`][cargo-md] field from the crate's Cargo.toml manifest will be used if it exists.
+1. The [`license-file`][cargo-md] field, as well as **all** other `LICENSE(-*)?` files will be parsed to determine the SPDX license identifier, and then all of those identifiers will be joined with the `AND` operator, meaning that you must accept **all** of the licenses detected.
 
 ### Evaluation Precedence
 
-Currently, the precedence for determining whether a particular license is 
-accepted or rejected is as follows:
+Currently, the precedence for determining whether a particular license is accepted or rejected is as follows:
 
 1. A license specified in the `deny` list is **always rejected**.
 1. A license specified in the `allow` list is **always accepted**.
-1. If the license is considered
-[copyleft](https://en.wikipedia.org/wiki/Copyleft), the
-[`[licenses.copyleft]`](cfg.md#the-copyleft-field-optional) configuration 
-determines its status
-1. If the license is [OSI Approved](https://opensource.org/licenses) or
-[FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html), the
-[`[licenses.allow-osi-fsf-free]`](cfg.md#the-allow-osi-fsf-free-field-optional) 
-configuration determines its status, if it is `neither` the check continues
-1. If the license does not match any of the above criteria, the 
-[`[licenses.default]`](cfg.md#the-default-field-optional) configuration 
-determines its status
+1. If the license is considered [copyleft](https://en.wikipedia.org/wiki/Copyleft), the
+[`[licenses.copyleft]`](cfg.md#the-copyleft-field-optional) configuration determines its status
+1. If the license is [OSI Approved](https://opensource.org/licenses) or [FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html), the [`[licenses.allow-osi-fsf-free]`](cfg.md#the-allow-osi-fsf-free-field-optional) configuration determines its status, if it is `neither` the check continues
+1. If the license does not match any of the above criteria, the [`[licenses.default]`](cfg.md#the-default-field-optional) configuration determines its status
 
 [SPDX]: https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/
 [cargo-md]: https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -10,7 +10,7 @@ Contains all of the configuration for `cargo deny check license`.
 
 ## SPDX Identifiers
 
-All identifiers used in the license configuration section are expected to be valid SPDX v2.1 short identifiers, either from version 3.7 of the [SPDX License List](https://spdx.org/licenses/), or use a [custom identifier](https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/#format-for-spdx-license-identifier) by prefixing it with `LicenseRef-`.
+All identifiers used in the license configuration section are expected to be valid SPDX v2.1 short identifiers, either from version 3.11 of the [SPDX License List](https://spdx.org/licenses/), or use a [custom identifier](https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/#format-for-spdx-license-identifier) by prefixing it with `LicenseRef-`.
 
 ```ini
 allow = [
@@ -111,7 +111,7 @@ Determines what happens when a license that is considered [copyleft](https://en.
 
 ### The `allow-osi-fsf-free` field (optional)
 
-Determines what happens when licenses aren't explicitly allowed or denied, but **are** marked as [OSI Approved](https://opensource.org/licenses) or [FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html) in version 3.7 of the [SPDX License List](https://spdx.org/licenses/).
+Determines what happens when licenses aren't explicitly allowed or denied, but **are** marked as [OSI Approved](https://opensource.org/licenses) or [FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html) in version 3.11 of the [SPDX License List](https://spdx.org/licenses/).
 
 * `both` - The license is accepted if it is both OSI approved and FSF Free
 * `either` - The license is accepted if it is either OSI approved or FSF Free

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -45,12 +45,9 @@ allow = [
 
 Determines what happens when a crate has not explicitly specified its license terms, and no license information could be confidently detected via `LICENSE*` files in the crate's source.
 
-* `deny` (default) - All unlicensed crates will emit an error and fail the
-license check
-* `allow` - All unlicensed crates will show a note, but will not fail the
-license check
-* `warn` - All unlicensed crates will show a warning, but will not fail the
-license check
+* `deny` (default) - All unlicensed crates will emit an error and fail the license check
+* `allow` - All unlicensed crates will show a note, but will not fail the license check
+* `warn` - All unlicensed crates will show a warning, but will not fail the license check
 
 ### The `allow` and `deny` fields (optional)
 
@@ -108,10 +105,8 @@ exceptions = [
 
 Determines what happens when a license that is considered [copyleft](https://en.wikipedia.org/wiki/Copyleft) is encountered.
 
-* `warn` (default) - Will emit a warning that a copyleft license was detected,
-but will not fail the license check
-* `deny` - The license is not accepted if it is copyleft, but the license check
-might not fail if the expression still evaluates to true
+* `warn` (default) - Will emit a warning that a copyleft license was detected, but will not fail the license check
+* `deny` - The license is not accepted if it is copyleft, but the license check might not fail if the expression still evaluates to true
 * `allow` - The license is accepted if it is copyleft
 
 ### The `allow-osi-fsf-free` field (optional)
@@ -132,10 +127,8 @@ Determines what happens when a license is encountered that:
 1. Isn't `copyleft`
 1. Isn't OSI Approved nor FSF Free/Libre, or `allow-osi-fsf-free = "neither"`
 
-* `warn` - Will emit a warning that the license was detected, but will not fail
-the license check
-* `deny` (default) - The license is not accepted, but the license check might
-not fail if the expression still evaluates to true
+* `warn` - Will emit a warning that the license was detected, but will not fail the license check
+* `deny` (default) - The license is not accepted, but the license check might not fail if the expression still evaluates to true
 * `allow` - The license is accepted
 
 ### The `confidence-threshold` field (optional)
@@ -204,9 +197,7 @@ private = { ignore = true }
 
 ### The `registries` field
 
-A list of private registries you may publish your workspace crates to. If a
-workspace member **only** publishes to private registries, it will also be
-ignored if `private.ignore = true`
+A list of private registries you may publish your workspace crates to. If a workspace member **only** publishes to private registries, it will also be ignored if `private.ignore = true`
 
 ```ini
 [package]

--- a/docs/src/checks/licenses/diags.md
+++ b/docs/src/checks/licenses/diags.md
@@ -2,8 +2,7 @@
 
 ### `L001` - failed to satisfy license requirements
 
-One or more licenses for a crate were rejected because they were not configured
-to be [allowed](cfg.md#the-allow-and-deny-fields-optional).
+One or more licenses for a crate were rejected because they were not configured to be [allowed](cfg.md#the-allow-and-deny-fields-optional).
 
 ### `L002` - license requirements satisfied
 
@@ -19,10 +18,8 @@ A workspace member is `publish = false` and was [skipped](cfg.md#the-private-fie
 
 ### `L005` - license exception was not encountered
 
-A [`licenses.exception`](cfg.md#the-exceptions-field-optional) was not used as
-the crate it applied to was not encountered.
+A [`licenses.exception`](cfg.md#the-exceptions-field-optional) was not used as the crate it applied to was not encountered.
 
 ### `L006` - license was not encountered
 
-A license in [`licenses.allow`](cfg.md#the-allow-and-deny-fields-optional) was
-not found in any crate.
+A license in [`licenses.allow`](cfg.md#the-allow-and-deny-fields-optional) was not found in any crate.

--- a/docs/src/checks/sources/README.md
+++ b/docs/src/checks/sources/README.md
@@ -10,20 +10,10 @@ cargo deny check sources
 
 ## Use Case - Only allowing known/trusted sources
 
-Cargo can retrieve crates from a variety of sources, namely registries, git 
-repositories, or local file paths. This is great in general and very flexible 
-for development. But, especially when re-routing dependencies to git 
-repositories, increasing the amount of sources that a project has to trust may
-be something a repository wants to explicitly opt-in to.
+Cargo can retrieve crates from a variety of sources, namely registries, git repositories, or local file paths. This is great in general and very flexible for development. But, especially when re-routing dependencies to git repositories, increasing the amount of sources that a project has to trust may be something a repository wants to explicitly opt-in to.
 
-See [Why npm lockfiles can be a security blindspot for injecting malicious 
-modules](https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/)
-for the motivating reason for why this check was added.
+See [Why npm lockfiles can be a security blindspot for injecting malicious modules](https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/) for the motivating reason for why this check was added.
 
 ## Use Case - Only using vendored file dependencies
 
-A project may want to only support local file dependencies, such as having all 
-dependencies vendored into the repository for full control and offline building.
-This can be achieved by disallowing all git and registry sources to ensure that
-every dependency is added into your source control rather than via an external
-source.
+A project may want to only support local file dependencies, such as having all dependencies vendored into the repository for full control and offline building. This can be achieved by disallowing all git and registry sources to ensure that every dependency is added into your source control rather than via an external source.

--- a/docs/src/checks/sources/cfg.md
+++ b/docs/src/checks/sources/cfg.md
@@ -10,38 +10,25 @@ Contains all of the configuration for `cargo deny check sources`
 
 ### The `unknown-registry` field (optional)
 
-Determines what happens when a crate from a crate registry that is not in the
-`allow-registry` list is encountered.
+Determines what happens when a crate from a crate registry that is not in the `allow-registry` list is encountered.
 
 * `deny` - Will emit an error with the URL of the source, and fail the check.
-* `warn` (default) - Prints a warning for each crate, but does not fail the
-check.
+* `warn` (default) - Prints a warning for each crate, but does not fail the check.
 * `allow` - Prints a note for each crate, but does not fail the check.
 
 ### The `unknown-git` field (optional)
 
-Determines what happens when a crate from a git repository not in the
-`allow-git` list is encountered.
+Determines what happens when a crate from a git repository not in the `allow-git` list is encountered.
 
-* `deny` - Will emit an error with the URL of the repository, and fail the
-check.
-* `warn` (default) - Prints a warning for each crate, but does not fail the
-check.
+* `deny` - Will emit an error with the URL of the repository, and fail the check.
+* `warn` (default) - Prints a warning for each crate, but does not fail the check.
 * `allow` - Prints a note for each crate, but does not fail the check.
 
 ### The `required-git-spec` (optional)
 
-Determines which [specifiers](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) are
-required for git sources. Git sources are a convient way to use patched code
-temporarily, but they have downsides for long term maintenance, as the specifier
-you use for the source determines what happens when you do a `cargo update`, and
-in the default case, this means you essentially have a wildcard dependency on
-the repository.
+Determines which [specifiers](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) are required for git sources. Git sources are a convient way to use patched code temporarily, but they have downsides for long term maintenance, as the specifier you use for the source determines what happens when you do a `cargo update`, and in the default case, this means you essentially have a wildcard dependency on the repository.
 
-This configuration value allows you to control what specifiers you want to allow
-for your git sources to reduce surprises. The following values are listed in
-order from least to most specific, and using a less specific specifier will
-also allow all of the more specific ones.
+This configuration value allows you to control what specifiers you want to allow for your git sources to reduce surprises. The following values are listed in order from least to most specific, and using a less specific specifier will also allow all of the more specific ones.
 
 * `any` (default) - Allows all git specs, including the default of not having
 any specifier, which tracks the latest commit on the `master` branch of the repo
@@ -51,20 +38,15 @@ any specifier, which tracks the latest commit on the `master` branch of the repo
 
 ### The `allow-git` field (optional)
 
-Configure which git urls are allowed for crate sources. If a crate's source is
-not in one of the listed urls, then the `unknown-git` setting will determine how
-it is handled.
+Configure which git urls are allowed for crate sources. If a crate's source is not in one of the listed urls, then the `unknown-git` setting will determine how it is handled.
 
 ### The `allow-registry` field (optional)
 
-The list of registries that are allowed. If a crate is not found in one of the
-listed registries, then the `unknown-registry` setting will determine how it is
-handled.
+The list of registries that are allowed. If a crate is not found in one of the listed registries, then the `unknown-registry` setting will determine how it is handled.
 
-If not specified, this list will by default contain the
-[crates.io](http://crates.io) registry, equivalent to this:
+If not specified, this list will by default contain the [crates.io](http://crates.io) registry, equivalent to this:
 
-```toml
+```ini
 [sources]
 allow-registry = [
     "https://github.com/rust-lang/crates.io-index"
@@ -73,7 +55,7 @@ allow-registry = [
 
 To not allow any crates registries, set it to empty:
 
-```toml
+```ini
 [sources]
 unknown-registry = "deny"
 allow-registry = []
@@ -81,39 +63,24 @@ allow-registry = []
 
 ### The `allow-org` field (optional)
 
-Generally, I think most projects in the Rust space probably follow a similar
-procedure as we do when they want to fix a bug or add a feature to one of their
-dependencies, which is basically.
+Generally, I think most projects in the Rust space probably follow a similar procedure as we do when they want to fix a bug or add a feature to one of their dependencies, which is basically.
 
 1. Fork the crate to make your changes
-1. Hack away locally, probably just patching your project(s) to use a `path`
-dependency to the cloned fork
-1. Push changes to your fork, and once you're happy, change the `path`
-dependency to a `git` dependency and point it to your fork for others/CI to be
-able to use the same changes easily
+1. Hack away locally, probably just patching your project(s) to use a `path` dependency to the cloned fork
+1. Push changes to your fork, and once you're happy, change the `path` dependency to a `git` dependency and point it to your fork for others/CI to be able to use the same changes easily
 1. Eventually (hopefully!) make a PR to the original repo with your changes
 1. Hopefully get your changes merged to the original repo
-1. Wait until a release is made that incorporates your changes, possibly
-changing the `git` source to point to the original repo
-1. Remove the `git` source and instead point at the new version of the crate
-with your changes
+1. Wait until a release is made that incorporates your changes, possibly changing the `git` source to point to the original repo
+1. Remove the `git` source and instead point at the new version of the crate with your changes
 1. Profit!
 
-When working in a company or organization, it is often the case that all crates
-will be forked to a shared organization account rather than a personal Github
-account. However, if you lint your git sources, every new and deleted fork needs
-to keep that list updated, which is tedious, even if all the forks fall under
-the same organization (in Github terminology), even though presumably only
-people you trust have permission to create forks there, and you would like to
-just blanket trust any repo under that org.
+When working in a company or organization, it is often the case that all crates will be forked to a shared organization account rather than a personal Github account. However, if you lint your git sources, every new and deleted fork needs to keep that list updated, which is tedious, even if all the forks fall under the same organization (in Github terminology), even though presumably only people you trust have permission to create forks there, and you would like to just blanket trust any repo under that org.
 
-The `allow-org` object allows you to specify 1 or more orgs in several VCS
-providers to more easily configure git sources for your projects.
+The `allow-org` object allows you to specify 1 or more orgs in several VCS providers to more easily configure git sources for your projects.
 
 #### The `github` field (optional)
 
-Allows you to specify one or more `github.com` organizations to allow as git
-sources.
+Allows you to specify one or more `github.com` organizations to allow as git sources.
 
 ```ini
 [sources.allow-org]
@@ -122,8 +89,7 @@ github = ["YourCoolOrgGoesHere"]
 
 #### The `gitlab` field (optional)
 
-Allows you to specify one or more `gitlab.com` organizations to allow as git
-sources.
+Allows you to specify one or more `gitlab.com` organizations to allow as git sources.
 
 ```ini
 [sources.allow-org]
@@ -132,8 +98,7 @@ gitlab = ["YourCoolOrgGoesHere"]
 
 #### The `bitbucket` field (optional)
 
-Allows you to specify one or more `bitbucket.org` organizations to allow as git
-sources.
+Allows you to specify one or more `bitbucket.org` organizations to allow as git sources.
 
 ```ini
 [sources.allow-org]

--- a/docs/src/checks/sources/diags.md
+++ b/docs/src/checks/sources/diags.md
@@ -2,8 +2,7 @@
 
 ### `S001` - 'git' source is underspecified
 
-A `git` source uses a specification that doesn't meet the minimum specifier
-required by [`sources.required-git-spec`](cfg.md#the-required-git-spec-optional).
+A `git` source uses a specification that doesn't meet the minimum specifier required by [`sources.required-git-spec`](cfg.md#the-required-git-spec-optional).
 
 ### `S002` - source explicitly allowed
 
@@ -19,11 +18,8 @@ A crate source was not explicitly allowed.
 
 ### `S005` - allowed source was not encountered
 
-An allowed source in [`sources.allow-git`](cfg.md#the-allow-git-field-optional)
-or [`sources.allow-registry`](cfg.md#the-allow-registry-field-optional) was not
-encountered.
+An allowed source in [`sources.allow-git`](cfg.md#the-allow-git-field-optional) or [`sources.allow-registry`](cfg.md#the-allow-registry-field-optional) was not encountered.
 
 ### `S006` - allowed organization  was not encountered
 
-An allowed source in [`sources.allow-org`](cfg.md#the-allow-org-field-optional)
-was not encountered.
+An allowed source in [`sources.allow-org`](cfg.md#the-allow-org-field-optional) was not encountered.

--- a/docs/src/cli/README.md
+++ b/docs/src/cli/README.md
@@ -37,7 +37,7 @@ Installing cargo-deny is relatively easy if you already have Rust and Cargo
 installed. You just have to type this snippet in your terminal:
 
 ```bash
-cargo install cargo-deny
+cargo install --locked cargo-deny
 ```
 
 This will fetch the source code for the latest release from
@@ -55,7 +55,7 @@ the latest bug-fixes and features, that will be released in the next version on
 version yourself.
 
 ```bash
-cargo install --git https://github.com/EmbarkStudios/cargo-deny cargo-deny
+cargo install --locked --git https://github.com/EmbarkStudios/cargo-deny cargo-deny
 ```
 
 Run `cargo deny help` in your terminal to verify if it works. Congratulations,

--- a/docs/src/cli/README.md
+++ b/docs/src/cli/README.md
@@ -1,14 +1,10 @@
 # Command Line Tool
 
-cargo-deny can be used either as a command line tool or as a
-[Rust crate](https://crates.io/crates/cargo-deny). Let's focus on the command 
-line tool capabilities first.
+cargo-deny can be used either as a command line tool or as a [Rust crate](https://crates.io/crates/cargo-deny). Let's focus on the command line tool capabilities first.
 
 ## Install From Binaries
 
-Precompiled binaries are provided for major platforms on a best-effort basis.
-Visit [the releases page](https://github.com/EmbarkStudios/cargo-deny/releases)
-to download the appropriate version for your platform.
+Precompiled binaries are provided for major platforms on a best-effort basis. Visit [the releases page](https://github.com/EmbarkStudios/cargo-deny/releases) to download the appropriate version for your platform.
 
 ## Install from AUR
 
@@ -24,58 +20,44 @@ cargo-deny can also be installed from source.
 
 ### Pre-requisites
 
-cargo-deny is written in **[Rust](https://www.rust-lang.org/)** and therefore 
-needs to be compiled with **Cargo**. If you haven't already installed Rust, 
-please go ahead and [install it](https://www.rust-lang.org/tools/install) now.
+cargo-deny is written in **[Rust](https://www.rust-lang.org/)** and therefore needs to be compiled with **Cargo**. If you haven't already installed Rust, please go ahead and [install it](https://www.rust-lang.org/tools/install) now.
 
-cargo-deny depends on some crates that use C code, so you will also need to have
-a C toolchain available on your machine, such as gcc, clang, or msvc.
+cargo-deny depends on some crates that use C code, so you will also need to have a C toolchain available on your machine, such as gcc, clang, or msvc.
 
 ### Install Crates.io version
 
-Installing cargo-deny is relatively easy if you already have Rust and Cargo
-installed. You just have to type this snippet in your terminal:
+Installing cargo-deny is relatively easy if you already have Rust and Cargo installed. You just have to type this snippet in your terminal:
 
 ```bash
 cargo install --locked cargo-deny
 ```
 
-This will fetch the source code for the latest release from
-[Crates.io](https://crates.io/) and compile it. You will have to add Cargo's
-`bin` directory to your `PATH` if you have not done so already.
+This will fetch the source code for the latest release from [Crates.io](https://crates.io/) and compile it. You will have to add Cargo's `bin` directory to your `PATH` if you have not done so already.
 
-Run `cargo deny help` in your terminal to verify if it works. Congratulations,
-you have installed cargo-deny!
+Run `cargo deny help` in your terminal to verify if it works. Congratulations, you have installed cargo-deny!
 
 ### Install Git version
 
-The **[git version](https://github.com/EmbarkStudios/cargo-deny)** contains all
-the latest bug-fixes and features, that will be released in the next version on
-**Crates.io**, if you can't wait until the next release. You can build the git
-version yourself.
+The **[git version](https://github.com/EmbarkStudios/cargo-deny)** contains all the latest bug-fixes and features, that will be released in the next version on **Crates.io**, if you can't wait until the next release. You can build the git version yourself.
 
 ```bash
 cargo install --locked --git https://github.com/EmbarkStudios/cargo-deny cargo-deny
 ```
 
-Run `cargo deny help` in your terminal to verify if it works. Congratulations,
-you have installed cargo-deny!
+Run `cargo deny help` in your terminal to verify if it works. Congratulations, you have installed cargo-deny!
 
 ## CI Usage
 
-We now have a Github Action for running cargo-deny on your Github repositories, 
-check it out [here](https://github.com/EmbarkStudios/cargo-deny-action).
+We now have a Github Action for running cargo-deny on your Github repositories, check it out [here](https://github.com/EmbarkStudios/cargo-deny-action).
 
-If you don't want to use the action, you can manually download (or install)
-cargo-deny as described above, but here's an example script that you can copy
-to get you started.
+If you don't want to use the action, you can manually download (or install) cargo-deny as described above, but here's an example script that you can copy to get you started.
 
 ```bash
 #!/bin/bash
 set -eu
 
 NAME="cargo-deny"
-VS="0.5.2"
+VS="0.8.5"
 DIR="/tmp/$NAME"
 
 mkdir $DIR

--- a/docs/src/cli/check.md
+++ b/docs/src/cli/check.md
@@ -1,15 +1,12 @@
 # The `check` command
 
-The check command is the primary subcommand of cargo-deny as it is what actually
-runs through all of the crates in your project and checks them against your
-configuration.
+The check command is the primary subcommand of cargo-deny as it is what actually runs through all of the crates in your project and checks them against your configuration.
 
 ## Args
 
 ### `<which>`
 
-The check(s) to perform. By default, **all** checks will be performed, unless
-one or more specific checks are specified.
+The check(s) to perform. By default, **all** checks will be performed, unless one or more specific checks are specified.
 
 See [checks](../checks/index.html) for the list of available checks.
 
@@ -17,17 +14,13 @@ See [checks](../checks/index.html) for the list of available checks.
 
 ### `-d, --disable-fetch`
 
-Disables fetching of advisory databases, if they would be loaded. If disabled,
-and there is not already an existing advisory database locally, an error will
-occur
+Disables fetching of advisory databases, if they would be loaded. If disabled, and there is not already an existing advisory database locally, an error will occur.
 
 ### `--hide-inclusion-graph`
 
 Hides the inclusion graph when printing out info for a crate.
 
-By default, if a diagnostic message pertains to a specific crate, cargo-deny
-will append an inverse dependency graph to the diagnostic to show you how that
-crate was pulled into your project.
+By default, if a diagnostic message pertains to a specific crate, cargo-deny will append an inverse dependency graph to the diagnostic to show you how that crate was pulled into your project.
 
 ```text
 some diagnostic message
@@ -42,11 +35,8 @@ the-crate
 
 ### `-c, --config`
 
-The path to the config file used to determine which crates are allowed or
-denied. Will default to `<context>/deny.toml` if not specified.
+The path to the config file used to determine which crates are allowed or denied. Will default to `<context>/deny.toml` if not specified.
 
 ### `-g, --graph`
 
-A root directory to place dotviz graphs into when duplicate crate versions are
-detected. Will be `<dir>/graph_output/<crate_name>.dot`. The `/graph_output/*`
-is deleted and recreated each run.
+A root directory to place dotviz graphs into when duplicate crate versions are detected. Will be `<dir>/graph_output/<crate_name>.dot`. The `/graph_output/*` is deleted and recreated each run.

--- a/docs/src/cli/common.md
+++ b/docs/src/cli/common.md
@@ -9,49 +9,31 @@ The path to a `Cargo.toml` file which is used as the context for operations.
 
 #### `--all-features` (single crate or workspace)
 
-Enables all features when determining which crates to consider. Works for both
-single crates and workspaces.
+Enables all features when determining which crates to consider. Works for both single crates and workspaces.
 
 #### `--no-default-features` (single crate only)
 
-Disables the `default` feature for a crate when determing which crates to
-consider.
+Disables the `default` feature for a crate when determing which crates to consider.
 
 #### `--features` (single crate only)
 
-Space-separated list of features to enable when determining which crates to
-consider.
+Space-separated list of features to enable when determining which crates to consider.
 
 #### `--workspace`
 
-Forces all workspace crates to be used as roots in the crate graph that we
-operate on, unless they are excluded by other means. By default, if you specify
-a [virtual manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#virtual-manifest)
-, all crates in the workspace will be used as roots. However, if you specify a
-normal package manifest somewhere inside a workspace, only that crate will be
-used as a graph root, and only other workspaces crates it depends on will be
-included in the graph. If you want to specify a sub-crate in a workspace, but
-still include all other crates in the workspace, you can use this flag.
+Forces all workspace crates to be used as roots in the crate graph that we operate on, unless they are excluded by other means. By default, if you specify a [virtual manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#virtual-manifest), all crates in the workspace will be used as roots. However, if you specify a normal package manifest somewhere inside a workspace, only that crate will be used as a graph root, and only other workspaces crates it depends on will be included in the graph. If you want to specify a sub-crate in a workspace, but still include all other crates in the workspace, you can use this flag.
 
 #### `--exclude`
 
-Exclude the specified package(s) from the crate graph. Unlike other cargo
-subcommands, it doesn't have to be used in conjunction with the `--workspace`
-flag. This flag may be specified multiple times.
+Exclude the specified package(s) from the crate graph. Unlike other cargo subcommands, it doesn't have to be used in conjunction with the `--workspace` flag. This flag may be specified multiple times.
 
-This uses a similar (though slightly more strict)
-[Package ID specification](https://doc.rust-lang.org/cargo/commands/cargo-pkgid.html)
-to other cargo subcommands.
+This uses a similar (though slightly more strict) [Package ID specification](https://doc.rust-lang.org/cargo/commands/cargo-pkgid.html) to other cargo subcommands.
 
-Packages can also be excluded in your
-[configuration](../checks/cfg.md#the-exclude-field-optional) files, specifying
-this on the command line will append the package ID to the list that may exist
-in your configuration.
+Packages can also be excluded in your [configuration](../checks/cfg.md#the-exclude-field-optional) files, specifying this on the command line will append the package ID to the list that may exist in your configuration.
 
 #### `-L, --log-level`
 
-The log level for messages, only log messages at or above the level will be
-emitted.
+The log level for messages, only log messages at or above the level will be emitted.
 
 Possible values:
 
@@ -73,8 +55,7 @@ Possible values:
 
 ### `--color`
 
-Whether coloring is applied to human-formatted output, using it on JSON output
-has no effect.
+Whether coloring is applied to human-formatted output, using it on JSON output has no effect.
 
 Possible values:
 
@@ -84,7 +65,4 @@ Possible values:
 
 #### `-t, --target`
 
-One or more platforms to filter crates with. If a dependency is target specific,
-it will be ignored if it does not match at least 1 of the specified targets.
-This overrides the top-level [`targets = []`](../checks/cfg.md) configuration
-value.
+One or more platforms to filter crates with. If a dependency is target specific, it will be ignored if it does not match at least 1 of the specified targets. This overrides the top-level [`targets = []`](../checks/cfg.md) configuration value.

--- a/docs/src/cli/fix.md
+++ b/docs/src/cli/fix.md
@@ -1,31 +1,21 @@
 # The `fix` command
 
-The fix command attempts to address advisories detected from one or more advisory
-databases by recursively applying patched versions of crates until it reaches
-your workspace members and edits one or more of them to reference the fixed
-version(s) so the advisories no longer apply.
+The fix command attempts to address advisories detected from one or more advisory databases by recursively applying patched versions of crates until it reaches your workspace members and edits one or more of them to reference the fixed version(s) so the advisories no longer apply.
 
-Note that the larger the workspace and the more dependencies that are used
-within it, the higher the likelihood that the fix command will not be able to
-update completely to the fixed version of the crate, as every crate that
-transitively depends on the crate the advisory applies to needs to have a
-published version that depends on one more of the fixed versions, when the
-crate in question even has fixed versions at all.
+Note that the larger the workspace and the more dependencies that are used within it, the higher the likelihood that the fix command will not be able to update completely to the fixed version of the crate, as every crate that transitively depends on the crate the advisory applies to needs to have a published version that depends on one more of the fixed versions, when the crate in question even has fixed versions at all.
 
 ## Flags
 
 ### `--allow-incompatible`
 
-Allows crates to be patched with versions which are incompatible with the
-current version requirements. So, for example, if you have
+Allows crates to be patched with versions which are incompatible with the current version requirements. So, for example, if you have
 
 ```ini
 [dependencies]
 vulnerable-crate = "0.5"
 ```
 
-and the vulnerability is fixed in version "1.0", the fix subcommand will be able
-to edit your manifest to be this
+and the vulnerability is fixed in version "1.0", the fix subcommand will be able to edit your manifest to be this
 
 ```diff
 [dependencies]
@@ -37,20 +27,16 @@ even though they are semver incompatible.
 
 ### `--dry-run`
 
-Prints the diff for the manifest changes, but does not actually modify any files
-on disk
+Prints the diff for the manifest changes, but does not actually modify any files on disk
 
 ### `-d, --disable-fetch`
 
 Disable fetching of the advisory database and crates.io index
 
-By default the advisory database and crates.io index are updated before checking
-the advisories, if disabled via this flag, an error occurs if the advisory
-database or crates.io index are not available locally already.
+By default the advisory database and crates.io index are updated before checking the advisories, if disabled via this flag, an error occurs if the advisory database or crates.io index are not available locally already.
 
 ## Options
 
 ### `-c, --config`
 
-The path to the config file used to determine which crates are allowed or
-denied. Will default to `<context>/deny.toml` if not specified.
+The path to the config file used to determine which crates are allowed or denied. Will default to `<context>/deny.toml` if not specified.

--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -1,8 +1,6 @@
 # The init command
 
-cargo-deny's configuration is a little bit complicated, so we provide the `init`
-command to create a configuration file from a template for you to give you a
-starting point for configuring how you want cargo-deny to lint your project.
+cargo-deny's configuration is a little bit complicated, so we provide the `init` command to create a configuration file from a template for you to give you a starting point for configuring how you want cargo-deny to lint your project.
 
 The `init` command is used like this:
 
@@ -10,19 +8,17 @@ The `init` command is used like this:
 cargo deny init
 ```
 
-### Specify a path
+## Specify a path
 
-The `init` command can take a path as an argument to use as path of the config
-instead of the default which is `<cwd>/deny.toml`.
+The `init` command can take a path as an argument to use as path of the config instead of the default which is `<cwd>/deny.toml`.
 
 ```bash
 cargo deny init path/to/config.toml
 ```
 
-### Template
+## Template
 
-A `deny.toml` file will be created in the current working directory that is a
-direct copy of [this template](https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml).
+A `deny.toml` file will be created in the current working directory that is a direct copy of [this template](https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml).
 
 ```ini
 {{#include ../../../deny.template.toml}}

--- a/docs/src/cli/list.md
+++ b/docs/src/cli/list.md
@@ -1,7 +1,6 @@
 # The `list` command
 
-Similarly to [cargo-license](https://github.com/onur/cargo-license), `list` 
-prints out the license information for each crate.
+Similarly to [cargo-license](https://github.com/onur/cargo-license), `list` prints out the license information for each crate.
 
 ## Options
 
@@ -23,26 +22,21 @@ Output coloring, only applies to the `human` format.
 
 Colors:
 
-- SPDX identifier - ![blue](https://placehold.it/15/5dade2/000000?text=+)
-- Crate with 1 license - ![white](https://placehold.it/15/717d7e/000000?text=+)
-- Crate with 2 or more licenses - ![yellow](https://placehold.it/15/f1c40f/000000?text=+)
-- Crate with 0 licenses - ![yellow](https://placehold.it/15/e74c3c/000000?text=+)
+* SPDX identifier - ![blue](https://placehold.it/15/5dade2/000000?text=+)
+* Crate with 1 license - ![white](https://placehold.it/15/717d7e/000000?text=+)
+* Crate with 2 or more licenses - ![yellow](https://placehold.it/15/f1c40f/000000?text=+)
+* Crate with 0 licenses - ![yellow](https://placehold.it/15/e74c3c/000000?text=+)
 
 ### `-l, --layout`
 
 The layout of the output. Does not apply to the `tsv` format.
 
-* `license` (default) - Each license acts as the key, and the values are all of
-the crates that use that license
-* `crate` - Each crate is a key, and the values are the list of licenses it
-uses.
+* `license` (default) - Each license acts as the key, and the values are all of the crates that use that license
+* `crate` - Each crate is a key, and the values are the list of licenses it uses.
 
 ### `-t, --threshold`
 
-The confidence threshold required for assigning a license identifier to a
-license text file. See the [license 
-configuration](../checks/licenses/cfg.md#the-confidence-threshold-field-optional)
-for more information.
+The confidence threshold required for assigning a license identifier to a license text file. See the [license configuration](../checks/licenses/cfg.md#the-confidence-threshold-field-optional) for more information.
 
 * `layout = license, format = human` (default)
 

--- a/src/advisories/helpers.rs
+++ b/src/advisories/helpers.rs
@@ -90,20 +90,20 @@ fn url_to_path(mut db_path: PathBuf, url: &Url) -> Result<PathBuf, Error> {
 }
 
 fn load_db(db_url: &Url, root_db_path: PathBuf, fetch: Fetch) -> Result<Database, Error> {
-    use rustsec::repository::GitRepository;
+    use rustsec::repository::git::Repository;
     let db_path = url_to_path(root_db_path, db_url)?;
 
     let db_repo = match fetch {
         Fetch::Allow => {
             debug!("Fetching advisory database from '{}'", db_url);
 
-            GitRepository::fetch(db_url.as_str(), &db_path, true /* ensure_fresh */)
+            Repository::fetch(db_url.as_str(), &db_path, true /* ensure_fresh */)
                 .context("failed to fetch advisory database")?
         }
         Fetch::Disallow => {
             debug!("Opening advisory database at '{}'", db_path.display());
 
-            GitRepository::open(&db_path).context("failed to open advisory database")?
+            Repository::open(&db_path).context("failed to open advisory database")?
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! [![Latest version](https://img.shields.io/crates/v/cargo-deny.svg)](https://crates.io/crates/cargo-deny)
 //! [![Docs](https://img.shields.io/badge/docs-The%20Book-green.svg)](https://embarkstudios.github.io/cargo-deny/)
 //! [![API Docs](https://docs.rs/cargo-deny/badge.svg)](https://docs.rs/cargo-deny)
-//! [![SPDX Version](https://img.shields.io/badge/SPDX%20Version-3.7-blue.svg)](https://spdx.org/licenses/)
+//! [![SPDX Version](https://img.shields.io/badge/SPDX%20Version-3.11-blue.svg)](https://spdx.org/licenses/)
 //! [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 //! [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.dev)
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! ## [Quickstart](https://embarkstudios.github.io/cargo-deny/)
 //!
 //! ```bash
-//! cargo install cargo-deny && cargo deny init && cargo deny check
+//! cargo install --locked cargo-deny && cargo deny init && cargo deny check
 //! ```
 //!
 //! ## Usage
@@ -66,7 +66,7 @@
 //! ### [Install](https://embarkstudios.github.io/cargo-deny/cli/index.html) cargo-deny
 //!
 //! ```bash
-//! cargo install cargo-deny
+//! cargo install --locked cargo-deny
 //! ```
 //!
 //! ### [Initialize](https://embarkstudios.github.io/cargo-deny/cli/init.html) your project


### PR DESCRIPTION
- Updated dependencies
- Increase MSRV `1.46.0` due to bump of `smol_str`/`rustsec`.
- Updated SPDX license list supported from 3.8 to 3.11 due to update of `spdx`.
- Add use of the `--locked` flag in all `cargo install` instructions, to avoid the default (broken) behavior as shown in [#331](https://github.com/EmbarkStudios/cargo-deny/issues/331).

Resolves: #331 

This resolves 331 both by the above mentioned use of the `--locked` flag, but also since it bumps bitvec, which resolves the immediate issue.