### PR TITLE
Add security policy supporting GitHub private reporting & Bug Bounty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+- [PR#] This project and repository is now part of our Security Bug Bounty Program and has Private vulnerability reporting enabled. See [`SECURITY.md`](./SECURITY.md) for more details.
+
 ## [0.13.5] - 2022-11-08
 ### Fixed
 - [PR#481](https://github.com/EmbarkStudios/cargo-deny/pull/481) bumped `krates` to 0.12.5 to fix an issue where features present (and enabled) for a crate could be remove if the index entry for the crate didn't contain that feature. The features are now merged to (hopefully) more accurately reflect the features that are "truly" available according to both the index and the actual crate manifest on disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 ### Added
-- [PR#] This project and repository is now part of our Security Bug Bounty Program and has Private vulnerability reporting enabled. See [`SECURITY.md`](./SECURITY.md) for more details.
+- [PR#485](https://github.com/EmbarkStudios/cargo-deny/pull/485) This project and repository is now part of our Security Bug Bounty Program and has Private vulnerability reporting enabled. See [`SECURITY.md`](./SECURITY.md) for more details.
 
 ## [0.13.5] - 2022-11-08
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Protecting your privacy and our products is paramount to establishing trust with
 
 We truly appreciate efforts to discover and disclose security issues responsibly.
 
-If you’re a security researcher looking to submit a report about a security vulnerability, this repository has GitHub's [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) enabled where you directly can submit reports to us privately and securely, as well as optionally create private a fork to help fix the issue.
+If you’re a security researcher looking to submit a report about a security vulnerability, this repository has GitHub's [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) enabled where you directly can submit reports to us privately and securely, as well as optionally create a private fork to help fix the issue.
 
 This is repository is also part of our [Security Bug Bounty Program](https://www.intigriti.com/programs) hosted by Intigriti. Please note that in order to report via Intigriti, you need to be a registered user.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@ Protecting your privacy and our products is paramount to establishing trust with
 
 We truly appreciate efforts to discover and disclose security issues responsibly.
 
-This repository is part of our [Security Bug Bounty Program](https://www.intigriti.com/programs) (hosted by Intigriti) and has GitHub's [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) enabled where you directly can submit vulnerability reports to us privately and securely, as well as optionally create private fork to help fix the issue.
+If you’re a security researcher looking to submit a report about a security vulnerability, this repository has GitHub's [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) enabled where you directly can submit reports to us privately and securely, as well as optionally create private a fork to help fix the issue.
+
+This is repository is also part of our [Security Bug Bounty Program](https://www.intigriti.com/programs) hosted by Intigriti. Please note that in order to report via Intigriti, you need to be a registered user.
 
 If you’d like to report a security issue found in any of our other products or have security concerns regarding Embark Studios, please reach out to security@embark-studios.com.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security policy
+
+Protecting your privacy and our products is paramount to establishing trust with our players and users. Therefore, we consistently tweak and enhance our ways of working with security, and aim to be as transparent as possible about this effort.
+
+We truly appreciate efforts to discover and disclose security issues responsibly.
+
+This repository is part of our [Security Bug Bounty Program](https://www.intigriti.com/programs) (hosted by Intigriti) and has GitHub's [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) enabled where you directly can submit vulnerability reports to us privately and securely, as well as optionally create private fork to help fix the issue.
+
+If you’d like to report a security issue found in any of our other products or have security concerns regarding Embark Studios, please reach out to security@embark-studios.com.


### PR DESCRIPTION
This is an updated version of our [standard security policy](https://github.com/EmbarkStudios/.github/blob/master/SECURITY.md) to be adapted for our repositories that use GitHub's new [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) as well as our Security Bug Bounty Program, which we now use here for cargo-deny :tada: 