### PR TITLE
Add version = 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "tame-index"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8d8b231dac2161abc5ac5abc07115fa29886f1defa6eae2bfcca40d6d61560"
+checksum = "ab9ccd31f158301d01e0bd1d3e2b1c3f2ad209f0301b4121d3ccb508aae5237d"
 dependencies = [
  "bytes",
  "camino",
@@ -2721,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "toml-span"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c5896fa509a428e0ffcb1e37c7954f183a507784cd2999cb76c3b7544bf52d"
+checksum = "369db38ce6d1fc320a54ea3f032d07c07a232ca19c40e287246aff06d57c2abe"
 dependencies = [
  "codespan-reporting",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ time = { version = "0.3", default-features = false, features = [
   "macros",
 ] }
 # Deserialization of configuration files and crate manifests
-toml-span = { version = "0.1.0", features = ["reporting"] }
+toml-span = { version = "0.2", features = ["reporting"] }
 # Small fast hash crate
 twox-hash = { version = "1.5", default-features = false }
 # Url parsing/manipulation
@@ -138,7 +138,7 @@ fs_extra = "1.3"
 insta = { version = "1.21", features = ["json"] }
 tame-index = { version = "0.9", features = ["local-builder"] }
 time = { version = "0.3", features = ["serde"] }
-toml-span = { version = "0.1.0", features = ["serde"] }
+toml-span = { version = "0.2", features = ["serde"] }
 # We use this for creating fake crate directories for crawling license files on disk
 tempfile = "3.1.0"
 

--- a/deny.toml
+++ b/deny.toml
@@ -11,14 +11,9 @@ targets = [
 all-features = true
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
-notice = "deny"
-unsound = "deny"
+version = 2
 ignore = [
-    # rmp-serde used by askalono for the cache files, these are always utf-8 so
-    # the advisory is not relevant
-    "RUSTSEC-2022-0092",
+    { id = "RUSTSEC-2022-0092", reason = "askalono always provides valid utf-8 files from a cache, this is not relevant" },
 ]
 
 [bans]
@@ -44,9 +39,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 
 [licenses]
-unlicensed = "deny"
-allow-osi-fsf-free = "neither"
-copyleft = "deny"
+version = 2
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93
 allow = [

--- a/src/advisories/diags.rs
+++ b/src/advisories/diags.rs
@@ -102,27 +102,6 @@ impl<'a> crate::CheckCtx<'a, super::cfg::ValidConfig> {
                 }
             });
 
-            // let (lint_level, ty) = match &advisory.informational {
-            //     // Everything that isn't an informational advisory is a vulnerability
-            //     None => (self.cfg.vulnerability, AdvisoryType::Vulnerability),
-            //     Some(info) => match info {
-            //         // Security notices for a crate which are published on https://rustsec.org
-            //         // but don't represent a vulnerability in a crate itself.
-            //         Informational::Notice => (self.cfg.notice, AdvisoryType::Notice),
-
-            //         Informational::Unmaintained => {
-            //             (self.cfg.unmaintained, AdvisoryType::Unmaintained)
-            //         }
-            //         Informational::Unsound => (self.cfg.unsound, AdvisoryType::Unsound),
-            //         // Other types of informational advisories: left open-ended to add
-            //         // more of them in the future.
-            //         Informational::Other(_) => {
-
-            //         }
-            //         _ => unreachable!("unknown advisory type encountered"),
-            //     },
-            // };
-
             // Ok, we found a crate whose version lies within the range of an
             // advisory, but the user might have decided to ignore it
             // for "reasons", but in that case we still emit it to the log

--- a/src/advisories/diags.rs
+++ b/src/advisories/diags.rs
@@ -89,26 +89,39 @@ impl<'a> crate::CheckCtx<'a, super::cfg::ValidConfig> {
         let mut pack = Pack::with_kid(Check::Advisories, krate.id.clone());
 
         let (severity, ty) = {
-            let (lint_level, ty) = match &advisory.informational {
-                // Everything that isn't an informational advisory is a vulnerability
-                None => (self.cfg.vulnerability, AdvisoryType::Vulnerability),
-                Some(info) => match info {
-                    // Security notices for a crate which are published on https://rustsec.org
-                    // but don't represent a vulnerability in a crate itself.
-                    Informational::Notice => (self.cfg.notice, AdvisoryType::Notice),
+            let adv_ty = advisory.informational.as_ref().map_or(AdvisoryType::Vulnerability, |info| {
+                match info {
                     // Crate is unmaintained / abandoned
-                    Informational::Unmaintained => {
-                        (self.cfg.unmaintained, AdvisoryType::Unmaintained)
+                    Informational::Unmaintained => AdvisoryType::Unmaintained,
+                    Informational::Unsound => AdvisoryType::Unsound,
+                    Informational::Notice => AdvisoryType::Notice,
+                    Informational::Other(other) => {
+                        unreachable!("rustsec only returns Informational::Other({other}) advisories if we ask, and there are none at the moment to ask for");
                     }
-                    Informational::Unsound => (self.cfg.unsound, AdvisoryType::Unsound),
-                    // Other types of informational advisories: left open-ended to add
-                    // more of them in the future.
-                    Informational::Other(_) => {
-                        unreachable!("rustsec only returns these if we ask, and there are none at the moment to ask for");
-                    }
-                    _ => unreachable!("unknown advisory type encountered"),
-                },
-            };
+                    _ => unreachable!("non_exhaustive enums are the worst"),
+                }
+            });
+
+            // let (lint_level, ty) = match &advisory.informational {
+            //     // Everything that isn't an informational advisory is a vulnerability
+            //     None => (self.cfg.vulnerability, AdvisoryType::Vulnerability),
+            //     Some(info) => match info {
+            //         // Security notices for a crate which are published on https://rustsec.org
+            //         // but don't represent a vulnerability in a crate itself.
+            //         Informational::Notice => (self.cfg.notice, AdvisoryType::Notice),
+
+            //         Informational::Unmaintained => {
+            //             (self.cfg.unmaintained, AdvisoryType::Unmaintained)
+            //         }
+            //         Informational::Unsound => (self.cfg.unsound, AdvisoryType::Unsound),
+            //         // Other types of informational advisories: left open-ended to add
+            //         // more of them in the future.
+            //         Informational::Other(_) => {
+
+            //         }
+            //         _ => unreachable!("unknown advisory type encountered"),
+            //     },
+            // };
 
             // Ok, we found a crate whose version lies within the range of an
             // advisory, but the user might have decided to ignore it
@@ -132,22 +145,29 @@ impl<'a> crate::CheckCtx<'a, super::cfg::ValidConfig> {
                 );
 
                 LintLevel::Allow
-            } else if let Some(severity_threshold) = self.cfg.severity_threshold {
-                if let Some(advisory_severity) = advisory.cvss.as_ref().map(|cvss| cvss.severity())
-                {
-                    if advisory_severity < severity_threshold {
-                        LintLevel::Allow
-                    } else {
-                        lint_level
+            } else if let Some(deprecated) = &self.cfg.deprecated {
+                'll: {
+                    if let (Some(st), Some(sev)) = (
+                        deprecated.severity_threshold,
+                        advisory.cvss.as_ref().map(|c| c.severity()),
+                    ) {
+                        if sev < st {
+                            break 'll LintLevel::Allow;
+                        }
                     }
-                } else {
-                    lint_level
+
+                    match adv_ty {
+                        AdvisoryType::Vulnerability => deprecated.vulnerability,
+                        AdvisoryType::Unmaintained => deprecated.unmaintained,
+                        AdvisoryType::Unsound => deprecated.unsound,
+                        AdvisoryType::Notice => deprecated.notice,
+                    }
                 }
             } else {
-                lint_level
+                LintLevel::Deny
             };
 
-            (lint_level.into(), ty)
+            (lint_level.into(), adv_ty)
         };
 
         let mut notes = get_notes_from_advisory(advisory);

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
@@ -32,12 +32,14 @@ expression: validated
       "use-instead": null
     }
   ],
-  "vulnerability": "deny",
-  "unmaintained": "warn",
-  "unsound": "warn",
+  "deprecated": {
+    "vulnerability": "deny",
+    "unmaintained": "warn",
+    "unsound": "warn",
+    "notice": "warn",
+    "severity_threshold": "medium"
+  },
   "yanked": "warn",
-  "notice": "warn",
-  "severity_threshold": "medium",
   "git_fetch_with_cli": false,
   "disable_yank_checking": false,
   "maximum_db_staleness": [

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -1,26 +1,5 @@
 #![cfg_attr(docsrs, doc(include = "../../docs/licenses/cfg.md"))]
 
-//! If a `[license]` configuration section, cargo-deny will use the default
-//! configuration.
-//!
-//! ```
-//! use cargo_deny::{LintLevel, licenses::cfg::Config};
-//!
-//! let dc = Config::default();
-//!
-//! assert_eq!(dc.unlicensed, LintLevel::Deny);
-//! assert_eq!(
-//!     dc.allow_osi_fsf_free,
-//!     cargo_deny::licenses::cfg::BlanketAgreement::Neither
-//! );
-//! assert_eq!(dc.copyleft, LintLevel::Warn);
-//! assert_eq!(dc.confidence_threshold, 0.8);
-//! assert!(dc.deny.is_empty());
-//! assert!(dc.allow.is_empty());
-//! assert!(dc.clarify.is_empty());
-//! assert!(dc.exceptions.is_empty());
-//! ```
-
 use crate::{
     cfg::{deprecated, PackageSpec, ValidationContext},
     diag::{Diagnostic, FileId, Label},

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
@@ -11,11 +11,7 @@ expression: validated
       "sekrets"
     ]
   },
-  "unlicensed": "warn",
-  "copyleft": "deny",
   "unused_allowed_license": "warn",
-  "allow_osi_fsf_free": "Both",
-  "default": "warn",
   "confidence_threshold": 0.95,
   "denied": [
     "BSD-2-Clause",
@@ -53,5 +49,12 @@ expression: validated
     }
   ],
   "ignore_sources": [],
+  "deprecated": {
+    "unlicensed": "warn",
+    "allow_osi_fsf_free": "Both",
+    "copyleft": "deny",
+    "default": "warn",
+    "deny": []
+  },
   "include_dev": false
 }


