### PR TITLE
Add gix lock timeout debug message

### DIFF
--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -405,8 +405,15 @@ fn fetch_via_gix(url: &Url, db_path: &Path) -> anyhow::Result<()> {
         std::fs::remove_dir(db_path)?;
     }
 
+    let lock_path = db_path.with_extension("cargo-deny");
+
+    log::debug!(
+        "About to acquire gix lock {} (this could take 10 minutes)",
+        lock_path
+    );
+
     let _lock = gix::lock::Marker::acquire_to_hold_resource(
-        db_path.with_extension("cargo-deny"),
+        lock_path,
         gix::lock::acquire::Fail::AfterDurationWithBackoff(std::time::Duration::from_secs(
             60 * 10, /* 10 minutes */
         )),


### PR DESCRIPTION
`cargo deny check` repeatedly seemed to hang "indefinitely" because I kept Ctrl-C'ing the process before it could hit the 10-minute mark. I had tried enabling the TRACE log messages, but it didn't give any clear reason why it seemed to be hanging. While I was cloning the repo and adding several more trace messages to figure out where and why it could be hanging, a background process finally hit the 10-minute mark and gave the exact error message I was looking for (ie: that a lockfile from a crashed instance was still lingering).

To prevent others from having the same confusion, I propose adding a new debug log message to inform that we might be waiting for an abandoned lockfile. That way, others who end up in the same situation have an early explanation of why the process might seem to be hanging.