### PR TITLE
Add `osi` and `fsf` values for `allow-osi-fsf-free` config

### DIFF
--- a/deny.template.toml
+++ b/deny.template.toml
@@ -117,8 +117,10 @@ copyleft = "warn"
 # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
 # * both - The license will be approved if it is both OSI-approved *AND* FSF
 # * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * osi - The license will be approved if it is OSI approved
+# * fsf - The license will be approved if it is FSF Free
+# * osi-only - The license will be approved if it is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if it is FSF *AND NOT* OSI-approved
 # * neither - This predicate is ignored and the default lint level is used
 allow-osi-fsf-free = "neither"
 # Lint level used when no other predicates are matched

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -133,6 +133,8 @@ Determines what happens when licenses aren't explicitly allowed or denied, but *
 
 * `both` - The license is accepted if it is both OSI approved and FSF Free
 * `either` - The license is accepted if it is either OSI approved or FSF Free
+* `osi` - The license is accepted if it is OSI approved
+* `fsf` - The license is accepted if it is FSF Free
 * `osi-only` - The license is accepted if it is OSI approved and not FSF Free
 * `fsf-only` - The license is accepted if it is FSF Free and not OSI approved
 * `neither` (default) - No special consideration is given the license

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -151,6 +151,18 @@ fn evaluate_expression(
                         allow!(IsBothFreeAndOsi);
                     }
                 }
+                BlanketAgreement::Osi => {
+                    if id.is_osi_approved() {
+                        allow!(IsOsiApproved);
+                    }
+                }
+                BlanketAgreement::Fsf => {
+                    if id.is_fsf_free_libre() {
+                        allow!(IsFsfFree);
+                    } else {
+                        deny!(IsFsfFree);
+                    }
+                }
                 BlanketAgreement::OsiOnly => {
                     if id.is_osi_approved() {
                         if id.is_fsf_free_libre() {

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -43,6 +43,10 @@ pub enum BlanketAgreement {
     Both,
     /// The license can be be either OSI Approved or FSF/Free Libre
     Either,
+    /// The license must be OSI Approved
+    Osi,
+    /// The license must be FSF/Free
+    Fsf,
     /// The license must be OSI Approved but not FSF/Free Libre
     OsiOnly,
     /// The license must be FSF/Free Libre but not OSI Approved
@@ -391,7 +395,7 @@ mod test {
         assert_eq!(validated.copyleft, LintLevel::Deny);
         assert_eq!(validated.unused_allowed_license, LintLevel::Warn);
         assert_eq!(validated.default, LintLevel::Warn);
-        assert_eq!(validated.allow_osi_fsf_free, BlanketAgreement::Both);
+        assert_eq!(validated.allow_osi_fsf_free, BlanketAgreement::Osi);
         assert_eq!(
             validated.allowed,
             vec![


### PR DESCRIPTION
This PR resolves #210 by adding `osi` and `fsf` as  new values for `allow-osi-fsf-free`. This allows for the use case where a cargo-deny user wants to blanket allow all FSF licenses while not caring about OSI (or vice versa).