### PR TITLE
Make version requirements truly optional

### DIFF
--- a/docs/src/checks/bans/cfg.md
+++ b/docs/src/checks/bans/cfg.md
@@ -48,7 +48,7 @@ The name of the crate.
 
 #### The `version` field (optional)
 
-An optional version constraint specifying the range of crate versions that will match. Defaults to all versions (`*`).
+An optional version constraint specifying the range of crate versions that will match. Defaults to any version.
 
 #### The `wrappers` field (optional)
 

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -99,7 +99,7 @@ The name of the crate that you are adding an exception for
 
 #### The `exceptions.version` field (optional)
 
-An optional version constraint specifying the range of crate versions you are excepting. Defaults to all versions (`*`).
+An optional version constraint specifying the range of crate versions you are excepting. Defaults to any version.
 
 #### The `allow` field
 
@@ -174,7 +174,7 @@ The name of the crate that you are clarifying
 
 #### The `version` field (optional)
 
-An optional version constraint specifying the range of crate versions you are clarifying. Defaults to all versions (`*`).
+An optional version constraint specifying the range of crate versions you are clarifying. Defaults to any version.
 
 #### The `expression` field
 

--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -13,8 +13,7 @@ pub struct CrateId {
     // The name of the crate
     pub name: String,
     /// The version constraints of the crate
-    #[serde(default = "any")]
-    pub version: VersionReq,
+    pub version: Option<VersionReq>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -22,8 +21,7 @@ pub struct CrateId {
 #[serde(deny_unknown_fields)]
 pub struct CrateBan {
     pub name: Spanned<String>,
-    #[serde(default = "any")]
-    pub version: VersionReq,
+    pub version: Option<VersionReq>,
     /// One or more crates that will allow this crate to be used if it is a
     /// direct dependency
     #[serde(default)]
@@ -37,11 +35,6 @@ pub struct TreeSkip {
     #[serde(flatten)]
     pub id: CrateId,
     pub depth: Option<usize>,
-}
-
-#[inline]
-fn any() -> VersionReq {
-    VersionReq::STAR
 }
 
 const fn highlight() -> GraphHighlight {
@@ -227,14 +220,14 @@ mod test {
         ($name:expr) => {
             KrateId {
                 name: String::from($name),
-                version: semver::VersionReq::STAR.into(),
+                version: None,
             }
         };
 
         ($name:expr, $vs:expr) => {
             KrateId {
                 name: String::from($name),
-                version: $vs.parse::<semver::VersionReq>().unwrap().into(),
+                version: Some($vs.parse::<semver::VersionReq>().unwrap().into()),
             }
         };
     }
@@ -280,7 +273,7 @@ mod test {
             vec![TreeSkip {
                 id: CrateId {
                     name: "blah".to_owned(),
-                    version: semver::VersionReq::STAR,
+                    version: None,
                 },
                 depth: Some(20),
             }]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,3 +315,10 @@ pub struct CheckCtx<'ctx, T> {
     /// serialized to the diagnostic
     pub serialize_extra: bool,
 }
+
+/// Checks if a version satisfies the specifies the specified version requirement.
+/// If the requirement is `None` then it is also satisfied.
+#[inline]
+pub fn match_req(version: &Version, req: Option<&semver::VersionReq>) -> bool {
+    req.map_or(true, |req| req.matches(version))
+}

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -79,7 +79,7 @@ fn evaluate_expression(
     // allow list separate from the general allow list
     let eval_res = match cfg.exceptions.iter().position(|exc| {
         exc.name.as_ref() == &krate_lic_nfo.krate.name
-            && exc.version.matches(&krate_lic_nfo.krate.version)
+            && crate::match_req(&krate_lic_nfo.krate.version, exc.version.as_ref())
     }) {
         Some(ind) => {
             let exception = &cfg.exceptions[ind];

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -101,7 +101,7 @@ pub struct FileSource {
 pub struct Clarification {
     /// The name of the crate that this clarification applies to
     pub name: String,
-    /// The optional version constraint for the crate. Defaults to every version
+    /// The optional version constraint for the crate. Defaults to any version.
     pub version: Option<VersionReq>,
     /// The [SPDX expression](https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/)
     /// to apply to the crate.
@@ -117,7 +117,7 @@ pub struct Clarification {
 pub struct Exception {
     /// The name of the crate to apply the exception to.
     pub name: Spanned<String>,
-    /// The optional version constraint for the crate. Defaults to every version
+    /// The optional version constraint for the crate. Defaults to any version.
     pub version: Option<VersionReq>,
     /// One or more [SPDX identifiers](https://spdx.org/licenses/) that are
     /// allowed only for this crate.
@@ -239,7 +239,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
 
             exceptions.push(ValidException {
                 name: exc.name,
-                version: exc.version.unwrap_or(VersionReq::STAR),
+                version: exc.version,
                 allowed,
             });
         }
@@ -286,7 +286,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
 
             clarifications.push(ValidClarification {
                 name: c.name,
-                version: c.version.unwrap_or(VersionReq::STAR),
+                version: c.version,
                 expr_offset: (c.expression.span.start + 1),
                 expression: expr,
                 license_files,
@@ -314,7 +314,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct ValidClarification {
     pub name: String,
-    pub version: VersionReq,
+    pub version: Option<VersionReq>,
     pub expr_offset: usize,
     pub expression: spdx::Expression,
     pub license_files: Vec<FileSource>,
@@ -324,7 +324,7 @@ pub struct ValidClarification {
 #[derive(Debug, PartialEq)]
 pub struct ValidException {
     pub name: crate::Spanned<String>,
-    pub version: VersionReq,
+    pub version: Option<VersionReq>,
     pub allowed: Vec<Licensee>,
 }
 
@@ -392,7 +392,7 @@ mod test {
             vec![ValidException {
                 name: "adler32".to_owned().fake(),
                 allowed: vec![spdx::Licensee::parse("Zlib").unwrap().fake()],
-                version: semver::VersionReq::parse("0.1.1").unwrap(),
+                version: Some(semver::VersionReq::parse("0.1.1").unwrap()),
             }]
         );
         let p: PathBuf = "LICENSE".into();
@@ -400,13 +400,13 @@ mod test {
             validated.clarifications,
             vec![ValidClarification {
                 name: "ring".to_owned(),
-                version: semver::VersionReq::parse("*").unwrap(),
+                version: None,
                 expression: spdx::Expression::parse("MIT AND ISC AND OpenSSL").unwrap(),
                 license_files: vec![FileSource {
                     path: p.fake(),
                     hash: 0xbd0e_ed23,
                 }],
-                expr_offset: 464,
+                expr_offset: 450,
             }]
         );
     }

--- a/src/licenses/gather.rs
+++ b/src/licenses/gather.rs
@@ -18,7 +18,7 @@ fn iter_clarifications<'a>(
 ) -> impl Iterator<Item = &'a ValidClarification> {
     all.iter().filter(move |vc| {
         if vc.name == krate.name {
-            return vc.version.matches(&krate.version);
+            return crate::match_req(&krate.version, vc.version.as_ref());
         }
 
         false

--- a/tests/cfg/licenses.toml
+++ b/tests/cfg/licenses.toml
@@ -25,7 +25,6 @@ version = "0.1.1"
 
 [[licenses.clarify]]
 name = "ring"
-version = "*"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }


### PR DESCRIPTION
Previously, the various config options in the `bans` and `licenses` that allow specifying a crate had an optional `version` component that could be used to restrict the match to a specific semver range. If none was specified, this would default to the `*` wildcard match to match any version of the crate. However, `*` has a non-intuitive interaction with pre-releases...they actually won't match. This causes user confusion since pre-releases are relatively rare in the rust ecosystem, and most people (myself included) think that `*` means everything, not everything, except for this niche case. So now, all config `VersionReq`s are _actually_ optional, and if not specified will match any version.

Even though this is _technically_ a breaking change, I actually consider this a bug fix and will release it as such.

Resolves: #371 