### PR TITLE
Allow the config file to live in `.cargo`

### DIFF
--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -87,6 +87,12 @@ impl KrateContext {
                     return Some(config_path);
                 }
 
+                config_path.pop();
+                config_path.push(".cargo/deny.toml");
+                if config_path.exists() {
+                    return Some(config_path);
+                }
+
                 p = parent.parent();
             }
 


### PR DESCRIPTION
Fixes #437

See also #396