### PR TITLE
Deprecate several fields

### DIFF
--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
@@ -1,0 +1,44 @@
+---
+source: src/advisories/cfg.rs
+expression: validated
+---
+{
+  "file_id": 1,
+  "db_path": "~/.cargo/advisory-dbs",
+  "db_urls": [
+    "https://github.com/RustSec/advisory-db"
+  ],
+  "ignore": [
+    "RUSTSEC-0000-0000"
+  ],
+  "ignore_yanked": [
+    {
+      "spec": {
+        "name": "crate",
+        "version-req": "=0.1"
+      },
+      "reason": null,
+      "use-instead": null
+    },
+    {
+      "spec": {
+        "name": "yanked",
+        "version-req": null
+      },
+      "reason": "a new version has not been released",
+      "use-instead": null
+    }
+  ],
+  "vulnerability": "deny",
+  "unmaintained": "warn",
+  "unsound": "warn",
+  "yanked": "warn",
+  "notice": "warn",
+  "severity_threshold": "medium",
+  "git_fetch_with_cli": false,
+  "disable_yank_checking": false,
+  "maximum_db_staleness": [
+    466560000,
+    0
+  ]
+}

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg.snap
@@ -1,44 +1,35 @@
 ---
 source: src/advisories/cfg.rs
-expression: validated
+expression: diags
 ---
-{
-  "file_id": 1,
-  "db_path": "~/.cargo/advisory-dbs",
-  "db_urls": [
-    "https://github.com/RustSec/advisory-db"
-  ],
-  "ignore": [
-    "RUSTSEC-0000-0000"
-  ],
-  "ignore_yanked": [
-    {
-      "spec": {
-        "name": "crate",
-        "version-req": "=0.1"
-      },
-      "reason": null,
-      "use-instead": null
-    },
-    {
-      "spec": {
-        "name": "yanked",
-        "version-req": null
-      },
-      "reason": "a new version has not been released",
-      "use-instead": null
-    }
-  ],
-  "vulnerability": "deny",
-  "unmaintained": "warn",
-  "unsound": "warn",
-  "yanked": "warn",
-  "notice": "warn",
-  "severity_threshold": "medium",
-  "git_fetch_with_cli": false,
-  "disable_yank_checking": false,
-  "maximum_db_staleness": [
-    466560000,
-    0
-  ]
-}
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/advisories.toml:4:1
+  │
+4 │ vulnerability = "deny"
+  │ ^^^^^^^^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/advisories.toml:5:1
+  │
+5 │ unmaintained = "warn"
+  │ ^^^^^^^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/advisories.toml:6:1
+  │
+6 │ unsound = "warn"
+  │ ^^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/advisories.toml:8:1
+  │
+8 │ notice = "warn"
+  │ ^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+   ┌─ tests/cfg/advisories.toml:14:1
+   │
+14 │ severity-threshold = "medium"
+   │ ^^^^^^^^^^^^^^^^^^
+
+

