### PR TITLE
Add pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: cargo-deny
+  name: check Cargo dependencies
+  description: check Cargo dependencies
+  entry: cargo-deny
+  language: rust
+  types: [file, toml]
+  files: Cargo\.(toml|lock)
+  pass_filenames: false
+  args: ["--all-features", "check"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ cargo deny check sources
 
 ![sources output](docs/src/output/sources.svg)
 
+### Pre-commit hook
+
+You can use `cargo-deny` with [pre-commit](https://pre-commit.com). Add it to your local `.pre-commit-config.yaml` as follows:
+
+```yaml
+- repo: https://github.com/EmbarkStudios/cargo-deny
+  rev: 0.14.11 # choose your preferred tag
+  hooks:
+    - id: cargo-deny
+    - args: ["--all-features", "check"] # optionally modify the arguments for cargo-deny (default arguments shown here)
+```
+
 ## Contributing
 
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
This allows using cargo-deny as a pre-commit hook out of the box. See https://pre-commit.com/#new-hooks for information about creating pre-commit hooks.

Example repository that already defines a pre-commit configuration: https://github.com/DevinR528/cargo-sort