### PR TITLE
Allow to use git executable for fetching advisory database

### DIFF
--- a/deny.template.toml
+++ b/deny.template.toml
@@ -60,6 +60,12 @@ ignore = [
 # * Critical - CVSS Score 9.0 - 10.0
 #severity-threshold =
 
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html

--- a/src/advisories/cfg.rs
+++ b/src/advisories/cfg.rs
@@ -45,6 +45,8 @@ pub struct Config {
     /// Vulnerabilities with explicit CVSS info which have a severity below
     /// this threshold will be ignored.
     pub severity_threshold: Option<advisory::Severity>,
+    /// use the git executable to fetch advisory database
+    pub git_fetch_with_cli: Option<bool>,
 }
 
 impl Default for Config {
@@ -60,6 +62,7 @@ impl Default for Config {
             yanked: yanked(),
             notice: LintLevel::Warn,
             severity_threshold: None,
+            git_fetch_with_cli: None,
         }
     }
 }
@@ -148,6 +151,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
             yanked: self.yanked,
             notice: self.notice,
             severity_threshold: self.severity_threshold,
+            git_fetch_with_cli: self.git_fetch_with_cli.unwrap_or_default(),
         }
     }
 }
@@ -165,6 +169,7 @@ pub struct ValidConfig {
     pub yanked: Spanned<LintLevel>,
     pub notice: LintLevel,
     pub severity_threshold: Option<advisory::Severity>,
+    pub git_fetch_with_cli: bool,
 }
 
 #[cfg(test)]

--- a/src/advisories/helpers.rs
+++ b/src/advisories/helpers.rs
@@ -1,5 +1,5 @@
 use crate::{Krate, Krates};
-use anyhow::{Context, Error, anyhow};
+use anyhow::{Context, Error};
 use log::{debug, info};
 pub use rustsec::{advisory::Id, lockfile::Lockfile, Database, Vulnerability};
 use std::path::{Path, PathBuf};
@@ -8,9 +8,8 @@ use url::Url;
 /// Whether the database will be fetched or not
 #[derive(Copy, Clone)]
 pub enum Fetch {
-    /// If this is true, then cargo deny will use the git executable to fetch advisory database.
-    /// If this is false, then it uses a built-in git library.
-    Allow(bool),
+    Allow,
+    AllowWithGitCli,
     Disallow,
 }
 
@@ -96,18 +95,19 @@ fn load_db(db_url: &Url, root_db_path: PathBuf, fetch: Fetch) -> Result<Database
     let db_path = url_to_path(root_db_path, db_url)?;
 
     let db_repo = match fetch {
-        Fetch::Allow(git_fetch_with_cli) => {
+        Fetch::Allow => {
             debug!("Fetching advisory database from '{}'", db_url);
 
-            if git_fetch_with_cli {
-                fetch_with_cli(db_url.as_str(), &db_path)
-                    .context("failed to fetch advisory database with cli")?;
+            Repository::fetch(db_url.as_str(), &db_path, true /* ensure_fresh */)
+                .context("failed to fetch advisory database")?
+        }
+        Fetch::AllowWithGitCli => {
+            debug!("Fetching advisory database with git cli from '{}'", db_url);
 
-                Repository::open(&db_path).context("failed to open advisory database")?
-            } else {
-                Repository::fetch(db_url.as_str(), &db_path, true /* ensure_fresh */)
-                    .context("failed to fetch advisory database")?
-            }
+            fetch_with_cli(db_url.as_str(), &db_path)
+                .context("failed to fetch advisory database with cli")?;
+
+            Repository::open(&db_path).context("failed to open advisory database")?
         }
         Fetch::Disallow => {
             debug!("Opening advisory database at '{}'", db_path.display());
@@ -128,32 +128,31 @@ fn load_db(db_url: &Url, root_db_path: PathBuf, fetch: Fetch) -> Result<Database
     res
 }
 
-fn fetch_with_cli(
-    url: &str,
-    db_path: &Path
-) -> Result<(), Error> {
+fn fetch_with_cli(url: &str, db_path: &Path) -> Result<(), Error> {
     use std::{fs, process::Command};
 
     if let Some(parent) = db_path.parent() {
         if !parent.is_dir() {
-            fs::create_dir_all(parent)?;
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create advisory database directory {}",
+                    parent.display()
+                )
+            })?;
         }
     } else {
-        return Err(anyhow!("invalid directory: {}", db_path.display()));
+        anyhow::bail!("invalid directory: {}", db_path.display());
     }
 
     if db_path.exists() {
         // make sure db_path is clean
         let mut cmd = Command::new("git");
-        cmd.arg("reset")
-            .arg("--hard")
-            .current_dir(db_path);
+        cmd.arg("reset").arg("--hard").current_dir(db_path);
         cmd.spawn()?.wait_with_output()?;
 
         // pull latest changes
         let mut cmd = Command::new("git");
-        cmd.arg("pull")
-            .current_dir(db_path);
+        cmd.arg("pull").current_dir(db_path);
         cmd.spawn()?.wait_with_output()?;
     } else {
         // clone repository

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -256,8 +256,10 @@ pub(crate) fn cmd(
                         .collect(),
                     if args.disable_fetch {
                         advisories::Fetch::Disallow
+                    } else if advisories.git_fetch_with_cli {
+                        advisories::Fetch::AllowWithGitCli
                     } else {
-                        advisories::Fetch::Allow(advisories.git_fetch_with_cli)
+                        advisories::Fetch::Allow
                     },
                 ));
             });

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -257,7 +257,7 @@ pub(crate) fn cmd(
                     if args.disable_fetch {
                         advisories::Fetch::Disallow
                     } else {
-                        advisories::Fetch::Allow
+                        advisories::Fetch::Allow(advisories.git_fetch_with_cli)
                     },
                 ));
             });

