### PR TITLE
Add support for sparse indices

### DIFF
--- a/src/advisories.rs
+++ b/src/advisories.rs
@@ -41,9 +41,9 @@ pub fn check<R, S>(
     let emit_audit_compatible_reports = audit_compatible_reporter.is_some();
 
     let (report, yanked) = rayon::join(
-        || Report::generate(advisory_dbs, &ctx.krates, emit_audit_compatible_reports),
+        || Report::generate(advisory_dbs, ctx.krates, emit_audit_compatible_reports),
         || {
-            let indices = Indices::load(&ctx.krates);
+            let indices = Indices::load(ctx.krates);
 
             let yanked: Vec<_> = ctx
                 .krates

--- a/src/advisories/helpers.rs
+++ b/src/advisories/helpers.rs
@@ -1,6 +1,7 @@
 use crate::{Krate, Krates};
 use anyhow::{Context, Error};
 use log::{debug, info};
+use rayon::prelude::*;
 pub use rustsec::{advisory::Id, Database, Lockfile, Vulnerability};
 use std::path::{Path, PathBuf};
 use url::Url;
@@ -631,9 +632,13 @@ pub(super) enum Index {
     Http(crates_index::SparseIndex),
 }
 
-impl Index {
-    fn load_all(krates: &Krates) -> anyhow::Result<Vec<Self>> {
-        let mut indices = Vec::<(&Url, Index)>::new();
+pub(super) struct Indices<'k> {
+    indices: Vec<(&'k Url, Option<Index>)>,
+}
+
+impl<'k> Indices<'k> {
+    pub(super) fn load(krates: &'k Krates) -> Self {
+        let mut indices = Vec::<(&Url, Option<Index>)>::new();
         for (krate, source) in krates
             .krates()
             .filter_map(|k| k.source.as_ref().map(|s| (k, s)))
@@ -645,83 +650,233 @@ impl Index {
                 continue;
             }
 
-            let index = match source.source_id {
+            let index = match &source.source_id {
                 crate::SourceId::Sparse(sparse) => {
                     let surl = format!("sparse+{sparse}");
-                    Index::Http(crates_index::SparseIndex::from_url(&surl).with_context(|| {
-                        format!("failed to load sparse index '{surl}' used by crate {krate}")
-                    })?)
+                    match crates_index::SparseIndex::from_url(&surl) {
+                        Ok(index) => Some(Index::Http(index)),
+                        Err(err) => {
+                            log::warn!("failed to load sparse index '{surl}' used by crate '{krate}': {err}");
+                            None
+                        }
+                    }
                 }
                 crate::SourceId::Rustsec(ssi) => {
                     let gindex = if ssi.is_default_registry() {
-                        crates_index::Index::new_cargo_default().with_context(|| {
-                            format!("failed to load crates.io index used by crate {krate}")
-                        })?
+                        match crates_index::Index::new_cargo_default() {
+                            Ok(i) => Some(i),
+                            Err(err) => {
+                                log::warn!(
+                                    "failed to load crates.io index used by crate '{krate}': {err}"
+                                );
+                                None
+                            }
+                        }
                     } else {
-                        crates_index::Index::from_url(ssi.url().as_str()).with_context(|| {
-                            format!("failed to load index '{ssi}' used by crate {krate}")
-                        })?
+                        match crates_index::Index::from_url(ssi.url().as_str()) {
+                            Ok(i) => Some(i),
+                            Err(err) => {
+                                log::warn!(
+                                    "failed to load index '{ssi}' used by crate '{krate}': {err}"
+                                );
+                                None
+                            }
+                        }
                     };
 
-                    Index::Git(gindex)
+                    gindex.map(Index::Git)
                 }
             };
 
             indices.push((&source.url, index));
         }
 
-        Ok(indices.into_iter().map(|(url, index)| index).collect())
+        Self { indices }
+    }
+
+    #[inline]
+    pub(super) fn is_yanked(&self, krate: &Krate) -> anyhow::Result<bool> {
+        // Ignore non-registry crates when checking, as a crate sourced
+        // locally or via git can have the same name as a registry package
+        let Some(src) = krate.source.as_ref().filter(|s| s.is_registry()) else { return Ok(false) };
+
+        let index = self
+            .indices
+            .iter()
+            .find_map(|(url, index)| {
+                index
+                    .as_ref()
+                    .filter(|_i| (src.url.as_str() == url.as_str()))
+            })
+            .context("failed to load source index")?;
+
+        let index_krate = match index {
+            Index::Git(gindex) => gindex
+                .crate_(&krate.name)
+                .context("failed to find crate in git index")?,
+            Index::Http(hindex) => hindex
+                .crate_from_cache(&krate.name)
+                .context("failed to find crate in sparse index")?,
+        };
+
+        Ok(index_krate
+            .versions()
+            .iter()
+            .any(|kv| kv.version() == krate.version.to_string() && kv.is_yanked()))
     }
 }
 
 pub use rustsec::{Warning, WarningKind};
 
-pub struct Report {
-    pub vulnerabilities: Vec<Vulnerability>,
-    pub notices: Vec<Warning>,
-    pub unmaintained: Vec<Warning>,
-    pub unsound: Vec<Warning>,
+pub struct Report<'db, 'k> {
+    pub advisories: Vec<(&'k Krate, krates::NodeId, &'db rustsec::Advisory)>,
     /// For backwards compatiblity with cargo-audit, we optionally serialize the
     /// reports to JSON and output them in addition to the normal cargo-deny
     /// diagnostics
     pub serialized_reports: Vec<serde_json::Value>,
 }
 
-impl Report {
-    pub fn generate(advisory_dbs: &DbSet, krates: &Krates, serialize_reports: bool) -> Self {
-        use rustsec::advisory::Informational;
-
-        let settings = rustsec::report::Settings {
-            // We already prune packages we don't care about, so don't filter
-            // any here
-            target_arch: None,
-            target_os: None,
-            // We handle the severity ourselves
-            severity: None,
-            // We handle the ignoring of particular advisory ids ourselves
-            ignore: Vec::new(),
-            informational_warnings: vec![
-                Informational::Notice,
-                Informational::Unmaintained,
-                Informational::Unsound,
-                //Informational::Other("*"),
-            ],
-        };
-
-        let mut vulnerabilities = Vec::new();
-        let mut notices = Vec::new();
-        let mut unmaintained = Vec::new();
-        let mut unsound = Vec::new();
+impl<'db, 'k> Report<'db, 'k> {
+    pub fn generate(advisory_dbs: &'db DbSet, krates: &'k Krates, serialize_reports: bool) -> Self {
         let mut serialized_reports = Vec::with_capacity(if serialize_reports {
             advisory_dbs.dbs.len()
         } else {
             0
         });
 
-        for (url, db) in advisory_dbs.iter() {
-            let mut rep = rustsec::Report::generate(db, &lockfile.0, &settings);
+        // We just use rustsec::Report directly to avoid divergence with cargo-audit,
+        // but since we operate differently we need to do shenanigans
+        let fake_lockfile = serialize_reports.then(|| {
+            // This is really gross, but the only field is private :p
+            let lfi: rustsec::report::LockfileInfo = serde_json::from_value(serde_json::json!({
+                "dependency-count": krates.len()
+            }))
+            .expect("check the definition of rustsec::report::LockfileInfo, it's been changed");
 
-            if serialize_reports {
+            lfi
+        });
+
+        let mut advisories = Vec::new();
+
+        for (url, db) in advisory_dbs.iter() {
+            // Ugh, db exposes advisories as a slice iter which rayon doesn't have an impl for :(
+            let mut db_advisories: Vec<_> = db
+                .iter()
+                .par_bridge()
+                .filter(|advisory| {
+                    if let Some(wdate) = &advisory.metadata.withdrawn {
+                        log::trace!(
+                            "ignoring advisory '{}', withdrawn {wdate}",
+                            advisory.metadata.id
+                        );
+                        return false;
+                    }
+
+                    // TODO: Support Rust std/core advisories at some point, but
+                    // AFAIK rustsec/cargo-audit doesn't support checking for them either
+                    advisory
+                        .metadata
+                        .collection
+                        .map_or(true, |c| c == rustsec::Collection::Crates)
+                })
+                .flat_map(|advisory| {
+                    krates
+                        .krates_by_name(advisory.metadata.package.as_str())
+                        .par_bridge()
+                        .filter_map(move |(nid, krate)| {
+                            let ksrc = krate.source.as_ref()?;
+
+                            // Validate the crate's source is the same as the advisory
+                            if !(advisory.metadata.collection.is_some() && ksrc.is_crates_io()) {
+                                if !ksrc.is_registry()
+                                    || !advisory
+                                        .metadata
+                                        .source
+                                        .as_ref()
+                                        .map_or(false, |sid| sid.url() == &ksrc.url)
+                                {
+                                    return None;
+                                }
+                            }
+
+                            // Ensure the crate's version is actually affected
+                            if !advisory.versions.is_vulnerable(&krate.version) {
+                                return None;
+                            }
+
+                            Some((krate, nid, advisory))
+                        })
+                })
+                .collect();
+
+            if let Some(lockfile) = fake_lockfile.clone() {
+                let mut warnings = std::collections::BTreeMap::<_, Vec<rustsec::Warning>>::new();
+                let mut vulns = Vec::new();
+
+                for (krate, _nid, advisory) in &db_advisories {
+                    let package = rustsec::package::Package {
+                        // :(
+                        name: krate.name.parse().unwrap(),
+                        version: krate.version.clone(),
+                        source: krate.source.as_ref().map(|s| s.to_rustsec()),
+                        // TODO: Get this info from the lockfile
+                        checksum: None,
+                        dependencies: Vec::new(),
+                        replace: None,
+                    };
+
+                    if let Some(kind) = advisory
+                        .metadata
+                        .informational
+                        .as_ref()
+                        .and_then(|i| i.warning_kind())
+                    {
+                        let warning = rustsec::Warning {
+                            kind,
+                            package,
+                            advisory: Some(advisory.metadata.clone()),
+                            versions: Some(advisory.versions.clone()),
+                        };
+
+                        if let Some(v) = warnings.get_mut(&kind) {
+                            v.push(warning);
+                        } else {
+                            warnings.insert(kind, vec![warning]);
+                        }
+                    } else {
+                        // Note we don't use new here since it takes references and just clones :p
+                        vulns.push(rustsec::Vulnerability {
+                            advisory: advisory.metadata.clone(),
+                            versions: advisory.versions.clone(),
+                            affected: advisory.affected.clone(),
+                            package,
+                        });
+                    }
+                }
+
+                use rustsec::advisory::Informational;
+                let rep = rustsec::Report {
+                    settings: rustsec::report::Settings {
+                        // We already prune packages we don't care about, so don't filter
+                        // any here
+                        target_arch: None,
+                        target_os: None,
+                        // We handle the severity ourselves
+                        severity: None,
+                        // We handle the ignoring of particular advisory ids ourselves
+                        ignore: Vec::new(),
+                        informational_warnings: vec![
+                            Informational::Notice,
+                            Informational::Unmaintained,
+                            Informational::Unsound,
+                            //Informational::Other("*"),
+                        ],
+                    },
+                    lockfile,
+                    vulnerabilities: rustsec::report::VulnerabilityInfo::new(vulns),
+                    warnings,
+                };
+
                 match serde_json::to_value(&rep) {
                     Ok(val) => serialized_reports.push(val),
                     Err(err) => {
@@ -730,41 +885,13 @@ impl Report {
                 }
             }
 
-            vulnerabilities.append(&mut rep.vulnerabilities.list);
-
-            for (kind, mut wi) in rep.warnings {
-                if wi.is_empty() {
-                    continue;
-                }
-
-                match kind {
-                    WarningKind::Notice => notices.append(&mut wi),
-                    WarningKind::Unmaintained => unmaintained.append(&mut wi),
-                    WarningKind::Unsound => unsound.append(&mut wi),
-                    _ => unreachable!(),
-                }
-            }
+            advisories.append(&mut db_advisories);
         }
 
         Self {
-            vulnerabilities,
-            notices,
-            unmaintained,
-            unsound,
+            advisories,
             serialized_reports,
         }
-    }
-
-    pub fn iter_warnings(&self) -> impl Iterator<Item = (WarningKind, &Warning)> {
-        self.notices
-            .iter()
-            .map(|wi| (WarningKind::Notice, wi))
-            .chain(
-                self.unmaintained
-                    .iter()
-                    .map(|wi| (WarningKind::Unmaintained, wi)),
-            )
-            .chain(self.unsound.iter().map(|wi| (WarningKind::Unsound, wi)))
     }
 }
 

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -183,7 +183,7 @@ impl KrateSpans {
         for krate in krates {
             let span_start = sl.len();
             match &krate.source {
-                Some(src) => writeln!(sl, "{} {} {}", krate.name, krate.version, src.source_id)
+                Some(src) => writeln!(sl, "{} {} {}", krate.name, krate.version, src)
                     .expect("unable to synthesize lockfile"),
                 None => writeln!(
                     sl,

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -284,10 +284,11 @@ pub fn check(
         // a help message that we skipped it
         if ctx.cfg.private.ignore
             && (krate_lic_nfo.krate.is_private(&private_registries)
-                || krate_lic_nfo
-                    .krate
-                    .normalized_source_url()
-                    .map_or(false, |source| ctx.cfg.ignore_sources.contains(&source)))
+                || ctx
+                    .cfg
+                    .ignore_sources
+                    .iter()
+                    .any(|url| krate_lic_nfo.krate.matches_url(url, true)))
         {
             pack.push(diags::SkippedPrivateWorkspaceCrate {
                 krate: krate_lic_nfo.krate,

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -201,7 +201,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
         for aurl in &self.private.ignore_sources {
             match url::Url::parse(aurl.as_ref()) {
                 Ok(mut url) => {
-                    crate::sources::normalize_url(&mut url);
+                    crate::normalize_url(&mut url);
                     ignore_sources.push(url);
                 }
                 Err(pe) => {

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -201,7 +201,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
         for aurl in &self.private.ignore_sources {
             match url::Url::parse(aurl.as_ref()) {
                 Ok(mut url) => {
-                    crate::normalize_url(&mut url);
+                    crate::normalize_git_url(&mut url);
                     ignore_sources.push(url);
                 }
                 Err(pe) => {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -59,20 +59,9 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
         // get allowed list of sources to check
         let (lint_level, type_name) = if source.is_registry() {
             (ctx.cfg.unknown_registry, "registry")
-        } else if let Some(git_url) = source.url().filter(|_| source.is_git()) {
+        } else if let Some(spec) = source.git_spec() {
             // Ensure the git source has at least the minimum specification
             if let Some((min, cfg_coord)) = &min_git_spec {
-                let mut spec = GitSpec::Any;
-
-                for (k, _v) in git_url.query_pairs() {
-                    spec = match k.as_ref() {
-                        "branch" | "ref" => GitSpec::Branch,
-                        "tag" => GitSpec::Tag,
-                        "rev" => GitSpec::Rev,
-                        _ => continue,
-                    };
-                }
-
                 if spec < *min {
                     pack.push(diags::BelowMinimumRequiredSpec {
                         src_label: &source_label,

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -7,7 +7,6 @@ use crate::{
     diag::{CfgCoord, Check, ErrorSink, Label, Pack},
     LintLevel,
 };
-use url::Url;
 
 const CRATES_IO_URL: &str = "https://github.com/rust-lang/crates.io-index";
 
@@ -44,12 +43,6 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
             None => continue,
         };
 
-        // get URL without git revision (query & fragment)
-        // example URL in Cargo.lock: https://github.com/RustSec/rustsec-crate.git?rev=aaba369#aaba369bebc4fcfb9133b1379bcf430b707188a2
-        // where we only want:        https://github.com/RustSec/rustsec-crate.git
-        // Unwrap is ok since we already know we have a source
-        let source_url = krate.normalized_source_url().unwrap();
-
         let mut pack = Pack::with_kid(Check::Sources, krate.id.clone());
 
         let source_label = {
@@ -66,12 +59,12 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
         // get allowed list of sources to check
         let (lint_level, type_name) = if source.is_registry() {
             (ctx.cfg.unknown_registry, "registry")
-        } else if source.is_git() {
+        } else if let Some(git_url) = source.url().filter(|_| source.is_git()) {
             // Ensure the git source has at least the minimum specification
             if let Some((min, cfg_coord)) = &min_git_spec {
                 let mut spec = GitSpec::Any;
 
-                for (k, _v) in source.url.query_pairs() {
+                for (k, _v) in git_url.query_pairs() {
                     spec = match k.as_ref() {
                         "branch" | "ref" => GitSpec::Branch,
                         "tag" => GitSpec::Tag,
@@ -96,68 +89,69 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
         };
 
         // check if the source URL is list of allowed sources
-        if let Some(ind) = ctx.cfg.allowed_sources.iter().position(|src| {
-            if src.exact {
-                src.url == source_url
-            } else {
-                source_url.host() == src.url.value.host()
-                    && source_url.path().starts_with(src.url.value.path())
-            }
-        }) {
+        let diag: crate::diag::Diag = if let Some(ind) = ctx
+            .cfg
+            .allowed_sources
+            .iter()
+            .position(|src| krate.matches_url(&src.url.value, src.exact))
+        {
+            source_hits.as_mut_bitslice().set(ind, true);
+
             // Show the location of the config that allowed this source, unless
             // it's crates.io since that will be a vast majority of crates and
             // is the default, so we might not have a real source location anyways
-            if source_url.as_str() != CRATES_IO_URL {
-                pack.push(diags::ExplicitlyAllowedSource {
-                    src_label: &source_label,
-                    type_name,
-                    allow_cfg: CfgCoord {
-                        file: ctx.cfg.file_id,
-                        span: ctx.cfg.allowed_sources[ind].url.span.clone(),
-                    },
-                });
+            if krate.is_crates_io() {
+                continue;
             }
 
-            source_hits.as_mut_bitslice().set(ind, true);
-        } else {
-            let diag: crate::diag::Diag = match get_org(&source_url) {
-                Some((orgt, orgname)) => {
-                    match ctx.cfg.allowed_orgs.iter().position(|(sorgt, sorgn)| {
-                        orgt == *sorgt && sorgn.value.as_str() == orgname
-                    }) {
-                        Some(ind) => {
-                            org_hits.as_mut_bitslice().set(ind, true);
-                            diags::SourceAllowedByOrg {
-                                src_label: &source_label,
-                                org_cfg: CfgCoord {
-                                    file: ctx.cfg.file_id,
-                                    span: ctx.cfg.allowed_orgs[ind].1.span.clone(),
-                                },
-                            }
-                            .into()
-                        }
-                        None => diags::SourceNotExplicitlyAllowed {
-                            src_label: &source_label,
-                            lint_level,
-                            type_name,
-                        }
-                        .into(),
-                    }
+            diags::ExplicitlyAllowedSource {
+                src_label: &source_label,
+                type_name,
+                allow_cfg: CfgCoord {
+                    file: ctx.cfg.file_id,
+                    span: ctx.cfg.allowed_sources[ind].url.span.clone(),
+                },
+            }
+            .into()
+        } else if let Some((orgt, orgname)) = krate
+            .source
+            .as_ref()
+            .and_then(|s| s.url().and_then(|u| get_org(u)))
+        {
+            if let Some(ind) = ctx
+                .cfg
+                .allowed_orgs
+                .iter()
+                .position(|(sorgt, sorgn)| orgt == *sorgt && sorgn.value.as_str() == orgname)
+            {
+                org_hits.as_mut_bitslice().set(ind, true);
+                diags::SourceAllowedByOrg {
+                    src_label: &source_label,
+                    org_cfg: CfgCoord {
+                        file: ctx.cfg.file_id,
+                        span: ctx.cfg.allowed_orgs[ind].1.span.clone(),
+                    },
                 }
-                None => diags::SourceNotExplicitlyAllowed {
+                .into()
+            } else {
+                diags::SourceNotExplicitlyAllowed {
                     src_label: &source_label,
                     lint_level,
                     type_name,
                 }
-                .into(),
-            };
+                .into()
+            }
+        } else {
+            diags::SourceNotExplicitlyAllowed {
+                src_label: &source_label,
+                lint_level,
+                type_name,
+            }
+            .into()
+        };
 
-            pack.push(diag);
-        }
-
-        if !pack.is_empty() {
-            sink.push(pack);
-        }
+        pack.push(diag);
+        sink.push(pack);
     }
 
     let mut pack = Pack::new(Check::Sources);
@@ -197,23 +191,6 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
 
     if !pack.is_empty() {
         sink.push(pack);
-    }
-}
-
-pub(crate) fn normalize_url(url: &mut Url) {
-    // Normalizes the URL so that different representations can be compared to each other.
-    // At the moment we just remove a tailing `.git` but there are more possible optimisations.
-    // See https://github.com/rust-lang/cargo/blob/1f6c6bd5e7bbdf596f7e88e6db347af5268ab113/src/cargo/util/canonical_url.rs#L31-L57
-    // for what cargo does
-
-    let git_extension = ".git";
-    let needs_chopping = url.path().ends_with(&git_extension);
-    if needs_chopping {
-        let last = {
-            let last = url.path_segments().unwrap().last().unwrap();
-            last[..last.len() - git_extension.len()].to_owned()
-        };
-        url.path_segments_mut().unwrap().pop().push(&last);
     }
 }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -105,7 +105,7 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
         } else if let Some((orgt, orgname)) = krate
             .source
             .as_ref()
-            .and_then(|s| s.url().and_then(|u| get_org(u)))
+            .and_then(|s| s.url().and_then(get_org))
         {
             if let Some(ind) = ctx
                 .cfg

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -64,9 +64,9 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
         };
 
         // get allowed list of sources to check
-        let (lint_level, type_name) = if source.source_id.is_registry() {
+        let (lint_level, type_name) = if source.is_registry() {
             (ctx.cfg.unknown_registry, "registry")
-        } else if source.source_id.is_git() {
+        } else if source.is_git() {
             // Ensure the git source has at least the minimum specification
             if let Some((min, cfg_coord)) = &min_git_spec {
                 let mut spec = GitSpec::Any;

--- a/src/sources/cfg.rs
+++ b/src/sources/cfg.rs
@@ -1,4 +1,4 @@
-use super::{normalize_url, OrgType};
+use super::OrgType;
 use crate::{cfg, diag::FileId, LintLevel, Spanned};
 use serde::Deserialize;
 
@@ -121,7 +121,7 @@ impl cfg::UnvalidatedConfig for Config {
         {
             match url::Url::parse(aurl.as_ref()) {
                 Ok(mut url) => {
-                    normalize_url(&mut url);
+                    crate::normalize_url(&mut url);
                     allowed_sources.push(UrlSource {
                         url: UrlSpan {
                             value: url,

--- a/src/sources/cfg.rs
+++ b/src/sources/cfg.rs
@@ -121,7 +121,7 @@ impl cfg::UnvalidatedConfig for Config {
         {
             match url::Url::parse(aurl.as_ref()) {
                 Ok(mut url) => {
-                    crate::normalize_url(&mut url);
+                    crate::normalize_git_url(&mut url);
                     allowed_sources.push(UrlSource {
                         url: UrlSpan {
                             value: url,


### PR DESCRIPTION
This PR adds support for sparse indices in preparation for them becoming the default in some future version of cargo. This also fixes an issue where crates yanked from non-crates.io registries would not be detected, but I'm not surprised no one ever reported this considering how niche that would be.

While it looks like this is adding a lot of code, it's not really that much, and importantly moves source ids to be completely independent from rustsec so that we can iterate and push changes without being blocked.

Resolves: #500 