--- a/src/diag/general.rs
+++ b/src/diag/general.rs
@@ -29,23 +29,39 @@ impl From<Code> for String {
 }
 
 pub enum DeprecationReason {
-    WillBeRemoved,
+    WillBeRemoved(Option<&'static str>),
     Moved(&'static str),
     Renamed(&'static str),
     MovedAndRenamed {
         table: &'static str,
         key: &'static str,
     },
+    Removed(&'static str),
 }
 
 impl fmt::Display for DeprecationReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::WillBeRemoved => f.write_str("the key will be removed in a future update"),
-            Self::Moved(tab) => write!(f, "the key has been moved to [{tab}]"),
-            Self::Renamed(nname) => write!(f, "the key has been renamed to '{nname}'"),
+            Self::WillBeRemoved(url) => {
+                if let Some(url) = url {
+                    write!(
+                        f,
+                        "this key will be removed in a future update, see {url} for details"
+                    )
+                } else {
+                    f.write_str("this key will be removed in a future update")
+                }
+            }
+            Self::Moved(tab) => write!(f, "this key has been moved to [{tab}]"),
+            Self::Renamed(nname) => write!(f, "this key has been renamed to '{nname}'"),
             Self::MovedAndRenamed { table, key } => {
-                write!(f, "the key been moved to [{table}] and renamed to '{key}'")
+                write!(f, "this key been moved to [{table}] and renamed to '{key}'")
+            }
+            Self::Removed(url) => {
+                write!(
+                    f,
+                    "this key has been removed, see {url} for migration information"
+                )
             }
         }
     }

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -278,7 +278,7 @@ impl<'de> Deserialize<'de> for Config {
         let mut fdeps = Vec::new();
 
         let private = th.optional("private").unwrap_or_default();
-        let unlicensed = th.optional("unlicensed").unwrap_or(LintLevel::Deny);
+        let unlicensed = deprecated(&mut th, "unlicensed", &mut fdeps).unwrap_or(LintLevel::Deny);
         let allow_osi_fsf_free =
             deprecated(&mut th, "allow-osi-fsf-free", &mut fdeps).unwrap_or_default();
         let copyleft = deprecated(&mut th, "copyleft", &mut fdeps).unwrap_or(LintLevel::Warn);

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -22,9 +22,9 @@
 //! ```
 
 use crate::{
-    cfg::{PackageSpec, ValidationContext},
+    cfg::{deprecated, PackageSpec, ValidationContext},
     diag::{Diagnostic, FileId, Label},
-    LintLevel, PathBuf, Spanned,
+    LintLevel, PathBuf, Span, Spanned,
 };
 use toml_span::{de_helpers::TableHelper, value::Value, DeserError, Deserialize};
 
@@ -248,6 +248,7 @@ pub struct Config {
     /// If true, performs license checks for dev-dependencies for workspace
     /// crates as well
     pub include_dev: bool,
+    deprecated: Vec<Span>,
 }
 
 impl Default for Config {
@@ -265,6 +266,7 @@ impl Default for Config {
             clarify: Vec::new(),
             exceptions: Vec::new(),
             include_dev: false,
+            deprecated: Vec::new(),
         }
     }
 }
@@ -273,15 +275,18 @@ impl<'de> Deserialize<'de> for Config {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
         let mut th = TableHelper::new(value)?;
 
+        let mut fdeps = Vec::new();
+
         let private = th.optional("private").unwrap_or_default();
         let unlicensed = th.optional("unlicensed").unwrap_or(LintLevel::Deny);
-        let allow_osi_fsf_free = th.optional("allow-osi-fsf-free").unwrap_or_default();
-        let copyleft = th.optional("copyleft").unwrap_or(LintLevel::Warn);
-        let default = th.optional("default").unwrap_or(LintLevel::Deny);
+        let allow_osi_fsf_free =
+            deprecated(&mut th, "allow-osi-fsf-free", &mut fdeps).unwrap_or_default();
+        let copyleft = deprecated(&mut th, "copyleft", &mut fdeps).unwrap_or(LintLevel::Warn);
+        let default = deprecated(&mut th, "default", &mut fdeps).unwrap_or(LintLevel::Deny);
         let confidence_threshold = th
             .optional("confidence-threshold")
             .unwrap_or(DEFAULT_CONFIDENCE_THRESHOLD);
-        let deny = th.optional("deny").unwrap_or_default();
+        let deny = deprecated(&mut th, "deny", &mut fdeps).unwrap_or_default();
         let allow = th.optional("allow").unwrap_or_default();
         let unused_allowed_license = th
             .optional("unused-allowed-license")
@@ -305,6 +310,7 @@ impl<'de> Deserialize<'de> for Config {
             clarify,
             exceptions,
             include_dev,
+            deprecated: fdeps,
         })
     }
 }
@@ -396,6 +402,23 @@ impl crate::cfg::UnvalidatedConfig for Config {
                 expression: expr,
                 license_files,
             });
