### PR TITLE
Only flag yanked crates which come from registries

### DIFF
--- a/src/advisories.rs
+++ b/src/advisories.rs
@@ -49,6 +49,10 @@ pub fn check<R>(
             let mut yanked = Vec::new();
 
             for package in &lockfile.0.packages {
+                if package.source.as_ref().map(|s| !s.is_default_registry()).unwrap_or(true) {
+                    continue;
+                }
+
                 if let Some(krate) = index.crate_(package.name.as_str()) {
                     if krate
                         .versions()

--- a/src/advisories.rs
+++ b/src/advisories.rs
@@ -49,7 +49,14 @@ pub fn check<R>(
             let mut yanked = Vec::new();
 
             for package in &lockfile.0.packages {
-                if package.source.as_ref().map(|s| !s.is_default_registry()).unwrap_or(true) {
+                // Ignore non-registry crates when checking, as a crate sourced
+                // locally or via git can have the same name as a registry package
+                if package
+                    .source
+                    .as_ref()
+                    .map(|s| !s.is_registry())
+                    .unwrap_or(true)
+                {
                     continue;
                 }
 

--- a/src/advisories.rs
+++ b/src/advisories.rs
@@ -51,12 +51,7 @@ pub fn check<R>(
             for package in &lockfile.0.packages {
                 // Ignore non-registry crates when checking, as a crate sourced
                 // locally or via git can have the same name as a registry package
-                if package
-                    .source
-                    .as_ref()
-                    .map(|s| !s.is_registry())
-                    .unwrap_or(true)
-                {
+                if package.source.as_ref().map_or(true, |s| !s.is_registry()) {
                     continue;
                 }
 


### PR DESCRIPTION
I have a project with a crate on the local filesystem that shares a name and version number with a yanked crate on crates.io that is incorrectly flagged by the current code.