### PR TITLE
Allow non-HTTPS Git URLs for the advisory database

### DIFF
--- a/src/advisories/cfg.rs
+++ b/src/advisories/cfg.rs
@@ -130,14 +130,6 @@ impl crate::cfg::UnvalidatedConfig for Config {
                         .with_labels(vec![Label::secondary(cfg_file, url.span.clone())]),
                 );
             }
-
-            if url.value.scheme() != "https" {
-                diags.push(
-                    Diagnostic::error()
-                        .with_message("advisory database url is not https")
-                        .with_labels(vec![Label::secondary(cfg_file, url.span.clone())]),
-                );
-            }
         }
 
         ValidConfig {


### PR DESCRIPTION
Fixes #412 

The check was apparently added because `rustsec` doesn't support non-HTTPS URLs, but `cargo-deny` doesn't actually use `rustsec` to fetch the repo; `cargo-deny` fetches it itself with the `git2` crate or the `git` executable and then passes the repo to `rustsec` as a local filesystem path. And indeed, after removing the check I'm able to use an `ssh://` URL for the advisory database without any problem. So, as far as I can see, the check is unnecessarily restrictive.