### PR TITLE
Update `krates` to 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#475](https://github.com/EmbarkStudios/cargo-deny/pull/475) updated `krates` to 0.12.4, which fixes an issue where cycles in a crate's feature set would result in an infinite loop.
+
 ## [0.13.2] - 2022-11-01
 ### Fixed
 - [PR#473](https://github.com/EmbarkStudios/cargo-deny/pull/473) updated `krates` to 0.12.3, which addresses an issue where a crate's feature set can differ between the version in the registry, and same version on disk.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "krates"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0425cc5541bc7cc1a175907c6c0bd6010e00d6d876fdc894deea03e33a0d1a59"
+checksum = "602dee659d55628741eeab24d262ebf9a3e5b309b7e49f5cc029a70a56df625e"
 dependencies = [
  "cargo_metadata",
  "cfg-expr",


### PR DESCRIPTION
`krates` < 0.12.4 would hang if a crate had cycles in its feature set, bumping to 0.12.4 pulls in https://github.com/EmbarkStudios/krates/pull/49 which fixes that issue.