### PR TITLE
Fix root config casing

### DIFF
--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -113,6 +113,7 @@ pub struct Args {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
     advisories: Option<advisories::cfg::Config>,
     bans: Option<bans::cfg::Config>,


### PR DESCRIPTION
The root config wasn't properly kebab-cased like all other sub configs, nor would it fail to parse if there were unrecognized fields.

Resolves: #509 