### PR TITLE
Add support for `--locked` & `--frozen`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
         # we release, but wasn't exercised until now
         run: cargo install --path . --debug --target ${{ matrix.target }} --features standalone
       - name: self check
-        run: cargo deny -L debug --all-features check
+        run: cargo deny -L debug --all-features --locked check
       - name: check external users
         run: ./scripts/check_external.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+- [PR#353](https://github.com/EmbarkStudios/cargo-deny/pull/353) resolved [#351](https://github.com/EmbarkStudios/cargo-deny/issues/351) by adding the `sources.private` field to blanket allow git repositories sourced from a particular url.
+- [PR#359](https://github.com/EmbarkStudios/cargo-deny/pull/359) resolved [#341](https://github.com/EmbarkStudios/cargo-deny/issues/341) and [#357](https://github.com/EmbarkStudios/cargo-deny/issues/357) by adding support for the [`--frozen`, `--locked`, and `--offline`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html#manifest-options) flags to determine whether network access is allowed, and whether the `Cargo.lock` file can be created and/or modified.
 ### Changed
 - [PR#358](https://github.com/EmbarkStudios/cargo-deny/pull/358) bumped the Minimum Stable Rust Version to **1.53.0**.
 - [PR#358](https://github.com/EmbarkStudios/cargo-deny/pull/358) bumped various dependencies, notably `semver` to `1.0.3`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "krates"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8e69c980acf7a9ca774e6d2fe05a183ec64af83da248f441e4a98a8ba0de46"
+checksum = "88e1558a47434143f044e413a23e4702e1b2e7b277e4c77a6ec2241fda6a09b1"
 dependencies = [
  "cargo_metadata",
  "cfg-expr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/cargo-deny/main.rs"
 default = ["vendored-openssl"]
 # Allows the use of a vendored version openssl when compiling libgit, which allows
 # us to compile static executables (eg musl) and avoid system dependencies
-vendored-openssl = ["rustsec/vendored-openssl"]
+vendored-openssl = ["rustsec/vendored-openssl", "git2/vendored-openssl"]
 # Allows embedding cargo as a library so that we can run in minimal (eg container)
 # environments that don't need to have cargo/rust installed on them for cargo-deny
 # to still function
@@ -59,7 +59,7 @@ similar = "1.3"
 # Logging utilities
 fern = "0.6"
 # We directly interact with git when doing index operations eg during fix
-git2 = { version = "0.13", features = ["vendored-openssl"] }
+git2 = "0.13"
 # We need to figure out HOME/CARGO_HOME in some cases
 home = "0.5"
 # Provides graphs on top of cargo_metadata

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -29,27 +29,27 @@ pub struct Args {
     ///
     /// Defaults to <cwd>/deny.toml if not specified
     #[structopt(short, long, parse(from_os_str))]
-    config: Option<PathBuf>,
+    pub config: Option<PathBuf>,
     /// Path to graph_output root directory
     ///
     /// If set, a dotviz graph will be created for whenever multiple versions of the same crate are detected.
     ///
     /// Each file will be created at <dir>/graph_output/<crate_name>.dot. <dir>/graph_output/* is deleted and recreated each run.
     #[structopt(short, long, parse(from_os_str))]
-    graph: Option<PathBuf>,
+    pub graph: Option<PathBuf>,
     /// Hides the inclusion graph when printing out info for a crate
     #[structopt(long)]
-    hide_inclusion_graph: bool,
+    pub hide_inclusion_graph: bool,
     /// Disable fetching of the advisory database
     ///
     /// When running the `advisories` check, the configured advisory database will be fetched and opened. If this flag is passed, the database won't be fetched, but an error will occur if it doesn't already exist locally.
     #[structopt(short, long)]
-    disable_fetch: bool,
+    pub disable_fetch: bool,
     /// To ease transition from cargo-audit to cargo-deny, this flag will tell cargo-deny to output the exact same output as cargo-audit would, to `stdout` instead of `stderr`, just as with cargo-audit.
     ///
     /// Note that this flag only applies when the output format is JSON, and note that since cargo-deny supports multiple advisory databases, instead of a single JSON object, there will be 1 for each unique advisory database.
     #[structopt(long)]
-    audit_compatible_output: bool,
+    pub audit_compatible_output: bool,
     /// Show stats for all the checks, regardless of the log-level
     #[structopt(short, long = "show-stats")]
     pub show_stats: bool,
@@ -58,7 +58,7 @@ pub struct Args {
         possible_values = &WhichCheck::variants(),
         case_insensitive = true,
     )]
-    which: Vec<WhichCheck>,
+    pub which: Vec<WhichCheck>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
The `--offline` flag now also disables fetching of the advisory database for the check subcommand.

Resolves: #341 
Resolves: #357 
