### PR TITLE
Migrate from difference to similar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,6 @@ dependencies = [
  "codespan",
  "codespan-reporting",
  "crossbeam",
- "difference",
  "fern",
  "git2",
  "home",
@@ -248,6 +247,7 @@ dependencies = [
  "semver 0.11.0",
  "serde",
  "serde_json",
+ "similar",
  "smallvec",
  "spdx",
  "structopt",
@@ -579,12 +579,6 @@ checksum = "b2ecd8322bca85301b52d821806315c282c7e5f85f03b0609e68d4189bda8f58"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "either"
@@ -1540,6 +1534,12 @@ name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "similar"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
 name = "sized-chunks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ codespan-reporting = "0.11"
 crossbeam = "0.8"
 # We use this for displaying diffs for dry runs of the `fix` subcommand, as
 # as in tests for printing easy to read errors
-difference = "2.0"
+similar = "1.3"
 # Logging utilities
 fern = "0.6"
 # We directly interact with git when doing index operations eg during fix

--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,6 @@ ignore = [
     # askalono uses failure, which is now unmaintained
     "RUSTSEC-2019-0036",
     "RUSTSEC-2020-0036",
-    # difference is unmaintained but suits our needs just fine
-    "RUSTSEC-2020-0095",
 ]
 
 [bans]


### PR DESCRIPTION
### Checklist

* [X] I have read the Contributor Guide
* [X] I have read and agree to the Code of Conduct
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Since `difference` is unmaintained, replace it with `similar` exactly matching the previous behavior.

Also remove unencountered ban skips

---

I debated using `dissimilar` vs `similar`

I tried using `dissimilar` first since: it's half the size, twice the downloads, and the maintainer is already sponsored by embark studios
However due to the way it finds differences I needed to write quite a bit of logic to replicate the structure output by the existing `difference` changeset

If you have these inputs:

original:
```
abc
def
```

new:
```
abc
dgg
```

It gives the changes like so:

unchanged:
```
abc
d
```

deleted:
```
ef
```

inserted:
```
gg
```

so you then need to account for the shared `d` and just generally it was more code than you probably want to maintain for a simple diff in an info log people wont see on the default warn level

`similar` had a line by line diff which made it easy to recreate the `difference` behavior in a couple of extra lines

---

I used manual escape codes rather than `ansi_term` to keep the colors identical to `difference`

https://github.com/EmbarkStudios/cargo-deny/blob/88dda4a8c827af9b06ab2cc0e4bac0656dd2f7bd/src/cargo-deny/fix.rs#L127-L128

---

I saw in a PR swapping difference to similar they had speed regression issues but I found the speed to be about the same (slightly faster in a quite quick and unscientific test)

https://github.com/colin-kiegel/rust-pretty-assertions/pull/51

```
$ hyperfine --warmup 3 '../../target/debug/cargo-deny -L info fix --dry-run' './new/cargo-deny -L info fix --dry-run'
Benchmark #1: ../../target/debug/cargo-deny -L info fix --dry-run
  Time (mean ± σ):      1.428 s ±  0.073 s    [User: 1.142 s, System: 0.286 s]
  Range (min … max):    1.325 s …  1.551 s    10 runs

Benchmark #2: ./new/cargo-deny -L info fix --dry-run
  Time (mean ± σ):      1.387 s ±  0.063 s    [User: 1.105 s, System: 0.282 s]
  Range (min … max):    1.321 s …  1.510 s    10 runs

Summary
  './new/cargo-deny -L info fix --dry-run' ran
    1.03 ± 0.07 times faster than '../../target/debug/cargo-deny -L info fix --dry-run'
```

---

The binary size does increase by about 2M :disappointed: 

```
$ du ../../target/debug/cargo-deny
160672	../../target/debug/cargo-deny

$ du ./new/cargo-deny
162464	./new/cargo-deny
```

### Related Issues

https://github.com/EmbarkStudios/krates/pull/32
