### PR TITLE
Implement `cargo deny dist` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +234,7 @@ dependencies = [
  "krates",
  "log",
  "rayon",
+ "reqwest",
  "rustsec",
  "semver",
  "serde",
@@ -236,6 +243,7 @@ dependencies = [
  "spdx",
  "tempfile",
  "time",
+ "tokio",
  "toml",
  "twox-hash",
  "url",
@@ -595,6 +603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +715,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+
+[[package]]
+name = "futures-task"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-util"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "fwdansi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +810,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,10 +874,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "idna"
@@ -865,6 +1011,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -1019,6 +1171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,12 +1186,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "miow"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1181,6 +1369,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1524,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1655,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1727,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1752,15 @@ checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
 dependencies = [
  "bitmaps",
  "typenum",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1666,6 +1947,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "once_cell",
+ "pin-project-lite",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +2008,38 @@ dependencies = [
  "kstring",
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twox-hash"
@@ -1800,6 +2154,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +2192,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1852,6 +2234,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+
+[[package]]
+name = "web-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1926,6 +2318,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ krates = { version = "0.11", features = ["targets"] }
 log = "0.4"
 # Moar brrrr
 rayon = "1.4"
+# Download license text for sdpx expressions in `cargo deny dist`
+reqwest = "0.11.12"
 # Used for interacting with advisory databases
 rustsec = { version = "0.26", default-features = false }
 # Parsing and checking of versions/version requirements
@@ -90,6 +92,8 @@ time = { version = "0.3", default-features = false, features = [
   "formatting",
   "macros",
 ] }
+# Execute futures, such as the ones given by reqwest
+tokio = { version = "1.21.1", features = ["rt"] }
 # Deserialization of configuration files and crate manifests
 toml = "0.5"
 # Small fast hash crate

--- a/src/cargo-deny/dist.rs
+++ b/src/cargo-deny/dist.rs
@@ -1,0 +1,268 @@
+use anyhow::{Context, Error};
+use cargo_deny::{
+    diag::Files,
+    licenses::{self, LicenseExprSource, LicenseInfo},
+};
+use spdx::{expression::ExprNode, LicenseItem};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::PathBuf,
+};
+use tokio::runtime;
+
+#[derive(clap::Parser, Debug)]
+pub struct Args {
+    /// Path to the config to use
+    ///
+    /// Defaults to a deny.toml in the same folder as the manifest path, or a deny.toml in a parent directory.
+    #[clap(short, long, action)]
+    config: Option<PathBuf>,
+    /// Minimum confidence threshold for license text
+    ///
+    /// When determining the license from file contents, a confidence score is assigned according to how close the contents are to the canonical license text. If the confidence score is below this threshold, they license text will ignored, which might mean the crate is treated as unlicensed.
+    ///
+    /// [possible values: 0.0 - 1.0]
+    #[clap(short, long, default_value = "0.8", action)]
+    threshold: f32,
+    /// The directory in which generated license notices are stored. Defaults to ./intellectual-property-notices.
+    /// This directory will be created if it does not already exist.
+    output_path: Option<PathBuf>,
+}
+
+#[derive(serde::Deserialize)]
+struct Config {
+    #[serde(default)]
+    targets: Vec<crate::common::Target>,
+    #[serde(default)]
+    exclude: Vec<String>,
+}
+
+struct ValidConfig {
+    targets: Vec<(krates::Target, Vec<String>)>,
+    exclude: Vec<String>,
+}
+
+impl ValidConfig {
+    fn load(
+        cfg_path: Option<PathBuf>,
+        files: &mut Files,
+        log_ctx: crate::common::LogContext,
+    ) -> Result<Self, Error> {
+        let (cfg_contents, cfg_path) = match cfg_path {
+            Some(cfg_path) if cfg_path.exists() => (
+                std::fs::read_to_string(&cfg_path).with_context(|| {
+                    format!("failed to read config from {}", cfg_path.display())
+                })?,
+                cfg_path,
+            ),
+            Some(cfg_path) => {
+                log::warn!(
+                    "config path '{}' doesn't exist, falling back to default config",
+                    cfg_path.display()
+                );
+
+                return Ok(Self {
+                    targets: Vec::new(),
+                    exclude: Vec::new(),
+                });
+            }
+            None => {
+                log::warn!("unable to find a config path, falling back to default config");
+
+                return Ok(Self {
+                    targets: Vec::new(),
+                    exclude: Vec::new(),
+                });
+            }
+        };
+
+        let cfg: Config = toml::from_str(&cfg_contents).with_context(|| {
+            format!("failed to deserialize config from '{}'", cfg_path.display())
+        })?;
+
+        log::info!("using config from {}", cfg_path.display());
+
+        let id = files.add(&cfg_path, cfg_contents);
+
+        use cargo_deny::diag::Diagnostic;
+
+        let validate = || -> Result<(Vec<Diagnostic>, Self), Vec<Diagnostic>> {
+            let mut diagnostics = Vec::new();
+            let targets = crate::common::load_targets(cfg.targets, &mut diagnostics, id);
+            let exclude = cfg.exclude;
+
+            Ok((diagnostics, Self { targets, exclude }))
+        };
+
+        let print = |diags: Vec<Diagnostic>| {
+            if diags.is_empty() {
+                return;
+            }
+
+            if let Some(printer) = crate::common::DiagPrinter::new(log_ctx, None) {
+                let mut lock = printer.lock();
+                for diag in diags {
+                    lock.print(diag, files);
+                }
+            }
+        };
+
+        match validate() {
+            Ok((diags, vc)) => {
+                print(diags);
+                Ok(vc)
+            }
+            Err(diags) => {
+                print(diags);
+
+                anyhow::bail!(
+                    "failed to validate configuration file {}",
+                    cfg_path.display()
+                );
+            }
+        }
+    }
+}
+
+pub fn cmd(
+    log_ctx: crate::common::LogContext,
+    args: Args,
+    krate_ctx: crate::common::KrateContext,
+) -> Result<(), Error> {
+    let mut exit_code = 0;
+    {
+        let mut files = Files::new();
+        let cfg = ValidConfig::load(krate_ctx.get_config_path(args.config), &mut files, log_ctx)?;
+
+        let (krates, store) = rayon::join(
+            || krate_ctx.gather_krates(cfg.targets, cfg.exclude),
+            crate::common::load_license_store,
+        );
+
+        let krates = krates.context("failed to gather crates")?;
+        let store = store.context("failed to load license store")?;
+
+        let gatherer = licenses::Gatherer::default()
+            .with_store(std::sync::Arc::new(store))
+            .with_confidence_threshold(args.threshold);
+
+        let mut files = Files::new();
+
+        let summary = gatherer.gather(&krates, &mut files, None);
+        let output_path = args
+            .output_path
+            .unwrap_or_else(|| PathBuf::from("./intellectual-property-notices"));
+        fs::create_dir_all(&output_path).context("failed to create output directory")?;
+        let mut license_text_cache = HashMap::new();
+        let tokio_runtime = runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to init tokio runtime")?;
+        for krate in summary.nfos {
+            let mut keep_folder = false;
+            let krate_path = output_path.join(&krate.krate.name);
+            if !krate_path.exists() {
+                fs::create_dir(&krate_path).with_context(|| {
+                    format!(
+                        "failed to create license directory for crate {}",
+                        krate.krate.name
+                    )
+                })?;
+            }
+            for license in &krate.krate.license_file {
+                let license_path = krate.krate.manifest_path.parent().unwrap().join(license);
+                let res = fs::copy(
+                    &license_path,
+                    krate_path.join(license.file_name().expect("infallible")),
+                );
+                if let Err(e) = res {
+                    exit_code = 1;
+                    log::error!(
+                        "Failed to copy {license_path} file for crate {} {e:?}",
+                        krate.krate.name
+                    );
+                };
+                keep_folder = true;
+            }
+            let name = &krate.krate.name;
+            match krate.lic_info {
+                LicenseInfo::SpdxExpression { expr, nfo } => {
+                    let version = env!("CARGO_PKG_VERSION");
+                    let spdx = expr.as_ref();
+                    let mut licenses = String::new();
+                    // Sometimes an spdx references a license multiple times, only include it once.
+                    let mut described_licenses = HashSet::new();
+                    for spdx_license in expr.iter().filter_map(|e| match e {
+                        ExprNode::Req(r) => Some(r),
+                        ExprNode::Op(_) => None,
+                    }) {
+                        match &spdx_license.req.license {
+                            LicenseItem::Spdx { id, .. } => {
+                                if !described_licenses.contains(id.name) {
+                                    described_licenses.insert(id.name);
+                                    if !license_text_cache.contains_key(id.name) {
+                                        let http_resp = tokio_runtime.block_on(async {
+                                        reqwest::get(
+                                            format!("https://raw.githubusercontent.com/spdx/license-list-data/master/text/{}.txt", id.name)
+                                        )
+                                        .await
+                                        .with_context(|| format!("failed to download license text for {}", id.full_name))?
+                                        .text()
+                                        .await
+                                        .with_context(|| format!("failed to decode license text response for {}", id.full_name))
+                                    })?;
+                                        license_text_cache.insert(id.name, http_resp);
+                                    }
+                                    let license_text = license_text_cache.get(id.name).unwrap();
+                                    licenses.push_str(license_text);
+                                    licenses.push_str("\r\n\r\n");
+                                }
+                            }
+                            LicenseItem::Other { lic_ref, .. } => {
+                                log::warn!("non-regular SPDX license id {lic_ref} found in {name}, these are not supported at this time");
+                            }
+                        }
+                    }
+                    match &nfo.source {
+                        LicenseExprSource::Metadata => {
+                            let contents = format!("\
+                        This notice is automatically generated by cargo-deny {version}. If you've found an inaccuracy in it please\r\n\
+                        file a bug at https://github.com/EmbarkStudios/cargo-deny/issues\r\n\
+                        \r\n\
+                        This software makes use of the Rust crate \"{name}\" which had the following license descriptor\r\n\
+                        attached.\r\n\
+                        \r\n\
+                        {spdx}\r\n\
+                        \r\n\
+                        Below is a reproduction of the license(s) associated with this descriptor.\r\n\
+                        \r\n\
+                        {licenses}\
+                        ");
+                            fs::write(krate_path.join("crate-license.txt"), contents)
+                                .with_context(|| {
+                                    format!("failed to write crate license data for {}", name)
+                                })?;
+                            keep_folder = true;
+                        }
+                        LicenseExprSource::LicenseFiles => {
+                            // Do nothing, this is covered by the prior for loop
+                        }
+                        LicenseExprSource::OverlayOverride | LicenseExprSource::UserOverride => {
+                            log::warn!("crate {name} had a manually overridden license. This command will not emit license notices for overrides.");
+                        }
+                    }
+                }
+                LicenseInfo::Unlicensed => {
+                    log::warn!("crate {name} was unlicensed. This command will not emit license notices for unlicensed crates.");
+                }
+            }
+            if !keep_folder {
+                if let Err(e) = fs::remove_dir(krate_path) {
+                    log::error!("failed to remove empty folder for {name} {e:?}");
+                }
+            }
+        }
+    }
+    std::process::exit(exit_code);
+}

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -85,6 +85,7 @@ use std::path::PathBuf;
 
 mod check;
 mod common;
+mod dist;
 mod fetch;
 mod init;
 mod list;
@@ -104,6 +105,9 @@ enum Command {
     /// Outputs a listing of all licenses and the crates that use them
     #[clap(name = "list")]
     List(list::Args),
+    /// Prepares license files from your cargo dependencies for redistribution
+    #[clap(name = "dist")]
+    Dist(dist::Args),
 }
 
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq)]
@@ -402,6 +406,7 @@ fn real_main() -> Result<(), Error> {
         Command::Fetch(fargs) => fetch::cmd(log_ctx, fargs, krate_ctx),
         Command::Init(iargs) => init::cmd(iargs, krate_ctx),
         Command::List(largs) => list::cmd(log_ctx, largs, krate_ctx),
+        Command::Dist(cargs) => dist::cmd(log_ctx, cargs, krate_ctx),
     }
 }
 

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -23,8 +23,8 @@ use crate::{
     LintLevel,
 };
 use cfg::BlanketAgreement;
-pub use gather::{Gatherer, LicenseInfo, LicenseStore};
-use gather::{KrateLicense, LicenseExprInfo, LicenseExprSource, Summary};
+pub use gather::{Gatherer, LicenseExprSource, LicenseInfo, LicenseStore};
+use gather::{KrateLicense, LicenseExprInfo, Summary};
 
 pub use cfg::{Config, ValidConfig};
 


### PR DESCRIPTION
This PR adds a new sub-command to `cargo-deny`, `dist`.

Most Rust crates use licenses with clauses like "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software."

Trouble is most people distributing Rust binaries aren't including the copyright notice. This command automates gathering those notices and makes it easy to give proper credit to the open source projects you rely on.