### PR TITLE
Improve advisory db fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "tame-index"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc228c36e24e0e5d03623ebc2dc2a66b45f7b840dd53429d92fd632c157d7ee3"
+checksum = "bb763cdef142072fdad51f24c90e15f036a5d9842bf856f6b38ca2e8a693bed5"
 dependencies = [
  "bytes",
  "camino",

--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -5,8 +5,10 @@ pub use rustsec::{advisory::Id, Database, Lockfile, Vulnerability};
 use std::fmt;
 use url::Url;
 
-// The default, official, rustsec advisory database
+/// The default, official, rustsec advisory database
 const DEFAULT_URL: &str = "https://github.com/RustSec/advisory-db";
+/// Refspec used to fetch updates from remote advisory databases
+const REF_SPEC: &str = "+HEAD:refs/remotes/origin/HEAD";
 
 /// Whether the database will be fetched or not
 #[derive(Copy, Clone)]
@@ -228,54 +230,6 @@ fn get_fetch_time(repo: &gix::Repository) -> anyhow::Result<time::OffsetDateTime
     Ok(timestamp)
 }
 
-fn get_remote_head(
-    repo: &gix::Repository,
-    fetch_response: &gix::remote::fetch::Outcome,
-) -> anyhow::Result<(gix::ObjectId, gix::bstr::BString)> {
-    let remote = repo
-        .head()
-        .context("failed to get HEAD")?
-        .into_remote(DIR)
-        .map(|r| r.context("failed to get remote for HEAD"))
-        .or_else(|| {
-            repo.find_default_remote(DIR)
-                .map(|r| r.context("failed to find default remote"))
-        })
-        .context("failed to find appropriate remote to fetch from")??;
-
-    let remote_head = format!(
-        "refs/remotes/{}/HEAD",
-        remote
-            .name()
-            .map(|s| s.as_bstr())
-            .context("remote name hasn't been persisted to disk")?
-    );
-
-    // Find the commit id of the remote's HEAD
-    let (remote_head_id, remote_ref_target) = fetch_response
-        .ref_map
-        .mappings
-        .iter()
-        .find_map(|mapping| {
-            let gix::remote::fetch::Source::Ref(rref) = &mapping.remote else { return None; };
-
-            if mapping.local.as_deref()? != remote_head.as_bytes() {
-                return None;
-            }
-
-            let gix::protocol::handshake::Ref::Symbolic {
-            full_ref_name,
-            object,
-            target,
-        } = rref else { return None; };
-
-            (full_ref_name == "HEAD").then(|| (*object, target.clone()))
-        })
-        .context("failed to locate remote HEAD")?;
-
-    Ok((remote_head_id, remote_ref_target))
-}
-
 /// Perform a fetch + checkout of the latest remote HEAD -> local HEAD
 ///
 /// Note this function is a bit involved as, either I'm dumb and can't figure out
