### PR TITLE
Add monospace font to SVG code blocks used in README

### DIFF
--- a/docs/src/output/advisories.svg
+++ b/docs/src/output/advisories.svg
@@ -8,7 +8,7 @@
   color: #abb2bf;
   word-break: break-word;
   overflow-wrap: break-word;
-  font-family: Monaco, courier;
+  font-family: Monaco, courier, monospace;
   font-size: 12px;
   line-height: 20px;
   padding: 14px 18px;

--- a/docs/src/output/bans.svg
+++ b/docs/src/output/bans.svg
@@ -8,7 +8,7 @@
   color: #abb2bf;
   word-break: break-word;
   overflow-wrap: break-word;
-  font-family: Monaco, courier;
+  font-family: Monaco, courier, monospace;
   font-size: 12px;
   line-height: 20px;
   padding: 14px 18px;

--- a/docs/src/output/licenses.svg
+++ b/docs/src/output/licenses.svg
@@ -8,7 +8,7 @@
   color: #abb2bf;
   word-break: break-word;
   overflow-wrap: break-word;
-  font-family: Monaco, courier;
+  font-family: Monaco, courier, monospace;
   font-size: 12px;
   line-height: 20px;
   padding: 14px 18px;

--- a/docs/src/output/sources.svg
+++ b/docs/src/output/sources.svg
@@ -8,7 +8,7 @@
   color: #abb2bf;
   word-break: break-word;
   overflow-wrap: break-word;
-  font-family: Monaco, courier;
+  font-family: Monaco, courier, monospace;
   font-size: 12px;
   line-height: 20px;
   padding: 14px 18px;


### PR DESCRIPTION
This PR adds the `monospace` attribute to the `font-family` property in SVGs used in the readme for `cargo-deny` to display correctly on platforms that don't support the `Monaco` and `courier` font definitions.

- https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#values

> `monospace`
>All glyphs have the same fixed width.
>
>For example: Fira Mono, DejaVu Sans Mono, Menlo, Consolas, Liberation Mono, Monaco, Lucida Console, monospace.

| Before                          | After                         |
|---------------------------------|-------------------------------|
| ![Before chnage][before_source] | ![After change][after_source] |

[before_source]: https://cdn.discordapp.com/attachments/343683201874526208/1063518706824654998/image.png
[after_source]: https://cdn.discordapp.com/attachments/343683201874526208/1063520047500365945/image_1.png