### PR TITLE
chore: Upgrade to clap 3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,9 +316,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "a836566fa5f52f7ddf909a8a2f9029b9f78ca584cd95cf7e87f8073110f4c5c9"
 dependencies = [
  "atty",
  "bitflags",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "986fd75d1dfd2c34eb8c9275ae38ad87ea9478c9b79e87f1801f7d866dfb1e37"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ bitvec = { version = "1.0", features = ["alloc"] }
 # Allows us to do eg cargo metadata operations without relying on an external cargo
 cargo = { version = "0.61", optional = true }
 # Argument parsing
-clap = { version = "3.1", features = ["derive", "env"] }
+clap = { version = "3.2.1", features = ["derive", "env"] }
 # Used for diagnostic reporting
 codespan = "0.11"
 codespan-reporting = "0.11"

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -9,7 +9,7 @@ use log::error;
 use serde::Deserialize;
 use std::{path::PathBuf, time::Instant};
 
-#[derive(clap::ArgEnum, Debug, PartialEq, Copy, Clone)]
+#[derive(clap::ValueEnum, Debug, PartialEq, Copy, Clone)]
 pub enum WhichCheck {
     Advisories,
     Ban,
@@ -25,33 +25,33 @@ pub struct Args {
     /// Path to the config to use
     ///
     /// Defaults to <cwd>/deny.toml if not specified
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, action)]
     pub config: Option<PathBuf>,
     /// Path to graph_output root directory
     ///
     /// If set, a dotviz graph will be created for whenever multiple versions of the same crate are detected.
     ///
     /// Each file will be created at <dir>/graph_output/<crate_name>.dot. <dir>/graph_output/* is deleted and recreated each run.
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, action)]
     pub graph: Option<PathBuf>,
     /// Hides the inclusion graph when printing out info for a crate
-    #[clap(long)]
+    #[clap(long, action)]
     pub hide_inclusion_graph: bool,
     /// Disable fetching of the advisory database
     ///
     /// When running the `advisories` check, the configured advisory database will be fetched and opened. If this flag is passed, the database won't be fetched, but an error will occur if it doesn't already exist locally.
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     pub disable_fetch: bool,
     /// To ease transition from cargo-audit to cargo-deny, this flag will tell cargo-deny to output the exact same output as cargo-audit would, to `stdout` instead of `stderr`, just as with cargo-audit.
     ///
     /// Note that this flag only applies when the output format is JSON, and note that since cargo-deny supports multiple advisory databases, instead of a single JSON object, there will be 1 for each unique advisory database.
-    #[clap(long)]
+    #[clap(long, action)]
     pub audit_compatible_output: bool,
     /// Show stats for all the checks, regardless of the log-level
-    #[clap(short, long = "show-stats")]
+    #[clap(short, long, action)]
     pub show_stats: bool,
     /// The check(s) to perform
-    #[clap(arg_enum)]
+    #[clap(value_enum, action)]
     pub which: Vec<WhichCheck>,
 }
 

--- a/src/cargo-deny/fetch.rs
+++ b/src/cargo-deny/fetch.rs
@@ -5,7 +5,7 @@ use cargo_deny::{
 };
 use std::path::PathBuf;
 
-#[derive(clap::ArgEnum, Debug, PartialEq, Copy, Clone)]
+#[derive(clap::ValueEnum, Debug, PartialEq, Copy, Clone)]
 pub enum FetchSource {
     Db,
     Index,
@@ -17,10 +17,10 @@ pub struct Args {
     /// Path to the config to use
     ///
     /// Defaults to <cwd>/deny.toml if not specified
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, action)]
     config: Option<PathBuf>,
     /// The sources to fetch
-    #[clap(arg_enum)]
+    #[clap(value_enum, action)]
     sources: Vec<FetchSource>,
 }
 

--- a/src/cargo-deny/init.rs
+++ b/src/cargo-deny/init.rs
@@ -6,7 +6,7 @@ pub struct Args {
     /// The path to create
     ///
     /// Defaults to <cwd>/deny.toml
-    #[clap(parse(from_os_str))]
+    #[clap(action)]
     config: Option<PathBuf>,
 }
 

--- a/src/cargo-deny/list.rs
+++ b/src/cargo-deny/list.rs
@@ -4,13 +4,13 @@ use cargo_deny::{diag::Files, licenses, Kid};
 use serde::Serialize;
 use std::path::PathBuf;
 
-#[derive(clap::ArgEnum, Copy, Clone, Debug)]
+#[derive(clap::ValueEnum, Copy, Clone, Debug)]
 pub enum Layout {
     Crate,
     License,
 }
 
-#[derive(clap::ArgEnum, Copy, Clone, Debug)]
+#[derive(clap::ValueEnum, Copy, Clone, Debug)]
 pub enum OutputFormat {
     Human,
     Json,
@@ -22,20 +22,20 @@ pub struct Args {
     /// Path to the config to use
     ///
     /// Defaults to a deny.toml in the same folder as the manifest path, or a deny.toml in a parent directory.
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, action)]
     config: Option<PathBuf>,
     /// Minimum confidence threshold for license text
     ///
     /// When determining the license from file contents, a confidence score is assigned according to how close the contents are to the canonical license text. If the confidence score is below this threshold, they license text will ignored, which might mean the crate is treated as unlicensed.
     ///
     /// [possible values: 0.0 - 1.0]
-    #[clap(short, long, default_value = "0.8")]
+    #[clap(short, long, default_value = "0.8", action)]
     threshold: f32,
     /// The format of the output
-    #[clap(short, long, default_value = "human", arg_enum)]
+    #[clap(short, long, default_value = "human", value_enum, action)]
     format: OutputFormat,
     /// The layout for the output, does not apply to TSV
-    #[clap(short, long, default_value = "license", arg_enum)]
+    #[clap(short, long, default_value = "license", value_enum, action)]
     layout: Layout,
 }
 


### PR DESCRIPTION
I decided to use cargo-deny as a test case for upgrading to clap 3.2 which was just released (release announcement forthcoming).

For derive users, there isn't too much different.  By specifying a default `#[clap(action)]` or `#[clap(value_parser)]` attribute, you opt-in to the new behavior that will be the default in clap 4.0.  The main difference is instead of the `parse` attribute that is unique to the derive, you now have the `value_parser` attribute which comes from `Arg::value_parser`.  When no `value_parser` is specified, we'll default to `value_parser!(T)` which will auto-select an appropriate value parser for the given field's  core type.  In practice, this means the default `value_parser` for `PathBuf` is now safe to use.

We also renamed `ArgEnum` to `ValueEnum` to make the name more meaningful and for some future work we'll be doing.  `value_parser` mostly gets rid of the need for `value_enum` attribute except for when dealing with defaults, so I just left the attribute in place.  I went ahead and switched some enums that were almost `ValueEnum` to being `ValueEnum`.