### PR TITLE
Add support for publishing aarch64-apple-darwin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,6 +144,10 @@ jobs:
             rust: stable
             target: x86_64-apple-darwin
             bin: cargo-deny
+          - os: macOS-latest
+            rust: stable
+            target: aarch64-apple-darwin
+            bin: cargo-deny
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install stable toolchain
@@ -156,6 +160,12 @@ jobs:
         if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get install -y musl-tools
+      - name: Workaround xcode shenanigans
+        if: matrix.target == 'aarch64-apple-darwin'
+        # https://github.com/actions/virtual-environments/issues/2557#issuecomment-769611326
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_12.3.app"
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
       - name: Checkout
         uses: actions/checkout@v2
       - name: cargo fetch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6b6cc773b635ad64a05f00367c6f66d06a8708f7360f67c41d446dacdd0a0f"
+checksum = "55ebe4f76cacc83caff34a6ad8731a260d5d1213bdedc655968c62f6cbc92783"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ serde_json = "1.0"
 # Avoid some heap allocations when we likely won't need them
 smallvec = "1.6"
 # Used for parsing and checking SPDX license expressions
-spdx = "0.3"
+spdx = "0.4"
 # Handles all of the argument parsing
 structopt = "0.3"
 # Deserialization of configuration files and crate manifests

--- a/src/licenses/mod.rs
+++ b/src/licenses/mod.rs
@@ -122,7 +122,7 @@ fn evaluate_expression(
             // 3. If the license isn't explicitly allowed, it still may
             // be allowed by the blanket "OSI Approved" or "FSF Free/Libre"
             // allowances
-            if let spdx::LicenseItem::SPDX { id, .. } = req.license {
+            if let spdx::LicenseItem::Spdx { id, .. } = req.license {
                 if id.is_copyleft() {
                     match cfg.copyleft {
                         LintLevel::Allow => {


### PR DESCRIPTION
This adds publishing of (cross-compiled) aarch64-apple-darwin binaries for cargo-deny releases.