### PR TITLE
Added deny.toml and cargo.toml headers to code snippets

### DIFF
--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -201,6 +201,7 @@ It's often not useful or wanted to check for licenses in your own private worksp
 If `true`, workspace members will not have their license expression checked if they are not published.
 
 ```ini
+#Cargo.toml
 [package]
 name = "sekret"
 license = "¯\_(ツ)_/¯"
@@ -208,6 +209,7 @@ publish = false # "private"!
 ```
 
 ```ini
+#deny.toml
 [licenses]
 # The sekret package would be ignored now
 private = { ignore = true }
@@ -219,12 +221,14 @@ A list of private registries you may publish your workspace crates to. If a work
 
 ```ini
 [package]
+#Cargo.toml
 name = "sekret"
 license = "¯\_(ツ)_/¯"
 publish = ["sauce"]
 ```
 
 ```ini
+#deny.toml
 [licenses]
 # Still ignored!
 private = { ignore = true, registries = ["sauce"] }

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -201,7 +201,7 @@ It's often not useful or wanted to check for licenses in your own private worksp
 If `true`, workspace members will not have their license expression checked if they are not published.
 
 ```ini
-#Cargo.toml
+# Cargo.toml
 [package]
 name = "sekret"
 license = "¯\_(ツ)_/¯"
@@ -209,7 +209,7 @@ publish = false # "private"!
 ```
 
 ```ini
-#deny.toml
+# deny.toml
 [licenses]
 # The sekret package would be ignored now
 private = { ignore = true }
@@ -220,15 +220,15 @@ private = { ignore = true }
 A list of private registries you may publish your workspace crates to. If a workspace member **only** publishes to private registries, it will also be ignored if `private.ignore = true`
 
 ```ini
+# Cargo.toml
 [package]
-#Cargo.toml
 name = "sekret"
 license = "¯\_(ツ)_/¯"
 publish = ["sauce"]
 ```
 
 ```ini
-#deny.toml
+# deny.toml
 [licenses]
 # Still ignored!
 private = { ignore = true, registries = ["sauce"] }


### PR DESCRIPTION
Took a look at the docs to add the file headers for deny, and Cargo, seemed to only to be two place in a single file. Choose not to do it to every code snippet, can if that is desired. 
Issue #342 