### PR TITLE
Fix rustsec/advisory-db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- Updated rustsec crate to address fetch failures due to the renaming of the `master` branch to `main` for https://github.com/rustsec/advisory-db
+
 ## [0.8.8] - 2021-02-25
 ### Changed
 - Updated dependencies, notably `cargo` and `rustsec`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86d15edf87746f448f4e68c8b97aaf145fcdc06c96b6af50a7c6832db9a0810"
+checksum = "653af8e2cd359a549b002043ef58597e3a9bece849b9c1461431f1591a2ff3be"
 dependencies = [
  "cargo-lock",
  "crates-index",


### PR DESCRIPTION
Updated rustsec crate to address fetch failures due to the renaming of the `master` branch to `main` for https://github.com/rustsec/advisory-db