+        }
+
+        use crate::diag::general::{Deprecated, DeprecationReason};
+
+        // Output any deprecations, we'll remove the fields at the same time we
+        // remove all the logic they drive
+        for dep in self.deprecated {
+            ctx.push(
+                Deprecated {
+                    reason: DeprecationReason::WillBeRemoved(Some(
+                        "https://github.com/EmbarkStudios/cargo-deny/pull/606",
+                    )),
+                    key: dep,
+                    file_id: ctx.cfg_id,
+                }
+                .into(),
+            )
         }
 
         ValidConfig {
@@ -537,7 +560,13 @@ mod test {
     #[test]
     fn deserializes_licenses_cfg() {
         let cd = ConfigData::<Licenses>::load("tests/cfg/licenses.toml");
-        let validated = cd.validate(|l| l.licenses);
+        let validated = cd.validate_with_diags(
+            |l| l.licenses,
+            |files, diags| {
+                let diags = write_diagnostics(files, diags.into_iter());
+                insta::assert_snapshot!(diags);
+            },
+        );
 
         insta::assert_json_snapshot!(validated);
     }

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
@@ -11,4 +11,10 @@ error: a license id was specified in both `allow` and `deny`
 11 │    "MIT",
    │     --- deny
 
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+   ┌─ license-in-allow-and-deny:10:1
+   │
+10 │ deny = [
+   │ ^^^^
+
 

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
@@ -1,0 +1,57 @@
+---
+source: src/licenses/cfg.rs
+expression: validated
+---
+{
+  "file_id": 1,
+  "private": {
+    "ignore": true,
+    "ignore_sources": [],
+    "registries": [
+      "sekrets"
+    ]
+  },
+  "unlicensed": "warn",
+  "copyleft": "deny",
+  "unused_allowed_license": "warn",
+  "allow_osi_fsf_free": "Both",
+  "default": "warn",
+  "confidence_threshold": 0.95,
+  "denied": [
+    "BSD-2-Clause",
+    "Nokia"
+  ],
+  "allowed": [
+    "Apache-2.0 WITH LLVM-exception",
+    "EUPL-1.2"
+  ],
+  "clarifications": [
+    {
+      "spec": {
+        "name": "ring",
+        "version-req": null
+      },
+      "expression": "MIT AND ISC AND OpenSSL",
+      "license-files": [
+        {
+          "path": "LICENSE",
+          "hash": 3171872035
+        }
+      ]
+    }
+  ],
+  "exceptions": [
+    {
+      "spec": {
+        "name": "adler32",
+        "version-req": "^0.1.1"
+      },
+      "allowed": [
+        "Zlib"
+      ],
+      "file_id": 1
+    }
+  ],
+  "ignore_sources": [],
+  "include_dev": false
+}

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
@@ -1,57 +1,29 @@
 ---
 source: src/licenses/cfg.rs
-expression: validated
+expression: diags
 ---
-{
-  "file_id": 1,
-  "private": {
-    "ignore": true,
-    "ignore_sources": [],
-    "registries": [
-      "sekrets"
-    ]
-  },
-  "unlicensed": "warn",
-  "copyleft": "deny",
-  "unused_allowed_license": "warn",
-  "allow_osi_fsf_free": "Both",
-  "default": "warn",
-  "confidence_threshold": 0.95,
-  "denied": [
-    "BSD-2-Clause",
-    "Nokia"
-  ],
-  "allowed": [
-    "Apache-2.0 WITH LLVM-exception",
-    "EUPL-1.2"
-  ],
-  "clarifications": [
-    {
-      "spec": {
-        "name": "ring",
-        "version-req": null
-      },
-      "expression": "MIT AND ISC AND OpenSSL",
-      "license-files": [
-        {
-          "path": "LICENSE",
-          "hash": 3171872035
-        }
-      ]
-    }
-  ],
-  "exceptions": [
-    {
-      "spec": {
-        "name": "adler32",
-        "version-req": "^0.1.1"
-      },
-      "allowed": [
-        "Zlib"
-      ],
-      "file_id": 1
-    }
-  ],
-  "ignore_sources": [],
-  "include_dev": false
-}
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/licenses.toml:3:1
+  │
+3 │ allow-osi-fsf-free = "both"
+  │ ^^^^^^^^^^^^^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/licenses.toml:4:1
+  │
+4 │ copyleft = "deny"
+  │ ^^^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/licenses.toml:5:1
+  │
+5 │ default = "warn"
+  │ ^^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/licenses.toml:8:1
+  │
+8 │ deny = [
+  │ ^^^^
+
+

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
@@ -3,6 +3,12 @@ source: src/licenses/cfg.rs
 expression: diags
 ---
 warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+  ┌─ tests/cfg/licenses.toml:2:1
+  │
+2 │ unlicensed = "warn"
+  │ ^^^^^^^^^^
+
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
   ┌─ tests/cfg/licenses.toml:3:1
   │
 3 │ allow-osi-fsf-free = "both"


### PR DESCRIPTION
This PR deprecates several fields which will be removed in a future update. I'll explain in detail why below, but the TLDR is that cargo-deny surfaces several configuration options that were added because we _could_, but not necessarily because they are useful in practice.

## Licenses

### [`deny`](https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-allow-and-deny-fields-optional) 

This field was only added for consistency with `[bans]` but makes no sense for `[licenses]`, if a license you don't explicitly allow is used it is implicitly denied.

### [`copyleft`](https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-copyleft-field-optional)

There is no reason to treat these differently from any other license, if it's not explicitly allowed it should be denied, and it just adds confusion due to the terrible default.

See: #602
See: #354

### [`allow-osi-fsf-free`](https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-allow-osi-fsf-free-field-optional)

Similarly to copyleft, this field just makes no sense and was only added because the SPDX metadata allowed us to query this information.

### [`default`](https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-default-field-optional)

This was added so that users could just ignore/warn all their dependencies not following the set of allowed licenses, but just isn't much value. Even in large projects with literally hundreds of external dependencies the set of licenses that need to be allowed are relatively small compared to the total set of licenses in SPDX due to the Rust ecosystem generally using only a handful of licenses, with rare exceptions.

### [`unlicensed`](https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-unlicensed-field-optional)

Crates that don't specify a license via `[package.license/license-file]` or have a license file in their package source are incredibly rare, and there is already a [mechanism](https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-clarify-field-optional) to provide/override license information for those rare crates.

## Advisories

### Blanket

- [`vulnerability`](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-vulnerability-field-optional)
- [`unmaintained`](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-unmaintained-field-optional)
- [`unsound`](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-unsound-field-optional)
- [`notice`](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-notice-field-optional)

There's no need to blanket handle any of these specific advisory types, there just aren't enough advisories (currently, this could change in the future) that a typical workspace will encounter that they can't be handled explicitly via `ignore`.

See: #449

### [`severity-threshold`](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-severity-threshold-field-optional)

This optional field is available in rustsec advisories, but provides no real value as it's just flavor on top of a reported vulnerability, but doesn't fundamentally change that it is a vulnerability, and can either be ignored or better yet, updated to a version without the vulnerability.