### PR TITLE
Replace atty with is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,17 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,7 +266,6 @@ version = "0.13.8"
 dependencies = [
  "anyhow",
  "askalono",
- "atty",
  "bitvec",
  "cargo",
  "clap",
@@ -289,6 +277,7 @@ dependencies = [
  "git2",
  "home",
  "insta",
+ "is-terminal",
  "krates",
  "log",
  "nu-ansi-term",
@@ -1044,15 +1033,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ anyhow = "1.0"
 # Used for detecting the license type of a file
 askalono = "0.4"
 # Used to detect if an output stream is a TTY to control default coloring
-atty = "0.2"
+is-terminal = "0.4.6"
 # Used to track various things during check runs
 bitvec = { version = "1.0", features = ["alloc"] }
 # Allows us to do eg cargo metadata operations without relying on an external cargo

--- a/deny.toml
+++ b/deny.toml
@@ -14,9 +14,6 @@ unmaintained = "deny"
 notice = "deny"
 unsound = "deny"
 ignore = [
-    # potential unaligned pointer read on windows. Doesn't happen in practice, don't
-    # care
-    "RUSTSEC-2021-0145",
     # rmp-serde used by askalono for the cache files, these are always utf-8 so
     # the advisory is not relevant
     "RUSTSEC-2022-0092",

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -7,6 +7,7 @@ use cargo_deny::{
     },
     licenses, sources, CheckCtx,
 };
+use is_terminal::IsTerminal as _;
 use log::error;
 use serde::Deserialize;
 use std::{path::PathBuf, time::Instant};
@@ -471,7 +472,7 @@ pub(crate) fn cmd(
 
     let colorize = log_ctx.format == crate::Format::Human
         && match log_ctx.color {
-            crate::Color::Auto => atty::is(atty::Stream::Stderr),
+            crate::Color::Auto => std::io::stderr().is_terminal(),
             crate::Color::Always => true,
             crate::Color::Never => false,
         };

--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
-
 use cargo_deny::{
     diag::{self, FileId, Files, Severity},
     licenses::LicenseStore,
 };
+use is_terminal::IsTerminal;
+use std::path::PathBuf;
 
 pub(crate) fn load_license_store() -> Result<LicenseStore, anyhow::Error> {
     log::debug!("loading license store...");
@@ -272,12 +272,12 @@ pub fn log_level_to_severity(log_level: log::LevelFilter) -> Option<Severity> {
 use codespan_reporting::term::{self, termcolor::ColorChoice};
 use std::io::Write;
 
-fn color_to_choice(color: crate::Color, stream: atty::Stream) -> ColorChoice {
+fn color_to_choice(color: crate::Color, stream: impl IsTerminal) -> ColorChoice {
     match color {
         crate::Color::Auto => {
             // The termcolor crate doesn't check the stream to see if it's a TTY
             // which doesn't really fit with how the rest of the coloring works
-            if atty::is(stream) {
+            if stream.is_terminal() {
                 ColorChoice::Auto
             } else {
                 ColorChoice::Never
@@ -476,7 +476,7 @@ impl<'a> DiagPrinter<'a> {
             crate::Format::Human => {
                 let stream = term::termcolor::StandardStream::stderr(color_to_choice(
                     ctx.color,
-                    atty::Stream::Stderr,
+                    std::io::stderr(),
                 ));
 
                 Self {

--- a/src/cargo-deny/list.rs
+++ b/src/cargo-deny/list.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Error};
 use cargo_deny::{diag::Files, licenses, Kid};
+use is_terminal::IsTerminal as _;
 use nu_ansi_term::Color;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -250,7 +251,7 @@ pub fn cmd(
             let color = match log_ctx.color {
                 crate::Color::Always => true,
                 crate::Color::Never => false,
-                crate::Color::Auto => atty::is(atty::Stream::Stdout),
+                crate::Color::Auto => std::io::stdout().is_terminal(),
             };
 
             match args.layout {

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Context, Error};
 use clap::{Parser, Subcommand, ValueEnum};
+use is_terminal::IsTerminal as _;
 use std::path::PathBuf;
 
 mod check;
@@ -231,7 +232,7 @@ fn real_main() -> Result<(), Error> {
     let log_level = args.log_level;
 
     let color = match args.color {
-        Color::Auto => atty::is(atty::Stream::Stderr),
+        Color::Auto => std::io::stderr().is_terminal(),
         Color::Always => true,
         Color::Never => false,
     };

--- a/src/cargo-deny/stats.rs
+++ b/src/cargo-deny/stats.rs
@@ -1,4 +1,5 @@
 use crate::Format;
+use is_terminal::IsTerminal as _;
 use nu_ansi_term::Color;
 use serde::Serialize;
 
@@ -46,7 +47,7 @@ pub(crate) fn print_stats(
             let mut summary = String::new();
 
             let color = match color {
-                crate::Color::Auto => atty::is(atty::Stream::Stdout),
+                crate::Color::Auto => std::io::stdout().is_terminal(),
                 crate::Color::Always => true,
                 crate::Color::Never => false,
             };


### PR DESCRIPTION
Replaces atty with is-terminal, as atty is unmaintained.