### PR TITLE
Use CARGO_TERM_COLOR env var for color value

### DIFF
--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -242,7 +242,7 @@ Possible values:
     /// Specify the format of cargo-deny's output
     #[structopt(short, long, default_value = "human", possible_values = Format::variants())]
     format: Format,
-    #[structopt(short, long, default_value = "auto", possible_values = Color::variants())]
+    #[structopt(short, long, default_value = "auto", possible_values = Color::variants(), env = "CARGO_TERM_COLOR")]
     color: Color,
     #[structopt(flatten)]
     ctx: GraphContext,


### PR DESCRIPTION
I think this would be rather convenient for CI environments which already might set `CARGO_TERM_COLOR`.