### PR TITLE
Fix JSON log message escaping

### DIFF
--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -293,16 +293,21 @@ fn setup_logger(
                 .level(level)
                 .format(move |out, message, record| {
                     out.finish(format_args!(
-                        r#"{{"type":"log","fields":{{"timestamp":"{date}","level":"{level}","message":"{message}"}}}}"#,
-                        date = chrono::Utc::now().to_rfc3339(),
-                        level = match record.level() {
-                            Error => "ERROR",
-                            Warn => "WARN",
-                            Info => "INFO",
-                            Debug => "DEBUG",
-                            Trace => "TRACE",
-                        },
-                        message = message,
+                        "{}",
+                        serde_json::json! {{
+                            "type": "log",
+                            "fields": {
+                                "timestamp": chrono::Utc::now().to_rfc3339(),
+                                "level": match record.level() {
+                                    Error => "ERROR",
+                                    Warn => "WARN",
+                                    Info => "INFO",
+                                    Debug => "DEBUG",
+                                    Trace => "TRACE",
+                                },
+                                "message": message,
+                            }
+                        }}
                     ));
                 })
                 .chain(std::io::stderr())


### PR DESCRIPTION
Currently the JSON output for log messages breaks﻿because the message is written as is.
This can produce invalid JSON when the message contains non-valid string values (like newlines) that must be scaped.

The PR replaces the manual JSON formatting in the logger setup with the `serde_json::json` macro, which converts string values on the fly, always producing proper JSON.
