### PR TITLE
Add trusted crate publishers

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2,3 +2,351 @@
 # cargo-vet audits file
 
 [audits]
+
+[[trusted.aho-corasick]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-28"
+end = "2024-06-05"
+
+[[trusted.anstream]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-16"
+end = "2024-06-07"
+
+[[trusted.anstyle]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-05-18"
+end = "2024-06-07"
+
+[[trusted.anstyle-parse]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-08"
+end = "2024-06-07"
+
+[[trusted.anstyle-wincon]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-08"
+end = "2024-06-07"
+
+[[trusted.bstr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-02"
+end = "2024-06-05"
+
+[[trusted.byteorder]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2024-06-05"
+
+[[trusted.bytes]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2021-01-11"
+end = "2024-06-07"
+
+[[trusted.cfg-expr]]
+criteria = "safe-to-deploy"
+user-id = 52553 # embark-studios
+start = "2020-01-09"
+end = "2024-06-07"
+
+[[trusted.clap]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-12-08"
+end = "2024-06-07"
+
+[[trusted.clap_builder]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-28"
+end = "2024-06-07"
+
+[[trusted.clap_derive]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-12-08"
+end = "2024-06-07"
+
+[[trusted.clap_lex]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-04-15"
+end = "2024-06-07"
+
+[[trusted.concolor-override]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-08"
+end = "2024-06-07"
+
+[[trusted.concolor-query]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-08-04"
+end = "2024-06-07"
+
+[[trusted.curl]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-12"
+end = "2024-06-07"
+
+[[trusted.curl-sys]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-12"
+end = "2024-06-07"
+
+[[trusted.filetime]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-04-23"
+end = "2024-06-05"
+
+[[trusted.globset]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-15"
+end = "2024-06-05"
+
+[[trusted.ignore]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-15"
+end = "2024-06-05"
+
+[[trusted.io-lifetimes]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-06-12"
+end = "2024-06-07"
+
+[[trusted.is-terminal]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2022-01-22"
+end = "2024-06-07"
+
+[[trusted.itoa]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2024-06-05"
+
+[[trusted.jobserver]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-15"
+end = "2024-06-05"
+
+[[trusted.krates]]
+criteria = "safe-to-deploy"
+user-id = 52553 # embark-studios
+start = "2020-01-14"
+end = "2024-06-07"
+
+[[trusted.kstring]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2020-03-16"
+end = "2024-06-07"
+
+[[trusted.libnghttp2-sys]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-08-13"
+end = "2024-06-05"
+
+[[trusted.libz-sys]]
+criteria = "safe-to-deploy"
+user-id = 4333 # Josh Triplett (joshtriplett)
+start = "2020-08-14"
+end = "2024-06-07"
+
+[[trusted.linux-raw-sys]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-06-12"
+end = "2024-06-07"
+
+[[trusted.memchr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-07"
+end = "2024-06-05"
+
+[[trusted.num_cpus]]
+criteria = "safe-to-deploy"
+user-id = 359 # Sean McArthur (seanmonstar)
+start = "2019-06-10"
+end = "2024-06-07"
+
+[[trusted.openssl-src]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-02-25"
+end = "2024-06-07"
+
+[[trusted.paste]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-19"
+end = "2024-06-05"
+
+[[trusted.regex]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-27"
+end = "2024-06-05"
+
+[[trusted.regex-automata]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-25"
+end = "2024-06-05"
+
+[[trusted.regex-syntax]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-30"
+end = "2024-06-05"
+
+[[trusted.rustix]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-10-29"
+end = "2024-06-07"
+
+[[trusted.rustversion]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-07-08"
+end = "2024-06-05"
+
+[[trusted.ryu]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2024-06-05"
+
+[[trusted.same-file]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-16"
+end = "2024-06-05"
+
+[[trusted.scopeguard]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2020-02-16"
+end = "2024-06-05"
+
+[[trusted.serde]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2024-06-05"
+
+[[trusted.serde_derive]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2024-06-05"
+
+[[trusted.serde_ignored]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-08-18"
+end = "2024-06-05"
+
+[[trusted.serde_json]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-02-28"
+end = "2024-06-05"
+
+[[trusted.serde_spanned]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-01-20"
+end = "2024-06-07"
+
+[[trusted.spdx]]
+criteria = "safe-to-deploy"
+user-id = 52553 # embark-studios
+start = "2019-10-03"
+end = "2024-06-07"
+
+[[trusted.syn]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2024-06-05"
+
+[[trusted.tar]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2024-06-05"
+
+[[trusted.target-lexicon]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2019-03-06"
+end = "2024-06-07"
+
+[[trusted.termcolor]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-04"
+end = "2024-06-05"
+
+[[trusted.thread_local]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2019-09-07"
+end = "2024-06-05"
+
+[[trusted.toml]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-05-16"
+end = "2024-06-05"
+
+[[trusted.toml]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-12-14"
+end = "2024-06-07"
+
+[[trusted.toml_edit]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-09-13"
+end = "2024-06-07"
+
+[[trusted.walkdir]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2024-06-05"
+
+[[trusted.winapi-util]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2020-01-11"
+end = "2024-06-05"
+
+[[trusted.winnow]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-02-22"
+end = "2024-06-07"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.6"
+version = "0.7"
 
 [imports.embark]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
@@ -28,9 +28,17 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [policy.cargo-deny]
 audit-as-crates-io = false
 
+[policy.errno-dragonfly]
+criteria = []
+notes = "Not used, unsupported target"
+
 [policy.js-sys]
 criteria = []
 notes = "Not used, web WASM-only"
+
+[policy.wasi]
+criteria = []
+notes = "Not used, unsupported target"
 
 [policy.wasm-bindgen]
 criteria = []
@@ -50,26 +58,6 @@ notes = "Not used, web WASM-only"
 
 [[exemptions.adler]]
 version = "1.0.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.aho-corasick]]
-version = "0.7.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.anstream]]
-version = "0.2.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.anstyle]]
-version = "0.3.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.anstyle-parse]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.anstyle-wincon]]
-version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.arrayvec]]
@@ -104,18 +92,6 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.bstr]]
-version = "1.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.byteorder]]
-version = "1.4.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.bytes]]
-version = "1.2.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.bytesize]]
 version = "1.2.0"
 criteria = "safe-to-deploy"
@@ -136,26 +112,6 @@ criteria = "safe-to-deploy"
 version = "1.0.79"
 criteria = "safe-to-deploy"
 
-[[exemptions.cfg-expr]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap]]
-version = "4.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_builder]]
-version = "4.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_derive]]
-version = "4.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_lex]]
-version = "0.4.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.codespan]]
 version = "0.11.1"
 criteria = "safe-to-deploy"
@@ -170,14 +126,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.commoncrypto-sys]]
 version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.concolor-override]]
-version = "1.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.concolor-query]]
-version = "0.3.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.const-oid]]
@@ -236,10 +184,6 @@ criteria = "safe-to-deploy"
 version = "0.4.44"
 criteria = "safe-to-deploy"
 
-[[exemptions.curl-sys]]
-version = "0.4.61+curl-8.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.cvss]]
 version = "2.0.0"
 criteria = "safe-to-deploy"
@@ -272,20 +216,12 @@ criteria = "safe-to-run"
 version = "0.9.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.errno-dragonfly]]
-version = "0.1.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.fern]]
 version = "0.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.ff]]
 version = "0.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.filetime]]
-version = "0.2.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.fixedbitset]]
@@ -324,10 +260,6 @@ criteria = "safe-to-deploy"
 version = "0.17.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.globset]]
-version = "0.4.10"
-criteria = "safe-to-deploy"
-
 [[exemptions.group]]
 version = "0.12.0"
 criteria = "safe-to-deploy"
@@ -364,10 +296,6 @@ criteria = "safe-to-deploy"
 version = "2.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.ignore]]
-version = "0.4.20"
-criteria = "safe-to-deploy"
-
 [[exemptions.im-rc]]
 version = "15.1.0"
 criteria = "safe-to-deploy"
@@ -384,32 +312,8 @@ criteria = "safe-to-run"
 version = "0.1.12"
 criteria = "safe-to-deploy"
 
-[[exemptions.io-lifetimes]]
-version = "1.0.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.is-terminal]]
-version = "0.4.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.itertools]]
 version = "0.10.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.itoa]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.jobserver]]
-version = "0.1.26"
-criteria = "safe-to-deploy"
-
-[[exemptions.krates]]
-version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.kstring]]
-version = "2.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.lazycell]]
@@ -424,24 +328,8 @@ criteria = "safe-to-deploy"
 version = "0.14.1+1.5.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.libnghttp2-sys]]
-version = "0.1.7+1.45.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.libssh2-sys]]
 version = "0.2.23"
-criteria = "safe-to-deploy"
-
-[[exemptions.libz-sys]]
-version = "1.1.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.linux-raw-sys]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.memchr]]
-version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.memoffset]]
@@ -460,10 +348,6 @@ criteria = "safe-to-deploy"
 version = "0.47.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.num_cpus]]
-version = "1.13.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.once_cell]]
 version = "1.15.0"
 criteria = "safe-to-deploy"
@@ -478,10 +362,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.openssl-macros]]
 version = "0.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.openssl-src]]
-version = "111.25.2+1.1.1t"
 criteria = "safe-to-deploy"
 
 [[exemptions.openssl-sys]]
@@ -506,10 +386,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.pasetors]]
 version = "0.6.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.paste]]
-version = "1.0.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.pathdiff]]
@@ -549,23 +425,11 @@ version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
-version = "0.2.16"
+version = "0.2.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
 version = "0.3.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex]]
-version = "1.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-automata]]
-version = "0.1.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-syntax]]
-version = "0.6.27"
 criteria = "safe-to-deploy"
 
 [[exemptions.rfc6979]]
@@ -580,72 +444,24 @@ criteria = "safe-to-deploy"
 version = "0.14.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustc-workspace-hack]]
-version = "1.0.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustfix]]
 version = "0.6.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustix]]
-version = "0.37.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustsec]]
 version = "0.26.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustversion]]
-version = "1.0.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.ryu]]
-version = "1.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.same-file]]
-version = "1.0.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.schannel]]
 version = "0.1.21"
-criteria = "safe-to-deploy"
-
-[[exemptions.scopeguard]]
-version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.sec1]]
 version = "0.7.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.serde]]
-version = "1.0.136"
-criteria = "safe-to-deploy"
-
 [[exemptions.serde-value]]
 version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_derive]]
-version = "1.0.136"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_ignored]]
-version = "0.1.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_json]]
-version = "1.0.85"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_spanned]]
-version = "0.6.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.sha1]]
-version = "0.10.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]
@@ -659,10 +475,6 @@ criteria = "safe-to-deploy"
 [[exemptions.signature]]
 version = "2.0.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.similar]]
-version = "2.2.1"
-criteria = "safe-to-run"
 
 [[exemptions.sized-chunks]]
 version = "0.6.5"
@@ -678,10 +490,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
 version = "0.4.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.spdx]]
-version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.spki]]
@@ -708,28 +516,8 @@ criteria = "safe-to-deploy"
 version = "2.4.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.syn]]
-version = "1.0.102"
-criteria = "safe-to-deploy"
-
-[[exemptions.tar]]
-version = "0.4.38"
-criteria = "safe-to-deploy"
-
-[[exemptions.target-lexicon]]
-version = "0.12.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.tempfile]]
 version = "3.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.termcolor]]
-version = "1.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.thread_local]]
-version = "1.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]
@@ -742,22 +530,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.time-macros]]
 version = "0.2.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml]]
-version = "0.5.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml_edit]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml_edit]]
-version = "0.19.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.twox-hash]]
@@ -784,14 +556,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.walkdir]]
-version = "2.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasi]]
-version = "0.11.0+wasi-snapshot-preview1"
-criteria = "safe-to-deploy"
-
 [[exemptions.winapi]]
 version = "0.3.9"
 criteria = "safe-to-deploy"
@@ -800,16 +564,8 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.winapi-util]]
-version = "0.1.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.winnow]]
-version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wyz]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,110 @@
 
 # cargo-vet imports lock
 
+[[publisher.aho-corasick]]
+version = "0.7.20"
+when = "2022-11-22"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.anstream]]
+version = "0.2.6"
+when = "2023-03-17"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle]]
+version = "0.3.5"
+when = "2023-03-17"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-parse]]
+version = "0.1.1"
+when = "2023-03-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-wincon]]
+version = "0.2.0"
+when = "2023-03-13"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.bstr]]
+version = "1.4.0"
+when = "2023-03-18"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.byteorder]]
+version = "1.4.3"
+when = "2021-03-10"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.bytes]]
+version = "1.4.0"
+when = "2023-01-31"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
+[[publisher.cfg-expr]]
+version = "0.15.0"
+when = "2023-04-04"
+user-id = 52553
+user-login = "embark-studios"
+
+[[publisher.clap]]
+version = "4.2.1"
+when = "2023-03-29"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_builder]]
+version = "4.2.1"
+when = "2023-03-29"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_derive]]
+version = "4.2.0"
+when = "2023-03-28"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_lex]]
+version = "0.4.1"
+when = "2023-03-28"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.concolor-override]]
+version = "1.0.0"
+when = "2023-03-08"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.concolor-query]]
+version = "0.3.3"
+when = "2023-03-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.core-foundation]]
 version = "0.9.3"
 when = "2022-02-07"