@@ -283,117 +237,98 @@ fn get_remote_head(
 /// when doing a clone, but if you are performing a fetch on an existing repo
 /// ...you have to do that all yourself, which is pretty tedious
 fn fetch_and_checkout(repo: &mut gix::Repository) -> anyhow::Result<()> {
-    // In a normal case there will be only one remote, called origin, but try
-    // and be robust about it
-    let mut remote = repo
-        .head()
-        .context("failed to get HEAD")?
-        .into_remote(DIR)
-        .map(|r| r.context("failed to get remote for HEAD"))
-        .or_else(|| {
-            repo.find_default_remote(DIR)
-                .map(|r| r.context("failed to find default remote"))
-        })
-        .context("failed to find appropriate remote to fetch from")??;
+    let mut progress = gix::progress::Discard;
+    let should_interrupt = &gix::interrupt::IS_INTERRUPTED;
 
-    let remote_head = format!(
-        "refs/remotes/{}/HEAD",
-        remote
-            .name()
-            .map(|s| s.as_bstr())
-            .context("remote name hasn't been persisted to disk")?
-    );
-
-    remote
-        .replace_refspecs(Some(format!("HEAD:{remote_head}").as_str()), DIR)
-        .expect("valid statically known refspec");
-
-    // Perform the actual fetch
-    let fetch_response: gix::remote::fetch::Outcome = remote
-        .connect(DIR)?
-        .prepare_fetch(&mut gix::progress::Discard, Default::default())
-        .context("failed to prepare fetch")?
-        .receive(
-            &mut gix::progress::Discard,
-            &std::sync::atomic::AtomicBool::default(),
-        )
-        .context("failed to fetch")?;
-
-    use gix::refs::{transaction as tx, Target};
-    let (remote_head_id, _remote_ref_target) = get_remote_head(repo, &fetch_response)?;
-
-    // In all (hopefully?) cases HEAD is a symbolic reference to
-    // refs/heads/<branch> which is a peeled commit id, if that's the case
-    // we update it to the new commit id, otherwise we just set HEAD
-    // directly
-    use gix::head::Kind;
-    let edit = match repo.head()?.kind {
-        Kind::Symbolic(sref) => {
-            // Update our local HEAD to the remote HEAD
-            if let Target::Symbolic(name) = sref.target {
-                Some(tx::RefEdit {
-                    change: tx::Change::Update {
-                        log: tx::LogChange {
-                            mode: tx::RefLog::AndReference,
-                            force_create_reflog: false,
-                            message: "".into(),
-                        },
-                        expected: tx::PreviousValue::MustExist,
-                        new: gix::refs::Target::Peeled(remote_head_id),
-                    },
-                    name,
-                    deref: true,
-                })
-            } else {
-                None
-            }
-        }
-        Kind::Unborn(_) | Kind::Detached { .. } => None,
-    };
-
-    let edit = edit.unwrap_or_else(|| tx::RefEdit {
-        change: tx::Change::Update {
-            log: tx::LogChange {
-                mode: tx::RefLog::AndReference,
-                force_create_reflog: false,
-                message: "".into(),
-            },
-            expected: tx::PreviousValue::Any,
-            new: gix::refs::Target::Peeled(remote_head_id),
-        },
-        name: "HEAD".try_into().unwrap(),
-        deref: true,
-    });
-
-    // We're updating the reflog which requires a committer be set, which might
-    // not be the case, particular in a CI environment, but also would default
-    // the the git config for the current directory/global, which on a normal
-    // user machine would show the user was the one who updated the database which
-    // is kind of misleading, so we just override the config for this operation
-    let repo = {
+    {
         let mut config = repo.config_snapshot_mut();
         config
-            .set_raw_value("committer", None, "name", "cargo-deny")
-            .context("failed to set committer.name")?;
+            .set_raw_value("committer", None, "name", "tame-index")
+            .context("failed to set `committer.name`")?;
         // Note we _have_ to set the email as well, but luckily gix does not actually
         // validate if it's a proper email or not :)
         config
             .set_raw_value("committer", None, "email", "")
-            .context("failed to set committer.email")?;
+            .context("failed to set `committer.email`")?;
 
-        config
+        let repo = config
             .commit_auto_rollback()
-            .context("failed to create auto rollback")?
-    };
+            .context("failed to set committer")?;
 
-    repo.edit_reference(edit).context("failed to update HEAD")?;
+        let mut remote = repo
+            .find_remote("origin")
+            .context("unable to find 'origin' remote")?;
 
-    // Sanity check that the local HEAD points to the same commit
-    // as the remote HEAD
-    anyhow::ensure!(
-        remote_head_id == repo.head_commit()?.id,
-        "failed to update HEAD to remote HEAD"
-    );
+        remote
+            .replace_refspecs(Some(REF_SPEC), DIR)
+            .expect("valid statically known refspec");
+
+        // Perform the actual fetch
+        let outcome = remote
+            .connect(DIR)
+            .context("failed to connect to remote")?
+            .prepare_fetch(&mut progress, Default::default())
+            .context("failed to prepare fetch")?
+            .receive(&mut progress, should_interrupt)
+            .context("failed to fetch")?;
+
+        let remote_head_id = tame_index::utils::git::write_fetch_head(&repo, &outcome, &remote)
+            .context("failed to write FETCH_HEAD")?;
+
+        use gix::refs::{transaction as tx, Target};
+
+        // In all (hopefully?) cases HEAD is a symbolic reference to
+        // refs/heads/<branch> which is a peeled commit id, if that's the case
+        // we update it to the new commit id, otherwise we just set HEAD
+        // directly
+        use gix::head::Kind;
+        let edit = match repo.head()?.kind {
+            Kind::Symbolic(sref) => {
+                // Update our local HEAD to the remote HEAD
+                if let Target::Symbolic(name) = sref.target {
+                    Some(tx::RefEdit {
+                        change: tx::Change::Update {
+                            log: tx::LogChange {
+                                mode: tx::RefLog::AndReference,
+                                force_create_reflog: false,
+                                message: "".into(),
+                            },
+                            expected: tx::PreviousValue::MustExist,
+                            new: gix::refs::Target::Peeled(remote_head_id),
+                        },
+                        name,
+                        deref: true,
+                    })
+                } else {
+                    None
+                }
+            }
+            Kind::Unborn(_) | Kind::Detached { .. } => None,
+        };
+
+        let edit = edit.unwrap_or_else(|| tx::RefEdit {
+            change: tx::Change::Update {
+                log: tx::LogChange {
+                    mode: tx::RefLog::AndReference,
+                    force_create_reflog: false,
+                    message: "".into(),
+                },
+                expected: tx::PreviousValue::Any,
+                new: gix::refs::Target::Peeled(remote_head_id),
+            },
+            name: "HEAD".try_into().unwrap(),
+            deref: true,
+        });
+
+        repo.edit_reference(edit).context("failed to update HEAD")?;
+
+        // Sanity check that the local HEAD points to the same commit
+        // as the remote HEAD
+        anyhow::ensure!(
+            remote_head_id == repo.head_commit()?.id,
+            "failed to update HEAD to remote HEAD"
+        );
+    }
 
     use gix::prelude::FindExt;
 
@@ -431,9 +366,9 @@ fn fetch_and_checkout(repo: &mut gix::Repository) -> anyhow::Result<()> {
             let objects = repo.objects.clone().into_arc()?;
             move |oid, buf| objects.find_blob(oid, buf)
         },
+        &mut progress,
         &mut gix::progress::Discard,
-        &mut gix::progress::Discard,
-        &std::sync::atomic::AtomicBool::default(),
+        should_interrupt,
         opts,
     )
     .context("failed to checkout")?;
@@ -441,60 +376,6 @@ fn fetch_and_checkout(repo: &mut gix::Repository) -> anyhow::Result<()> {
     index
         .write(Default::default())
         .context("failed to write index")?;
-
-    // Now that we've checked out everything write FETCH_HEAD
-    write_fetch_head(&repo, &fetch_response)?;
-
-    Ok(())
-}
-
-/// The format of `FETCH_HEAD` is a bit different from other refs, and
-/// we don't write it the same as git does, as it includes the tips
-/// of _all_ active remote branches, and we don't care about anything
-/// except the branch with HEAD
-///
-/// `<commit_oid>\t\tbranch '<name>' of '<remote>'`
-fn write_fetch_head(
-    repo: &gix::Repository,
-    fetch: &gix::remote::fetch::Outcome,
-) -> anyhow::Result<()> {
-    let fetch_head_path = repo.path().join("FETCH_HEAD");
-
-    let (remote_head_id, remote_ref_target) = get_remote_head(repo, fetch)?;
-
-    let remote_head = remote_head_id.to_hex();
-    // At least for the official rustsec repo, the default branch is 'main', so
-    // we default to that if the target is invalid utf8 or empty
-    let remote_ref_target = String::try_from(remote_ref_target).ok();
-    let remote_branch_name = remote_ref_target
-        .as_deref()
-        .and_then(|s| s.rsplit('/').next())
-        .unwrap_or("main");
-
-    let remote = repo
-        .head()
-        .context("failed to get HEAD")?
-        .into_remote(DIR)
-        .map(|r| r.context("failed to get remote for HEAD"))
-        .or_else(|| {
-            repo.find_default_remote(DIR)
-                .map(|r| r.context("failed to find default remote"))
-        })
-        .context("failed to find appropriate remote to fetch from")??;
-
-    // This _should_ be impossible if we got here...
-    let remote_url: String = remote
-        .url(DIR)
-        .context("fetch url is not available for remote")?
-        .to_bstring()
-        .try_into()
-        .context("remote url is not valid utf-8")?;
-
-    std::fs::write(
-        &fetch_head_path,
-        format!("{remote_head}\t\tbranch '{remote_branch_name}' of {remote_url}"),
-    )
-    .with_context(|| format!("failed to write {fetch_head_path:?}"))?;
 
     Ok(())
 }
@@ -524,45 +405,95 @@ fn fetch_via_gix(url: &Url, db_path: &Path) -> anyhow::Result<()> {
         std::fs::remove_dir(db_path)?;
     }
 
-    let (mut repo, cloned) = gix::open(db_path)
-        .map(|repo| (repo, false))
-        .or_else(|err| {
-            if matches!(err, gix::open::Error::NotARepository { .. }) {
-                let (mut checkout, out) = gix::prepare_clone(url.as_str(), db_path)
-                    .context("failed to prepare clone")?
-                    .fetch_then_checkout(
-                        gix::progress::Discard,
-                        &std::sync::atomic::AtomicBool::default(),
-                    )
-                    .context("failed to fetch")?;
+    let open_or_clone_repo = || -> anyhow::Result<_> {
+        let mut mapping = gix::sec::trust::Mapping::default();
+        let open_with_complete_config =
+            gix::open::Options::default().permissions(gix::open::Permissions {
+                config: gix::open::permissions::Config {
+                    // Be sure to get all configuration, some of which is only known by the git binary.
+                    // That way we are sure to see all the systems credential helpers
+                    git_binary: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
 
-                let repo = checkout
-                    .main_worktree(
-                        gix::progress::Discard,
-                        &std::sync::atomic::AtomicBool::default(),
-                    )
-                    .context("failed to checkout")?
-                    .0;
+        mapping.reduced = open_with_complete_config.clone();
+        mapping.full = open_with_complete_config.clone();
 
-                write_fetch_head(&repo, &out)?;
+        let _lock = gix::lock::Marker::acquire_to_hold_resource(
+            db_path.with_extension("cargo-deny"),
+            gix::lock::acquire::Fail::AfterDurationWithBackoff(std::time::Duration::from_secs(
+                60 * 10, /* 10 minutes */
+            )),
+            Some(std::path::PathBuf::from_iter(Some(
+                std::path::Component::RootDir,
+            ))),
+        )
+        .context("failed to acquire lock")?;
 
-                Ok((repo, true))
-            } else {
-                Err(err).context("unable to open repository")
-            }
+        // Attempt to open the repository, if it fails for any reason,
+        // attempt to perform a fresh clone instead
+        let repo = gix::ThreadSafeRepository::discover_opts(
+            db_path,
+            gix::discover::upwards::Options::default().apply_environment(),
+            mapping,
+        )
+        .ok()
+        .map(|repo| repo.to_thread_local())
+        .filter(|repo| {
+            // The `cargo` standard registry clone has no configured origin (when created with `git2`).
+            repo.find_remote("origin").map_or(false, |remote| {
+                remote
+                    .url(DIR)
+                    .map_or(false, |remote_url| remote_url.to_bstring() == url.as_str())
+            })
         })
-        .with_context(|| format!("failed to open git repository at '{db_path}'"))?;
+        .or_else(|| gix::open_opts(&db_path, open_with_complete_config).ok());
 
-    // If we didn't open a fresh repo we need to peform a fetch ourselves, and
-    // do the work of updating the HEAD to point at the latest remote HEAD, which
-    // gix doesn't currently do.
-    //
-    // Gix also doesn't write the FETCH_HEAD, which we rely on for staleness
-    // checking, so we write it ourselves to keep identical logic between gix
-    // and git/git2
-    if !cloned {
+        let res = if let Some(repo) = repo {
+            (repo, None)
+        } else {
+            let mut progress = gix::progress::Discard;
+            let should_interrupt = &gix::interrupt::IS_INTERRUPTED;
+
+            let (mut prep_checkout, out) = gix::prepare_clone(url.as_str(), &db_path)
+                .map_err(Box::new)?
+                .with_remote_name("origin")?
+                .configure_remote(|remote| Ok(remote.with_refspecs([REF_SPEC], DIR)?))
+                .fetch_then_checkout(&mut progress, should_interrupt)?;
+
+            let repo = prep_checkout
+                .main_worktree(&mut progress, should_interrupt)
+                .context("failed to checkout")?
+                .0;
+
+            (repo, Some(out))
+        };
+
+        Ok(res)
+    };
+
+    let (mut repo, fetch_outcome) = open_or_clone_repo()?;
+
+    if let Some(fetch_outcome) = fetch_outcome {
+        tame_index::utils::git::write_fetch_head(
+            &repo,
+            &fetch_outcome,
+            &repo.find_remote("origin").unwrap(),
+        )?;
+    } else {
+        // If we didn't open a fresh repo we need to peform a fetch ourselves, and
+        // do the work of updating the HEAD to point at the latest remote HEAD, which
+        // gix doesn't currently do.
+        //
+        // Gix also doesn't write the FETCH_HEAD, which we rely on for staleness
+        // checking, so we write it ourselves to keep identical logic between gix
+        // and git/git2
         fetch_and_checkout(&mut repo)?;
     }
+
+    repo.object_cache_size_if_unset(4 * 1024 * 1024);
 
     Ok(())
 }

--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -410,6 +410,7 @@ fn fetch_via_gix(url: &Url, db_path: &Path) -> anyhow::Result<()> {
         gix::lock::acquire::Fail::AfterDurationWithBackoff(std::time::Duration::from_secs(
             60 * 10, /* 10 minutes */
         )),
+        #[allow(clippy::disallowed_types)]
         Some(std::path::PathBuf::from_iter(Some(
             std::path::Component::RootDir,
         ))),
@@ -449,7 +450,7 @@ fn fetch_via_gix(url: &Url, db_path: &Path) -> anyhow::Result<()> {
                     .map_or(false, |remote_url| remote_url.to_bstring() == url.as_str())
             })
         })
-        .or_else(|| gix::open_opts(&db_path, open_with_complete_config).ok());
+        .or_else(|| gix::open_opts(db_path, open_with_complete_config).ok());
 
         let res = if let Some(repo) = repo {
             (repo, None)
@@ -457,7 +458,7 @@ fn fetch_via_gix(url: &Url, db_path: &Path) -> anyhow::Result<()> {
             let mut progress = gix::progress::Discard;
             let should_interrupt = &gix::interrupt::IS_INTERRUPTED;
 
-            let (mut prep_checkout, out) = gix::prepare_clone(url.as_str(), &db_path)
+            let (mut prep_checkout, out) = gix::prepare_clone(url.as_str(), db_path)
                 .map_err(Box::new)?
                 .with_remote_name("origin")?
                 .configure_remote(|remote| Ok(remote.with_refspecs([REF_SPEC], DIR)?))

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -453,7 +453,7 @@ fn crates_io_source_replacement() {
     // for crates.io
     let lrd = temp_dir();
     {
-        use tame_index::index::{local, reqwest};
+        use tame_index::{external::reqwest, index::local};
 
         let sparse = tame_index::index::RemoteSparseIndex::new(
             tame_index::SparseIndex::new(tame_index::IndexLocation::new(


### PR DESCRIPTION
This fixes a few issues with advisory dbs, notably ensuring they can be fetched regardless of the environment, writing `FETCH_HEAD` via https://docs.rs/tame-index/0.2.4/tame_index/utils/git/fn.write_fetch_head.html, and properly locking repos before opening/cloning.

Resolves: #479 