### PR TITLE
Only ignore root-level target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/target
+/target
 **/*.rs.bk
 /examples/06_advisories/target
 scripts/check


### PR DESCRIPTION
Reason: When running `cargo vendor`, some of the dependencies have
"target" directories that should *not* be ignored: platforms-3.0.2 and cargo-0.69.1