### PR TITLE
Remove the misleading comment about RUSTSEC from deny.template.toml

### DIFF
--- a/deny.template.toml
+++ b/deny.template.toml
@@ -67,9 +67,7 @@ vulnerability = "deny"
 unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry
 yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
+# The lint level for crates with security notices.
 notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.


### PR DESCRIPTION
Removes the comment from the template file. The comment might lead to people think there is no reason to use the `advisories/notice` option any more due to that comment.

The https://github.com/rustsec/advisory-db is updated regularly, so people may need to spend time thinking whether they need those or not instead of thinking that since 2019-12-17, there has been nothing, and so it is pointless now.