### PR TITLE
Fix infinite loop with tree-skip

### DIFF
--- a/src/bans.rs
+++ b/src/bans.rs
@@ -120,15 +120,15 @@ impl TreeSkipper {
 
         let mut pending = vec![(krate_id, 1)];
         while let Some((node_id, depth)) = pending.pop() {
-            if depth < max_depth {
-                for dep in graph.edges_directed(node_id, Direction::Outgoing) {
-                    pending.push((dep.target(), depth + 1));
-                }
-            }
-
             let pkg_id = &krates[node_id].id;
             if let Err(i) = skip_crates.binary_search(pkg_id) {
                 skip_crates.insert(i, pkg_id.clone());
+
+                if depth < max_depth {
+                    for dep in graph.edges_directed(node_id, Direction::Outgoing) {
+                        pending.push((dep.target(), depth + 1));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Using `tree-skip` could cause an infinite loop since we were (almost) unconditionally adding nodes to check. Now we gate it behind the parent not actually already being in the list.

Resolves: #375