### PR TITLE
Allow banning multiple versions of a specific crate

### DIFF
--- a/src/bans.rs
+++ b/src/bans.rs
@@ -177,6 +177,7 @@ pub fn check(
     let ValidConfig {
         file_id,
         denied,
+        denied_multiple_versions,
         allowed,
         skipped,
         multiple_versions,
@@ -313,8 +314,13 @@ pub fn check(
             }
         } else if !tree_skipper.matches(krate, &mut pack) {
             if multi_detector.name != krate.name {
-                if multi_detector.dupes.len() > 1 && multiple_versions != LintLevel::Allow {
-                    let severity = match multiple_versions {
+                let lint_level = match matches(&denied_multiple_versions, krate) {
+                    Some(_) => LintLevel::Deny,
+                    None => multiple_versions,
+                };
+
+                if multi_detector.dupes.len() > 1 && lint_level != LintLevel::Allow {
+                    let severity = match lint_level {
                         LintLevel::Warn => Severity::Warning,
                         LintLevel::Deny => Severity::Error,
                         LintLevel::Allow => unreachable!(),


### PR DESCRIPTION
This PR adds a `multiple-versions` boolean field to the deny list in bans, allowing the `multiple-versions` lint level to be set to "allow" or "warn" for all crates and overriding it to "deny" for a chosen few:

```toml
[bans]
multiple-versions = "allow"
deny = [
    { name = "naga", multiple-versions = true },
]
```

Settings both `multiple-versions` and `wrappers` is explicitely not supported as I don't think it would make sense, I added an error diagnostic for that specific case that unfortunately required to add a few `Option` and `Spanned` wrappers in `CrateBan` to display the relevant labels. The exact format of the configuration could be different anyway, I simply went with an option that seemed to require only a few changes instead of introducing a completely new deny list specifically for duplicate crates for instance