### PR DESCRIPTION
This is a follow up to #606 that actually provides a way to remove the deprecated fields and opt in to the new behavior until the fields are removed and the new behavior becomes the only behavior.

Basically, `version = 2` can be added to the `[advisories]` and `[licenses]`, which opts in to the new behavior, and means any of the deprecated keys no longer impact the results of the checks.

The new behavior is as follows:

### `[advisories]`

- `vulnerability` - `deny`
- `unmaintained` - `deny`, old default = `warn`
- `unsound` - `deny`, old default = `warn`
- `notice` - `deny`, old default = `warn`
- `severity-threshold` - CVSS severity no longer considered

Resolves: #449

### `[licenses]`

#### `unlicensed`

New default of `deny`, old default was `warn`.

If a crate is unlicensed, a [clarification](https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-clarify-field-optional) can be used to assign a license based on one or more source files in the package

#### `allow-osi-fsf-free`

Old default was `both`, the new default is `neither`, ie, it doesn't matter if the license is osi and/or fsf free, only if it is in the allow (or exception) list.

#### `copyleft`

Old default was `warn`, the new default is `deny, it only matters if the license is allowed in the allow or exception list.

Resolves: #602
Resolves: #354

#### `default`

Provided the default for a license not otherwise listed, now all licenses are `deny` unless explicitly in the allow or exception list.

#### `deny`

This list served no purpose, if the license is not in the allow or exception list, it is denied.