@@ -14,6 +118,291 @@ when = "2023-04-03"
 user-id = 5946
 user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
+
+[[publisher.curl-sys]]
+version = "0.4.61+curl-8.0.1"
+when = "2023-03-20"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.filetime]]
+version = "0.2.20"
+when = "2023-02-08"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.globset]]
+version = "0.4.10"
+when = "2023-01-05"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.ignore]]
+version = "0.4.20"
+when = "2023-01-15"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.io-lifetimes]]
+version = "1.0.9"
+when = "2023-03-20"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.is-terminal]]
+version = "0.4.6"
+when = "2023-03-29"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.itoa]]
+version = "1.0.6"
+when = "2023-03-03"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.jobserver]]
+version = "0.1.26"
+when = "2023-02-28"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.krates]]
+version = "0.13.0"
+when = "2023-04-04"
+user-id = 52553
+user-login = "embark-studios"
+
+[[publisher.kstring]]
+version = "2.0.0"
+when = "2022-03-29"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.libnghttp2-sys]]
+version = "0.1.7+1.45.0"
+when = "2021-09-20"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.libz-sys]]
+version = "1.1.8"
+when = "2022-05-28"
+user-id = 4333
+user-login = "joshtriplett"
+user-name = "Josh Triplett"
+
+[[publisher.linux-raw-sys]]
+version = "0.3.1"
+when = "2023-03-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.memchr]]
+version = "2.5.0"
+when = "2022-04-30"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.num_cpus]]
+version = "1.15.0"
+when = "2022-12-20"
+user-id = 359
+user-login = "seanmonstar"
+user-name = "Sean McArthur"
+
+[[publisher.openssl-src]]
+version = "111.25.2+1.1.1t"
+when = "2023-03-20"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.paste]]
+version = "1.0.12"
+when = "2023-03-05"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.regex]]
+version = "1.7.3"
+when = "2023-03-25"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-automata]]
+version = "0.1.10"
+when = "2021-06-01"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-syntax]]
+version = "0.6.29"
+when = "2023-03-21"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.rustix]]
+version = "0.37.7"
+when = "2023-04-03"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.rustversion]]
+version = "1.0.12"
+when = "2023-03-05"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.ryu]]
+version = "1.0.13"
+when = "2023-03-03"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.same-file]]
+version = "1.0.6"
+when = "2020-01-11"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.scopeguard]]
+version = "1.1.0"
+when = "2020-02-16"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.serde]]
+version = "1.0.159"
+when = "2023-03-28"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_derive]]
+version = "1.0.159"
+when = "2023-03-28"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_ignored]]
+version = "0.1.7"
+when = "2023-01-03"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_json]]
+version = "1.0.95"
+when = "2023-03-27"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_spanned]]
+version = "0.6.1"
+when = "2023-01-30"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.spdx]]
+version = "0.10.0"
+when = "2022-12-20"
+user-id = 52553
+user-login = "embark-studios"
+
+[[publisher.syn]]
+version = "1.0.109"
+when = "2023-02-24"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.syn]]
+version = "2.0.13"
+when = "2023-04-01"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.tar]]
+version = "0.4.38"
+when = "2021-12-14"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.target-lexicon]]
+version = "0.12.6"
+when = "2023-02-10"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.termcolor]]
+version = "1.2.0"
+when = "2023-01-15"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.thread_local]]
+version = "1.1.7"
+when = "2023-02-12"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.toml]]
+version = "0.5.7"
+when = "2020-10-11"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.toml]]
+version = "0.7.3"
+when = "2023-03-13"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.toml_edit]]
+version = "0.15.0"
+when = "2022-10-21"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.toml_edit]]
+version = "0.19.8"
+when = "2023-03-23"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
 
 [[publisher.unicode-normalization]]
 version = "0.1.22"
