### PR TITLE
Add option to require default-features = false

### DIFF
--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -97,6 +97,9 @@ pub struct Config {
     /// How to handle wildcard dependencies
     #[serde(default = "crate::lint_allow")]
     pub wildcards: LintLevel,
+    /// How to handle crates with default-features enabled
+    #[serde(default = "crate::lint_allow")]
+    pub default_features: LintLevel,
 }
 
 impl Default for Config {
@@ -109,6 +112,7 @@ impl Default for Config {
             skip: Vec::new(),
             skip_tree: Vec::new(),
             wildcards: LintLevel::Allow,
+            default_features: LintLevel::Allow,
         }
     }
 }
@@ -190,6 +194,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
             allowed,
             skipped,
             wildcards: self.wildcards,
+            default_features: self.default_features,
             tree_skipped: self
                 .skip_tree
                 .into_iter()
@@ -237,6 +242,7 @@ pub struct ValidConfig {
     pub(crate) skipped: Vec<Skrate>,
     pub(crate) tree_skipped: Vec<Spanned<TreeSkip>>,
     pub wildcards: LintLevel,
+    pub default_features: LintLevel,
 }
 
 #[cfg(test)]

--- a/src/bans/mod.rs
+++ b/src/bans/mod.rs
@@ -212,6 +212,7 @@ pub fn check(
         highlight,
         tree_skipped,
         wildcards,
+        default_features,
     } = ctx.cfg;
 
     let krate_spans = &ctx.krate_spans;
@@ -440,6 +441,35 @@ pub fn check(
                         krate,
                         severity,
                         wildcards,
+                        cargo_spans: &cargo_spans,
+                    });
+                }
+            }
+            if default_features != LintLevel::Allow {
+                let severity = match default_features {
+                    LintLevel::Warn => Severity::Warning,
+                    LintLevel::Deny => Severity::Error,
+                    LintLevel::Allow => unreachable!(),
+                };
+
+                let default_features: Vec<_> = krate
+                    .deps
+                    .iter()
+                    .filter(|dep| {
+                        if !dep.uses_default_features {
+                            return false;
+                        }
+                        return true;
+                        // FIXME: we should not warn if package
+                        // does not actually define default feature
+                        // let dep_pkg = ctx.krates.
+                    })
+                    .collect();
+                if !default_features.is_empty() {
+                    sink.push(diags::DefaultFeatures {
+                        krate,
+                        severity,
+                        default_features,
                         cargo_spans: &cargo_spans,
                     });
                 }


### PR DESCRIPTION
Should close #206

Unfortunately, the current implementation is too strict IMHO: it triggers even if dependency does not have a `default` feature defined. I have not found a way how to check it (it seems that I need `Kid` aka `cargo_metadata::PackageId` to get package details, but what I have is `cargo_metadata::Dependency` which does not contain any identifiers), so I'd like to get some piece of advice on it.

Also, I'm unsure whether this lint should check non-local packages