--- a/src/cargo-deny/fetch.rs
+++ b/src/cargo-deny/fetch.rs
@@ -151,7 +151,11 @@ pub fn cmd(
                         .into_iter()
                         .map(|dburl| dburl.take())
                         .collect(),
-                    advisories::Fetch::Allow(cfg.advisories.git_fetch_with_cli),
+                    if cfg.advisories.git_fetch_with_cli {
+                        advisories::Fetch::AllowWithGitCli
+                    } else {
+                        advisories::Fetch::Allow
+                    },
                 ));
             });
         }

--- a/src/cargo-deny/fetch.rs
+++ b/src/cargo-deny/fetch.rs
@@ -151,7 +151,7 @@ pub fn cmd(
                         .into_iter()
                         .map(|dburl| dburl.take())
                         .collect(),
-                    advisories::Fetch::Allow,
+                    advisories::Fetch::Allow(cfg.advisories.git_fetch_with_cli),
                 ));
             });
         }

--- a/src/cargo-deny/fix.rs
+++ b/src/cargo-deny/fix.rs
@@ -170,7 +170,7 @@ pub fn cmd(
                 if args.disable_fetch {
                     advisories::Fetch::Disallow
                 } else {
-                    advisories::Fetch::Allow
+                    advisories::Fetch::Allow(false)
                 },
             ));
         });

--- a/src/cargo-deny/fix.rs
+++ b/src/cargo-deny/fix.rs
@@ -169,8 +169,10 @@ pub fn cmd(
                 advisories.db_urls.into_iter().map(|u| u.take()).collect(),
                 if args.disable_fetch {
                     advisories::Fetch::Disallow
+                } else if advisories.git_fetch_with_cli {
+                    advisories::Fetch::AllowWithGitCli
                 } else {
-                    advisories::Fetch::Allow(false)
+                    advisories::Fetch::Allow
                 },
             ));
         });

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -44,7 +44,7 @@ fn load() -> TestCtx {
 
     let db = {
         let tmp = tempfile::tempdir().unwrap();
-        advisories::DbSet::load(Some(tmp), vec![], advisories::Fetch::Allow).unwrap()
+        advisories::DbSet::load(Some(tmp), vec![], advisories::Fetch::Allow(false)).unwrap()
     };
 
     let lockfile = advisories::PrunedLockfile::prune(lock, &krates);

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -44,7 +44,7 @@ fn load() -> TestCtx {
 
     let db = {
         let tmp = tempfile::tempdir().unwrap();
-        advisories::DbSet::load(Some(tmp), vec![], advisories::Fetch::Allow(false)).unwrap()
+        advisories::DbSet::load(Some(tmp), vec![], advisories::Fetch::Allow).unwrap()
     };
 
     let lockfile = advisories::PrunedLockfile::prune(lock, &krates);


### PR DESCRIPTION
This PR allows the use of the git executable directly instead of using git2 (fetching advisory database only!). This is similar to what cargo does and solves https://github.com/EmbarkStudios/cargo-deny/issues/419 for me.

The option can be selected from deny.toml's advisories section
```toml
[advisories]
# If this is true, then cargo deny will use the git executable to fetch advisory database.
# If this is false, then it uses a built-in git library.
# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
# See Git Authentication for more information about setting up git authentication.
git-fetch-with-cli = true
```