@@ -36,6 +425,27 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
+[[publisher.walkdir]]
+version = "2.3.3"
+when = "2023-03-16"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.winapi-util]]
+version = "0.1.5"
+when = "2020-04-20"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.winnow]]
+version = "0.4.1"
+when = "2023-03-24"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[audits.embark.audits.anyhow]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -46,6 +456,18 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 violation = "<0.20.0"
 notes = "Specified crate license does not include licenses of embedded fonts if using default features or the `default_fonts` feature. Tracked in: https://github.com/emilk/egui/issues/2321"
+
+[[audits.embark.audits.rustc-workspace-hack]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "No unsafe usage or ambient capabilities. No functionality in it beyond a #[test]. "
+
+[[audits.embark.audits.similar]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "2.2.1"
+notes = "No unsafe usage or ambient capabilities"
 
 [[audits.embark.audits.strum]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -86,23 +508,25 @@ notes = "No unsafe usage or ambient capabilities"
 [[audits.firefox.wildcard-audits.core-foundation]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 5946
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
 start = "2019-03-29"
 end = "2023-05-04"
+renew = false
 notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
 
 [[audits.firefox.wildcard-audits.core-foundation-sys]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 5946
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
 start = "2020-10-14"
 end = "2023-05-04"
+renew = false
 notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
 
 [[audits.firefox.wildcard-audits.unicode-normalization]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 1139
+user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-11-06"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"
@@ -110,7 +534,7 @@ notes = "All code written or reviewed by Manish"
 [[audits.firefox.wildcard-audits.unicode-width]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 1139
+user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-12-05"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"
@@ -118,15 +542,10 @@ notes = "All code written or reviewed by Manish"
 [[audits.firefox.wildcard-audits.unicode-xid]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 1139
+user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"
-
-[[audits.firefox.audits.aho-corasick]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.7.18 -> 0.7.20"
 
 [[audits.firefox.audits.anyhow]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -169,16 +588,6 @@ delta = "0.13.0 -> 0.13.1"
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.2 -> 0.10.3"
-
-[[audits.firefox.audits.bytes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.2.1 -> 1.3.0"
-
-[[audits.firefox.audits.bytes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.3.0 -> 1.4.0"
 
 [[audits.firefox.audits.crossbeam-epoch]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -302,11 +711,6 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.9.1 -> 1.9.2"
 
-[[audits.firefox.audits.itoa]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.3 -> 1.0.5"
-
 [[audits.firefox.audits.linked-hash-map]]
 who = "Aria Beingessner <a.beingessner@gmail.com>"
 criteria = "safe-to-deploy"
@@ -338,16 +742,6 @@ who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"
 version = "0.2.15"
 notes = "All code written or reviewed by Josh Stone."
-
-[[audits.firefox.audits.num_cpus]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.13.1 -> 1.14.0"
-
-[[audits.firefox.audits.num_cpus]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.14.0 -> 1.15.0"
 
 [[audits.firefox.audits.once_cell]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -455,20 +849,10 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.10.1 -> 1.10.2"
 
-[[audits.firefox.audits.regex]]
+[[audits.firefox.audits.redox_syscall]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
-delta = "1.6.0 -> 1.7.0"
-
-[[audits.firefox.audits.regex]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.7.0 -> 1.7.1"
-
-[[audits.firefox.audits.regex-syntax]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.6.27 -> 0.6.28"
+delta = "0.2.13 -> 0.2.16"
 
 [[audits.firefox.audits.rustc-hash]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -476,60 +860,20 @@ criteria = "safe-to-deploy"
 version = "1.1.0"
 notes = "Straightforward crate with no unsafe code, does what it says on the tin."
 
-[[audits.firefox.audits.ryu]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
+[[audits.firefox.audits.sha1]]
+who = "Dana Keeler <dkeeler@mozilla.com>"
 criteria = "safe-to-deploy"
-delta = "1.0.11 -> 1.0.12"
-
-[[audits.firefox.audits.serde]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.143 -> 1.0.144"
-
-[[audits.firefox.audits.serde]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.144 -> 1.0.151"
-
-[[audits.firefox.audits.serde]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.151 -> 1.0.152"
-
-[[audits.firefox.audits.serde_derive]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.143 -> 1.0.144"
-
-[[audits.firefox.audits.serde_derive]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.144 -> 1.0.151"
-
-[[audits.firefox.audits.serde_derive]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.151 -> 1.0.152"
-
-[[audits.firefox.audits.serde_json]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.85 -> 1.0.91"
-
-[[audits.firefox.audits.serde_json]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.91 -> 1.0.93"
+version = "0.10.5"
 
 [[audits.firefox.audits.sha2]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.2 -> 0.10.6"
 
-[[audits.firefox.audits.termcolor]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
+[[audits.firefox.audits.toml]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "1.1.3 -> 1.2.0"
+delta = "0.5.7 -> 0.5.9"
 
 [[audits.firefox.audits.toml]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -641,61 +985,6 @@ delta = "1.6.1 -> 1.7.0"
 who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
 delta = "1.10.2 -> 1.11.0"
-
-[[audits.isrg.audits.serde]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.152 -> 1.0.153"
-
-[[audits.isrg.audits.serde]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.153 -> 1.0.154"
-
-[[audits.isrg.audits.serde]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.154 -> 1.0.155"
-
-[[audits.isrg.audits.serde]]
-who = "Brandon Pitman <bran@bran.land>"
-criteria = "safe-to-deploy"
-delta = "1.0.156 -> 1.0.159"
-
-[[audits.isrg.audits.serde_derive]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.152 -> 1.0.153"
-
-[[audits.isrg.audits.serde_derive]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.153 -> 1.0.154"
-
-[[audits.isrg.audits.serde_derive]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.154 -> 1.0.155"
-
-[[audits.isrg.audits.serde_derive]]
-who = "Brandon Pitman <bran@bran.land>"
-criteria = "safe-to-deploy"
-delta = "1.0.156 -> 1.0.159"
-
-[[audits.isrg.audits.serde_json]]
-who = "Brandon Pitman <bran@bran.land>"
-criteria = "safe-to-deploy"
-delta = "1.0.93 -> 1.0.94"
-
-[[audits.isrg.audits.serde_json]]
-who = "Brandon Pitman <bran@bran.land>"
-criteria = "safe-to-deploy"
-delta = "1.0.94 -> 1.0.95"
-
-[[audits.isrg.audits.syn]]
-who = "Brandon Pitman <bran@bran.land>"
-criteria = "safe-to-deploy"
-delta = "1.0.104 -> 2.0.11"
 
 [[audits.mozilla.audits.crossbeam-channel]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
@@ -877,12 +1166,6 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.2.15"
 notes = "no build.rs, no macros, no unsafe. It reads the filesystem and makes copies of DLLs into OUT_DIR."
-
-[[audits.wasmtime.audits.walkdir]]
-who = "Andrew Brown <andrew.brown@intel.com>"
-criteria = "safe-to-deploy"
-delta = "2.3.2 -> 2.3.3"
-notes = "No significant changes: minor refactoring and removes the need to use `winapi`."
 
 [[audits.wasmtime.audits.windows-sys]]
 who = "Dan Gohman <dev@sunfishcode.online>"
@@ -1072,19 +1355,6 @@ criteria = "safe-to-deploy"
 delta = "1.9.2 -> 1.9.3"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[[audits.zcash.audits.itoa]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "1.0.1 -> 1.0.3"
-notes = "Update makes no changes to code."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.itoa]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.5 -> 1.0.6"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
 [[audits.zcash.audits.proc-macro2]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -1101,86 +1371,6 @@ aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/suppl
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.0.23 -> 1.0.26"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.regex]]
-who = "Sean Bowe <ewillbefull@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.7.1 -> 1.7.3"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.regex-syntax]]
-who = "Sean Bowe <ewillbefull@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.6.28 -> 0.6.29"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.ryu]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.12 -> 1.0.13"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.serde]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "1.0.136 -> 1.0.143"
-notes = "Bumps serde-derive and adds some constructors."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.serde]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.155 -> 1.0.156"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.serde_derive]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "1.0.136 -> 1.0.143"
-notes = "Bumps syn, inverts some build flags."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.serde_derive]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.155 -> 1.0.156"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.syn]]
-who = "Sean Bowe <ewillbefull@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.102 -> 1.0.104"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.syn]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "1.0.102 -> 1.0.107"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.syn]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.107 -> 1.0.109"
-notes = "Fixes string literal parsing to only skip specified whitespace characters."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.syn]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "2.0.11 -> 2.0.13"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.thread_local]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "1.1.4 -> 1.1.7"
-notes = """
-New `unsafe` usage:
-- An extra `deallocate_bucket`, to replace a `Mutex::lock` with a `compare_exchange`.
-- Setting and getting a `#[thread_local] static mut Option<Thread>` on nightly.
-"""
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.time-macros]]
@@ -1213,12 +1403,6 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.5.1 -> 0.6.1"
 notes = "Fixes a bug in parsing negative minutes in datetime string offsets."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.toml_edit]]
-who = "Sean Bowe <ewillbefull@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.19.7 -> 0.19.8"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.windows-targets]]


### PR DESCRIPTION
Similar to how we've done in a few of our other reviews, so we can focus on audits of more unknown crates and publishers.

Also excluded auditing for a few additional crates that are not used in practice (unsupported/unused targets).

Current audit state:

`Vetting Succeeded (136 fully audited, 26 partially audited, 107 exempted)`

Related (private link): https://github.com/EmbarkStudios/ark/issues/7090
