### PR TITLE
Update `krates` to 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#473](https://github.com/EmbarkStudios/cargo-deny/pull/473) updated `krates` to 0.12.3, which addresses an issue where a crate's feature set can differ between the version in the registry, and same version on disk.
+
 ## [0.13.1] - 2022-10-28
 ### Fixed
 - [PR#471](https://github.com/EmbarkStudios/cargo-deny/pull/471) fixed a bug where optional dependencies could be pruned if the feature that enabled it was named differently from the crate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,12 +917,13 @@ dependencies = [
 
 [[package]]
 name = "krates"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120c4d72191846f2f52ceaf84a0b48393a9f0e3969348914d8309838b22b7cd"
+checksum = "0425cc5541bc7cc1a175907c6c0bd6010e00d6d876fdc894deea03e33a0d1a59"
 dependencies = [
  "cargo_metadata",
  "cfg-expr",
+ "crates-index",
  "petgraph",
  "semver",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ git2 = "0.14"
 # We need to figure out HOME/CARGO_HOME in some cases
 home = "0.5"
 # Provides graphs on top of cargo_metadata
-krates = { version = "0.12", features = ["targets"] }
+krates = { version = "0.12", features = ["prefer-index", "targets"] }
 # Log macros
 log = "0.4"
 # Moar brrrr

--- a/tests/snapshots/sources__allows_bitbucket_org.snap
+++ b/tests/snapshots/sources__allows_bitbucket_org.snap
@@ -132,7 +132,7 @@ expression: diags
       "labels": [
         {
           "column": 17,
-          "line": 42,
+          "line": 41,
           "message": "source",
           "span": "git+https://bitbucket.org/marshallpierce/line-wrap-rs#41e42b9d95684d41615dd3d0aeeb1cfc4cc47225"
         },
@@ -171,7 +171,7 @@ expression: diags
       "labels": [
         {
           "column": 12,
-          "line": 88,
+          "line": 86,
           "message": "source",
           "span": "git+https://github.com/EmbarkStudios/spdx?tag=0.3.4#ba8dc9f0b164619771892b865f00236ebbd4cd39"
         }

--- a/tests/snapshots/sources__allows_git.snap
+++ b/tests/snapshots/sources__allows_git.snap
@@ -150,7 +150,7 @@ expression: diags
       "labels": [
         {
           "column": 17,
-          "line": 42,
+          "line": 41,
           "message": "source",
           "span": "git+https://bitbucket.org/marshallpierce/line-wrap-rs#41e42b9d95684d41615dd3d0aeeb1cfc4cc47225"
         },
@@ -189,7 +189,7 @@ expression: diags
       "labels": [
         {
           "column": 12,
-          "line": 88,
+          "line": 86,
           "message": "source",
           "span": "git+https://github.com/EmbarkStudios/spdx?tag=0.3.4#ba8dc9f0b164619771892b865f00236ebbd4cd39"
         }

--- a/tests/snapshots/sources__allows_github_org.snap
+++ b/tests/snapshots/sources__allows_github_org.snap
@@ -138,7 +138,7 @@ expression: diags
       "labels": [
         {
           "column": 17,
-          "line": 42,
+          "line": 41,
           "message": "source",
           "span": "git+https://bitbucket.org/marshallpierce/line-wrap-rs#41e42b9d95684d41615dd3d0aeeb1cfc4cc47225"
         }
@@ -171,7 +171,7 @@ expression: diags
       "labels": [
         {
           "column": 12,
-          "line": 88,
+          "line": 86,
           "message": "source",
           "span": "git+https://github.com/EmbarkStudios/spdx?tag=0.3.4#ba8dc9f0b164619771892b865f00236ebbd4cd39"
         },

--- a/tests/snapshots/sources__allows_gitlab_org.snap
+++ b/tests/snapshots/sources__allows_gitlab_org.snap
@@ -144,7 +144,7 @@ expression: diags
       "labels": [
         {
           "column": 17,
-          "line": 42,
+          "line": 41,
           "message": "source",
           "span": "git+https://bitbucket.org/marshallpierce/line-wrap-rs#41e42b9d95684d41615dd3d0aeeb1cfc4cc47225"
         }
@@ -177,7 +177,7 @@ expression: diags
       "labels": [
         {
           "column": 12,
-          "line": 88,
+          "line": 86,
           "message": "source",
           "span": "git+https://github.com/EmbarkStudios/spdx?tag=0.3.4#ba8dc9f0b164619771892b865f00236ebbd4cd39"
         }

--- a/tests/snapshots/sources__fails_unknown_git.snap
+++ b/tests/snapshots/sources__fails_unknown_git.snap
@@ -132,7 +132,7 @@ expression: diags
       "labels": [
         {
           "column": 17,
-          "line": 42,
+          "line": 41,
           "message": "source",
           "span": "git+https://bitbucket.org/marshallpierce/line-wrap-rs#41e42b9d95684d41615dd3d0aeeb1cfc4cc47225"
         }
@@ -165,7 +165,7 @@ expression: diags
       "labels": [
         {
           "column": 12,
-          "line": 88,
+          "line": 86,
           "message": "source",
           "span": "git+https://github.com/EmbarkStudios/spdx?tag=0.3.4#ba8dc9f0b164619771892b865f00236ebbd4cd39"
         }


### PR DESCRIPTION
This includes the workaround for the [issue](https://github.com/EmbarkStudios/krates/issues/46) originally filed on this repo where certain crate versions can differ between their index entry, and the actual package manifest on disk, which causes cargo metadata to output resolved nodes that can reference features which don't exist in the package. `krates` now uses the actual crates.io registry index as the source of truth, only for features (at least atm) since that was the source of the bug.