### PR TITLE
Update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This can be useful in Docker Images.
 cargo install --locked cargo-deny
 
 # Or, if you're an Arch user
-yay -S cargo-deny
+pacman -S cargo-deny
 ```
 
 ### [Initialize](https://embarkstudios.github.io/cargo-deny/cli/init.html) your project

--- a/docs/src/cli/README.md
+++ b/docs/src/cli/README.md
@@ -6,12 +6,12 @@ cargo-deny can be used either as a command line tool or as a [Rust crate](https:
 
 Precompiled binaries are provided for major platforms on a best-effort basis. Visit [the releases page](https://github.com/EmbarkStudios/cargo-deny/releases) to download the appropriate version for your platform.
 
-## Install from AUR
+## Installation on Arch Linux
 
-A community maintained Arch package is available on [AUR](https://aur.archlinux.org/packages/cargo-deny/), you can install it via
+cargo-deny is available in the Arch Linux [community repository](https://archlinux.org/packages/community/x86_64/cargo-deny/), you can install it via [pacman](https://wiki.archlinux.org/title/Pacman) as shown below:
 
 ```bash
-yay -S cargo-deny
+pacman -S cargo-deny
 ```
 
 ## Install From Source


### PR DESCRIPTION
`cargo-deny` is maintained in the Arch Linux community repository and can be installed via `pacman`. This PR updates the documentation to reflect this.

ref: https://archlinux.org/packages/community/x86_64/cargo-deny/

