### PR TITLE
Fix cargo registry index paths for big-endian architectures

### DIFF
--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -742,25 +742,49 @@ mod test {
 
         {
             let url = Url::parse("https://github.com/RustSec/advisory-db").unwrap();
+
+            #[cfg(target_endian = "little")]
             assert_eq!(
                 url_to_db_path(root_path.clone(), &url).unwrap(),
                 root_path.join("github.com-a946fc29ac602819")
+            );
+
+            #[cfg(target_endian = "big")]
+            assert_eq!(
+                url_to_db_path(root_path.clone(), &url).unwrap(),
+                root_path.join("github.com-f4edf1c00e90fd42")
             );
         }
 
         {
             let url = Url::parse("https://bare.com").unwrap();
+
+            #[cfg(target_endian = "little")]
             assert_eq!(
                 url_to_db_path(root_path.clone(), &url).unwrap(),
                 root_path.join("bare.com-9c003d1ed306b28c")
+            );
+
+            #[cfg(target_endian = "big")]
+            assert_eq!(
+                url_to_db_path(root_path.clone(), &url).unwrap(),
+                root_path.join("bare.com-c9767e4ee31501de")
             );
         }
 
         {
             let url = Url::parse("https://example.com/countries/việt nam").unwrap();
+
+            #[cfg(target_endian = "little")]
             assert_eq!(
                 url_to_db_path(root_path.clone(), &url).unwrap(),
                 root_path.join("example.com-1c03f84825fb7438")
+            );
+
+            #[cfg(target_endian = "big")]
+            assert_eq!(
+                url_to_db_path(root_path.clone(), &url).unwrap(),
+                root_path.join("example.com-5ebf17a6f3e576f0")
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,10 @@ pub enum Source {
 
 /// The directory name under which crates sourced from the crates.io sparse
 /// registry are placed
+#[cfg(target_endian = "little")]
 const CRATES_IO_SPARSE_DIR: &str = "index.crates.io-6f17d22bba15001f";
+#[cfg(target_endian = "big")]
+const CRATES_IO_SPARSE_DIR: &str = "index.crates.io-d11c229612889eed";
 
 impl Source {
     pub fn crates_io(is_sparse: bool) -> Self {


### PR DESCRIPTION
The hexadecimal part of cargo index paths is different on little- and big-endian architectures.
See also https://github.com/EmbarkStudios/tame-index/issues/36

I have verified that the endianness-specific  `CRATES_IO_SPARSE_DIR` definition is correct and indeed matches what cargo writes to on big-endian architectures.