### PR TITLE
Fix a mistake made in #531

### DIFF
--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -159,8 +159,6 @@ fn evaluate_expression(
                 BlanketAgreement::Fsf => {
                     if id.is_fsf_free_libre() {
                         allow!(IsFsfFree);
-                    } else {
-                        deny!(IsFsfFree);
                     }
                 }
                 BlanketAgreement::OsiOnly => {


### PR DESCRIPTION
I had initially patterned the new license checks on `OsiOnly` and `FsfOnly` before realizing that perhaps deny!() didn't make sense here, and I removed it (or so I thought). It seems I blundered and left one in--sorry.

I believe this deny!() shouldn't be here.

Apologies for the mistake... I thought I'd double-checked my diff but it seems I did a poor job of it.

(Also, thanks for catching that other mistake I made in #531 Jake)