### PR TITLE
Fixup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "krates"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926bc1b844661829bdb2e685d5c51676cc7265770ae1a29f376a37dedda8b279"
+checksum = "9120c4d72191846f2f52ceaf84a0b48393a9f0e3969348914d8309838b22b7cd"
 dependencies = [
  "cargo_metadata",
  "cfg-expr",

--- a/src/bans.rs
+++ b/src/bans.rs
@@ -130,11 +130,8 @@ impl TreeSkipper {
                 skip_crates.insert(i, pkg_id.clone());
 
                 if depth < max_depth {
-                    for dep in graph
-                        .edges_directed(node_id, Direction::Outgoing)
-                        .filter(|edge| !matches!(edge.weight(), krates::Edge::Feature))
-                    {
-                        pending.push((dep.target(), depth + 1));
+                    for dep in krates.direct_dependencies(node_id) {
+                        pending.push((dep.node_id, depth + 1));
                     }
                 }
             }
@@ -185,7 +182,6 @@ impl fmt::Debug for DupGraph {
 pub type OutputGraph = dyn Fn(DupGraph) -> Result<(), Error> + Send + Sync;
 
 use crate::diag::{Check, Diag, Pack, Severity};
-use krates::petgraph::{visit::EdgeRef, Direction};
 
 pub fn check(
     ctx: crate::CheckCtx<'_, ValidConfig>,

--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -124,7 +124,8 @@ impl KrateContext {
             gb.include_targets(cfg_targets);
         }
 
-        gb.ignore_kind(DepKind::Dev, krates::Scope::NonWorkspace);
+        let scope = krates::Scope::NonWorkspace; // krates::Scope::All
+        gb.ignore_kind(DepKind::Dev, scope);
         gb.workspace(self.workspace);
 
         if !self.exclude.is_empty() || !cfg_excludes.is_empty() {


### PR DESCRIPTION
- Add ability to include features in dup graph
- Fix bug when building skip trees

This fixes two issues introduced in 0.13.

1. There was a bug in https://github.com/EmbarkStudios/krates/pull/45 that would cause optional dependencies to be pruned if their feature name differed from the crate name, resulting in incorrect graphs.
2. Skip trees were being created differently from 0.12 due to the addition of features, causing crates that were being skipped in that version to no longer be skipped in 0.13.

Resolves: #469