### PR TITLE
Suggest running cargo update

### DIFF
--- a/src/advisories/diags.rs
+++ b/src/advisories/diags.rs
@@ -126,7 +126,7 @@ impl<'a> crate::CheckCtx<'a, super::cfg::ValidConfig> {
                 notes.push("Solution: No safe upgrade is available!".to_owned());
             } else {
                 notes.push(format!(
-                    "Solution: Upgrade to {}",
+                    "Solution: Upgrade to {} (try `cargo update`)",
                     versions
                         .patched()
                         .iter()


### PR DESCRIPTION
I've had multiple coworkers ask me how to update a crate that doesn't appear in the `Cargo.toml` file after getting an error from `cargo deny`. Suggesting the `cargo update` command along with the solution would help them discover the command themselves.