### PR TITLE
Add basic shell expansion for `dp-path`

### DIFF
--- a/deny.template.toml
+++ b/deny.template.toml
@@ -63,18 +63,10 @@ feature-depth = 1
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-# The path where the advisory database is cloned/fetched into
-db-path = "~/.cargo/advisory-db"
+# The path where the advisory databases are cloned/fetched into
+#db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use
-db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
-# The lint level for crates that have been yanked from their source registry
-yanked = "warn"
-# The lint level for crates with security notices.
-notice = "warn"
+#db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -93,8 +85,6 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -103,22 +93,6 @@ allow = [
     #"Apache-2.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]
-# Lint level for licenses considered copyleft
-copyleft = "warn"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi - The license will be approved if it is OSI approved
-# * fsf - The license will be approved if it is FSF Free
-# * osi-only - The license will be approved if it is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if it is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/docs/src/checks/advisories/cfg.md
+++ b/docs/src/checks/advisories/cfg.md
@@ -16,41 +16,51 @@ Default: [RustSec Advisory DB](https://github.com/RustSec/advisory-db)
 
 ### The `db-path` field (optional)
 
-Path to the root directory into which one or more advisory databases are cloned into
+Path to the root directory into which one or more advisory databases are cloned into.
 
-Default: `~/.cargo/advisory-db`
+This value supports basic shell expansion:
+
+- `~` - Expands to [`home::home_dir`](https://docs.rs/home/latest/home/fn.home_dir.html)
+- `$VARNAME` - Expands to [`std::env::var("VARNAME")`](https://doc.rust-lang.org/std/env/fn.var.html)
+- `${VARNAME}` - Expands to [`std::env::var("VARNAME")`](https://doc.rust-lang.org/std/env/fn.var.html)
+- `${VARNAME:-fallback}` - Expands to [`std::env::var("VARNAME")`](https://doc.rust-lang.org/std/env/fn.var.html) or the fallback value if it doesn't exist (everything between the `:-` and `}`)
+- `$CARGO_HOME` - Expands to [`std::env::var("CARGO_HOME")`](https://doc.rust-lang.org/std/env/fn.var.html) if it exists, otherwise expands to `$(home::home_dir())/.cargo`
+
+Note that the path must be valid utf-8, after expansion.
+
+Default: `$CARGO_HOME/advisory-dbs`
 
 ### The `vulnerability` field (optional)
 
 Determines what happens when a crate with a security vulnerability is encountered.
 
-* `deny` (default) - Will emit an error with details about each vulnerability, and fail the check.
-* `warn` - Prints a warning for each vulnerability, but does not fail the check.
-* `allow` - Prints a note about the security vulnerability, but does not fail the check.
+- `deny` (default) - Will emit an error with details about each vulnerability, and fail the check.
+- `warn` - Prints a warning for each vulnerability, but does not fail the check.
+- `allow` - Prints a note about the security vulnerability, but does not fail the check.
 
 ### The `unmaintained` field (optional)
 
 Determines what happens when a crate with an `unmaintained` advisory is encountered.
 
-* `deny` - Will emit an error with details about the unmaintained advisory, and fail the check.
-* `warn` (default) - Prints a warning for each unmaintained advisory, but does not fail the check.
-* `allow` - Prints a note about the unmaintained advisory, but does not fail the check.
+- `deny` - Will emit an error with details about the unmaintained advisory, and fail the check.
+- `warn` (default) - Prints a warning for each unmaintained advisory, but does not fail the check.
+- `allow` - Prints a note about the unmaintained advisory, but does not fail the check.
 
 ### The `unsound` field (optional)
 
 Determines what happens when a crate with an `unsound` advisory is encountered.
 
-* `deny` - Will emit an error with details about the unsound advisory, and fail the check.
-* `warn` (default) - Prints a warning for each unsound advisory, but does not fail the check.
-* `allow` - Prints a note about the unsound advisory, but does not fail the check.
+- `deny` - Will emit an error with details about the unsound advisory, and fail the check.
+- `warn` (default) - Prints a warning for each unsound advisory, but does not fail the check.
+- `allow` - Prints a note about the unsound advisory, but does not fail the check.
 
 ### The `yanked` field (optional)
 
 Determines what happens when a crate with a version that has been yanked from its source registry is encountered.
 
-* `deny` - Will emit an error with the crate name and version that was yanked, and fail the check.
-* `warn` (default) - Prints a warning with the crate name and version that was yanked, but does not fail the check.
-* `allow` - Prints a note about the yanked crate, but does not fail the check.
+- `deny` - Will emit an error with the crate name and version that was yanked, and fail the check.
+- `warn` (default) - Prints a warning with the crate name and version that was yanked, but does not fail the check.
+- `allow` - Prints a note about the yanked crate, but does not fail the check.
 
 ### The `notice` field (optional)
 
@@ -58,9 +68,9 @@ Determines what happens when a crate with a `notice` advisory is encountered.
 
 **NOTE**: As of 2019-12-17 there are no `notice` advisories in the [RustSec Advisory DB](https://github.com/RustSec/advisory-db)
 
-* `deny` - Will emit an error with details about the notice advisory, and fail the check.
-* `warn` (default) - Prints a warning for each notice advisory, but does not fail the check.
-* `allow` - Prints a note about the notice advisory, but does not fail the check.
+- `deny` - Will emit an error with details about the notice advisory, and fail the check.
+- `warn` (default) - Prints a warning for each notice advisory, but does not fail the check.
+- `allow` - Prints a note about the notice advisory, but does not fail the check.
 
 ### The `ignore` field (optional)
 
@@ -81,18 +91,18 @@ In addition, yanked crate versions can be ignored by specifying a [PackageSpec](
 
 The threshold for security vulnerabilities to be turned into notes instead of warnings or errors, depending upon its [CVSS](https://en.wikipedia.org/wiki/Common_Vulnerability_Scoring_System) score. So having a high threshold means some vulnerabilities might not fail the check, but having a log level `>= info` will mean that a note will be printed instead of a warning or error, depending on `[advisories.vulnerability]`.
 
-* `None` (default) - CVSS Score 0.0
-* `Low` - CVSS Score 0.1 - 3.9
-* `Medium` - CVSS Score 4.0 - 6.9
-* `High` - CVSS Score 7.0 - 8.9
-* `Critical` - CVSS Score 9.0 - 10.0
+- `None` (default) - CVSS Score 0.0
+- `Low` - CVSS Score 0.1 - 3.9
+- `Medium` - CVSS Score 4.0 - 6.9
+- `High` - CVSS Score 7.0 - 8.9
+- `Critical` - CVSS Score 9.0 - 10.0
 
 ### The `git-fetch-with-cli` field (optional)
 
 Similar to cargo's [net.git-fetch-with-cli](https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli), this field allows you to opt-in to fetching advisory databases with the git CLI rather than using `gix`.
 
-* `false` (default) - Fetches advisory databases via `gix`
-* `true` - Fetches advisory databases using `git`. Git must be installed and in `PATH`.
+- `false` (default) - Fetches advisory databases via `gix`
+- `true` - Fetches advisory databases using `git`. Git must be installed and in `PATH`.
 
 ### The `maximum-db-staleness` field (optional)
 
@@ -122,5 +132,5 @@ Note that while the spec supports `,` as a decimal separator, for simplicity car
 
 One final note, there are 2 units available in the format that are not exact, namely, year 'Y' and month 'M'. It's not recommended to use either of them for that reason, but if you do they are calculated as follows.
 
-* 1 year = 365 days
-* 1 month = 30.43 days
+- 1 year = 365 days
+- 1 month = 30.43 days

--- a/src/advisories/cfg.rs
+++ b/src/advisories/cfg.rs
@@ -1,8 +1,9 @@
 use crate::{
     cfg::{PackageSpecOrExtended, Reason, ValidationContext},
     diag::{Diagnostic, FileId, Label},
-    LintLevel, PathBuf, Span, Spanned,
+    utf8path, LintLevel, PathBuf, Span, Spanned,
 };
+use anyhow::Context as _;
 use rustsec::advisory;
 use time::Duration;
 use toml_span::{de_helpers::*, value::ValueInner, Deserialize, Value};
@@ -83,7 +84,7 @@ pub(crate) struct Deprecated {
 
 pub struct Config {
     /// Path to the root directory where advisory databases are stored (default: $CARGO_HOME/advisory-dbs)
-    pub db_path: Option<PathBuf>,
+    pub db_path: Option<Spanned<PathBuf>>,
     /// List of urls to git repositories of different advisory databases.
     pub db_urls: Vec<Spanned<Url>>,
     /// How to handle crates that have been yanked from eg crates.io
@@ -133,7 +134,7 @@ impl<'de> Deserialize<'de> for Config {
 
         let version = th.optional("version").unwrap_or(1);
 
-        let db_path = th.optional::<String>("db-path").map(PathBuf::from);
+        let db_path = th.optional_s::<String>("db-path").map(|s| s.map());
         let db_urls = if let Some((_, mut urls)) = th.take("db-urls") {
             let mut u = Vec::new();
 
@@ -355,6 +356,51 @@ impl crate::cfg::UnvalidatedConfig for Config {
             }
         }
 
+        let db_path = if let Some(root) = self.db_path {
+            let exp_result;
+
+            // When testing we use a specific default otherwise it gets redacted by insta
+            #[cfg(test)]
+            {
+                exp_result = shellexpand(root, ctx.cfg_id, |exp| match exp {
+                    Expand::Home => Ok(Some("/home/you".into())),
+                    Expand::Var(var) => {
+                        unreachable!("unexpected expansion request for '{var}'")
+                    }
+                });
+            }
+            #[cfg(not(test))]
+            {
+                exp_result = shellexpand(root, ctx.cfg_id, normal_expand);
+            }
+
+            match exp_result {
+                Ok(expanded) => Some(expanded),
+                Err(err) => {
+                    ctx.diagnostics.push(err);
+                    None
+                }
+            }
+        } else {
+            fn def_path() -> anyhow::Result<PathBuf> {
+                utf8path(
+                    home::cargo_home()
+                        .context("failed to resolve CARGO_HOME or HOME")?
+                        .join("advisory-dbs"),
+                )
+            }
+
+            match def_path() {
+                Ok(pb) => Some(pb),
+                Err(err) => {
+                    ctx.diagnostics.push(Diagnostic::error()
+                        .with_message(format!("unable to obtain default advisory-dbs directory: {err:#}"))
+                        .with_notes(vec!["the default directory is determined by $CARGO_HOME -> $HOME/.cargo".into()]));
+                    None
+                }
+            }
+        };
+
         use crate::diag::general::{Deprecated, DeprecationReason};
 
         // Output any deprecations, we'll remove the fields at the same time we
@@ -374,7 +420,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
 
         ValidConfig {
             file_id: ctx.cfg_id,
-            db_path: self.db_path,
+            db_path: db_path.unwrap_or_default(), // If we failed to get a path the default won't be used since errors will have occurred
             db_urls,
             ignore: ignore.into_iter().map(|s| s.value).collect(),
             ignore_yanked: ignore_yanked
@@ -398,7 +444,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
 #[cfg_attr(test, derive(serde::Serialize))]
 pub struct ValidConfig {
     pub file_id: FileId,
-    pub db_path: Option<PathBuf>,
+    pub db_path: PathBuf,
     pub db_urls: Vec<Spanned<Url>>,
     pub(crate) ignore: Vec<IgnoreId>,
     pub(crate) ignore_yanked: Vec<crate::bans::SpecAndReason>,
@@ -563,8 +609,150 @@ fn parse_rfc3339_duration(value: &str) -> anyhow::Result<Duration> {
     Ok(duration)
 }
 
+/// We could just hardcode these, but this makes testing easier
+enum Expand<'v> {
+    Home,
+    Var(&'v str),
+}
+
+#[cfg_attr(test, allow(dead_code))]
+fn normal_expand(exp: Expand<'_>) -> anyhow::Result<Option<String>> {
+    match exp {
+        Expand::Home => {
+            let hd =
+                home::home_dir().context("HOME directory could not be obtained from the OS")?;
+            let uhd = utf8path(hd)?;
+            Ok(Some(uhd.into()))
+        }
+        // We treat this one variable specially
+        Expand::Var("CARGO_HOME") => Ok(Some(
+            utf8path(home::cargo_home().context("unable to determine CARGO_HOME")?)?.into(),
+        )),
+        Expand::Var(var_name) => match std::env::var(var_name) {
+            Ok(vv) => Ok(Some(vv)),
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotUnicode(original)) => {
+                anyhow::bail!("'{original:?}' is not utf-8")
+            }
+        },
+    }
+}
+
+/// This is a _basic_ shell expander, it's not meant to be fully featured, just
+/// support the basic options a user would normally use, namely `~` expansion
+/// and `$VAR_NAME` || `${VAR_NAME(?::-(default_value))?}` expansion
+fn shellexpand(
+    to_expand: Spanned<PathBuf>,
+    cfg_id: FileId,
+    expand: impl Fn(Expand<'_>) -> anyhow::Result<Option<String>>,
+) -> Result<PathBuf, Diagnostic> {
+    let span = to_expand.span;
+    let original = to_expand.value;
+    let te = original.as_str();
+
+    if !te.contains('~') && !te.contains('$') {
+        return Ok(original);
+    }
+
+    let mut exp = String::new();
+
+    let mut cursor = 0;
+
+    if te.starts_with('~') {
+        exp.push_str(
+            &expand(Expand::Home)
+                .map_err(|err| {
+                    Diagnostic::error()
+                        .with_message(format!("unable to obtain $HOME: {err:#}"))
+                        .with_labels(vec![Label::primary(cfg_id, span.start..span.start + 1)])
+                })?
+                .expect("this either fails or returns a path"),
+        );
+        cursor += 1;
+    }
+
+    while let Some(ind) = te[cursor..].find('$') {
+        exp.push_str(&te[cursor..cursor + ind]);
+        let sspan = span.start + cursor + ind;
+        cursor += ind;
+
+        let mut default = None;
+        let (var_name, next) = if te[cursor..].starts_with("${") {
+            let end = te[cursor..].find('}').ok_or_else(|| {
+                Diagnostic::error()
+                    .with_message("opening `{` is unbalanced")
+                    .with_labels(vec![Label::primary(cfg_id, sspan..span.end)])
+            })?;
+
+            // Check if a default value is available
+            let vname = if let Some((vname, def)) = te[cursor + 2..cursor + end].split_once(":-") {
+                default = Some(def);
+                vname
+            } else {
+                &te[cursor + 2..cursor + end]
+            };
+
+            // Ensure the variable name is valid so we can give a better error
+            // other than always failing to find a variable that can never exist
+            if vname
+                .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .is_some()
+            {
+                return Err(Diagnostic::error()
+                    .with_message("variable name is invalid")
+                    .with_labels(vec![Label::primary(
+                        cfg_id,
+                        sspan..span.start + cursor + end + 1,
+                    )]));
+            }
+
+            (vname, cursor + end + 1)
+        } else {
+            cursor += 1;
+            if let Some(end) = te[cursor..].find(|c: char| !(c.is_alphanumeric() || c == '_')) {
+                (&te[cursor..cursor + end], cursor + end)
+            } else {
+                (&te[cursor..], te.len())
+            }
+        };
+
+        if var_name.is_empty() {
+            return Err(Diagnostic::error()
+                .with_message("variable name cannot be empty")
+                .with_labels(vec![Label::primary(cfg_id, sspan..span.start + next)]));
+        }
+
+        match expand(Expand::Var(var_name)) {
+            Ok(Some(vv)) => {
+                exp.push_str(&vv);
+            }
+            Err(err) => {
+                return Err(Diagnostic::error()
+                    .with_message(format!("failed to expand variable: {err:#}"))
+                    .with_labels(vec![Label::primary(cfg_id, sspan..span.start + next)]));
+            }
+            Ok(None) => {
+                if let Some(default) = default {
+                    exp.push_str(default);
+                } else {
+                    return Err(Diagnostic::error()
+                        .with_message("failed to find variable")
+                        .with_labels(vec![Label::primary(cfg_id, sspan..span.start + next)]));
+                }
+            }
+        }
+
+        cursor = next;
+    }
+
+    exp.push_str(&te[cursor..]);
+
+    Ok(exp.into())
+}
+
 #[cfg(test)]
 mod test {
+
     use super::{parse_rfc3339_duration as dur_parse, *};
     use crate::test_utils::{write_diagnostics, ConfigData};
 
@@ -697,5 +885,149 @@ ignore = [
                 }
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn expands_path() {
+        use super::Expand;
+        use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
+
+        // Überraschung in ISO_8859_15
+        const SURPRISE: &[u8] = &[220, 98, 101, 114, 114, 97, 115, 99, 104, 117, 110, 103];
+
+        macro_rules! expand {
+            ($expand:expr, $expected:literal, $value:expr) => {
+                if let Expand::Var(vn) = $expand {
+                    assert_eq!(vn, $expected);
+                    $value
+                } else {
+                    unreachable!("expected a variable name");
+                }
+            };
+        }
+
+        // These closurs need to be kept aligned with the toml array below
+        #[allow(clippy::type_complexity)]
+        let expanders: [Option<Box<dyn Fn(Expand<'_>) -> anyhow::Result<Option<String>>>>;
+            16] = [
+            Some(Box::new(|exp| {
+                if let Expand::Home = exp {
+                    anyhow::bail!("HOME directory could not be obtained from the OS");
+                } else {
+                    panic!("unexpected request")
+                }
+            })),
+            Some(Box::new(|exp| {
+                if let Expand::Home = exp {
+                    utf8path(std::ffi::OsStr::from_bytes(SURPRISE).into())?;
+                    unreachable!();
+                } else {
+                    panic!("unexpected request")
+                }
+            })),
+            Some(Box::new(|exp| {
+                if let Expand::Home = exp {
+                    Ok(Some("/this-home".into()))
+                } else {
+                    panic!("unexpected request")
+                }
+            })),
+            Some(Box::new(|exp| {
+                expand!(exp, "CARGO_HOME", Ok(Some("/default/.works".into())))
+            })),
+            Some(Box::new(|exp| {
+                expand!(exp, "CARGO_HOME2", Ok(Some("/this-also/.works".into())))
+            })),
+            None,
+            Some(Box::new(|exp| expand!(exp, "NOPE", Ok(None)))),
+            Some(Box::new(|exp| {
+                expand!(
+                    exp,
+                    "NON_UTF8",
+                    anyhow::bail!("'{:?}' is not utf-8", OsStr::from_bytes(SURPRISE))
+                )
+            })),
+            None,
+            None,
+            Some(Box::new(|exp| {
+                expand!(exp, "TRAILING", Ok(Some("trail".into())))
+            })),
+            Some(Box::new(|exp| {
+                expand!(exp, "WINDOWS", Ok(Some("windows".into())))
+            })),
+            None,
+            None,
+            Some(Box::new(|exp| {
+                expand!(exp, "IN_MID", Ok(Some("in-the-middle".into())))
+            })),
+            Some(Box::new(|exp| {
+                if matches!(exp, Expand::Var("FIRST")) {
+                    expand!(exp, "FIRST", Ok(Some("furst".into())))
+                } else {
+                    expand!(exp, "SECOND", Ok(Some("secund".into())))
+                }
+            })),
+        ];
+
+        let toml = r#"
+expansions = [
+    "~/nope", # can't find $HOME
+    "~/not-utf8", # $HOME is not a utf-8 path
+    "~/works", # expands to /this-home/works
+    "$CARGO_HOME/advisory-dbs", # expands to /default/.works/advisory-dbs
+    "${CARGO_HOME2}/advisory-dbs", # expands to /this-also/.works/advisory-dbs
+    "${no-end", # fails due to unclosed {
+    "/missing/${NOPE:-but i have a default}/", # expands to /missing/but i have a default/
+    "/non-utf8/$NON_UTF8", # fails due to NON_UTF8
+    "$/empty", # fails due to empty variable
+    "/also-empty/${}", # ditto
+    "/has-trailing/$TRAILING", # expands to /has-trailing/trail
+    "C:/Users/me/$WINDOWS/works", # expands to C:/Users/me/windows/works
+    "$!", # fails due to empty variable name
+    "${!}", # fails due to invalid character in variable name
+    "/expands/stuff-${IN_MID}-like-this", # /expands/stuff-in-the-middle-like-this
+    "/expands/$FIRST-item/${SECOND}-item/multiple", # /expands/furst-item/secund-item/multiple
+]
+"#;
+        let mut tv = toml_span::parse(toml).unwrap();
+        let toml_span::value::ValueInner::Table(mut tab) = tv.take() else {
+            unreachable!()
+        };
+        let mut expansions = tab.remove(&"expansions".into()).unwrap();
+        let toml_span::value::ValueInner::Array(exp) = expansions.take() else {
+            unreachable!()
+        };
+
+        use toml_span::Deserialize as _;
+
+        let mut files = crate::diag::Files::new();
+        let cfg_id = files.add("expansions.toml", toml.into());
+
+        let mut output = String::new();
+
+        for (mut expansion, expander) in exp.into_iter().zip(expanders.into_iter()) {
+            let expansion = toml_span::Spanned::<String>::deserialize(&mut expansion)
+                .unwrap()
+                .map();
+
+            let expander = expander.unwrap_or_else(|| {
+                Box::new(|_exp| {
+                    unreachable!("this should not be called");
+                })
+            });
+
+            match super::shellexpand(expansion, cfg_id, expander) {
+                Ok(pb) => output.push_str(pb.as_str()),
+                Err(err) => {
+                    let ds = crate::test_utils::write_diagnostics(&files, std::iter::once(err));
+                    output.push_str(&ds);
+                }
+            }
+
+            output.push('\n');
+        }
+
+        insta::assert_snapshot!(output);
     }
 }

--- a/src/advisories/cfg.rs
+++ b/src/advisories/cfg.rs
@@ -409,7 +409,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
             ctx.push(
                 Deprecated {
                     reason: DeprecationReason::WillBeRemoved(Some(
-                        "https://github.com/EmbarkStudios/cargo-deny/pull/606",
+                        "https://github.com/EmbarkStudios/cargo-deny/pull/611",
                     )),
                     key: dep,
                     file_id: ctx.cfg_id,

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
@@ -4,7 +4,7 @@ expression: validated
 ---
 {
   "file_id": 1,
-  "db_path": "~/.cargo/advisory-dbs",
+  "db_path": "/home/you/.cargo/advisory-dbs",
   "db_urls": [
     "https://github.com/RustSec/advisory-db"
   ],

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg.snap
@@ -2,34 +2,32 @@
 source: src/advisories/cfg.rs
 expression: diags
 ---
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/advisories.toml:4:1
   │
 4 │ vulnerability = "deny"
   │ ^^^^^^^^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/advisories.toml:5:1
   │
 5 │ unmaintained = "warn"
   │ ^^^^^^^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/advisories.toml:6:1
   │
 6 │ unsound = "warn"
   │ ^^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/advisories.toml:8:1
   │
 8 │ notice = "warn"
   │ ^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
    ┌─ tests/cfg/advisories.toml:14:1
    │
 14 │ severity-threshold = "medium"
    │ ^^^^^^^^^^^^^^^^^^
-
-

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__expands_path.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__expands_path.snap
@@ -1,0 +1,68 @@
+---
+source: src/advisories/cfg.rs
+expression: output
+---
+error: unable to obtain $HOME: HOME directory could not be obtained from the OS
+  ┌─ expansions.toml:3:6
+  │
+3 │     "~/nope", # can't find $HOME
+  │      ^
+
+
+error: unable to obtain $HOME: non-utf8 path: PathBuf contains invalid UTF-8: �berraschung: Path contains invalid UTF-8
+  ┌─ expansions.toml:4:6
+  │
+4 │     "~/not-utf8", # $HOME is not a utf-8 path
+  │      ^
+
+
+/this-home/works
+/default/.works/advisory-dbs
+/this-also/.works/advisory-dbs
+error: opening `{` is unbalanced
+  ┌─ expansions.toml:8:6
+  │
+8 │     "${no-end", # fails due to unclosed {
+  │      ^^^^^^^^
+
+
+/missing/but i have a default/
+error: failed to expand variable: '"\xDCberraschung"' is not utf-8
+   ┌─ expansions.toml:10:16
+   │
+10 │     "/non-utf8/$NON_UTF8", # fails due to NON_UTF8
+   │                ^^^^^^^^^
+
+
+error: variable name cannot be empty
+   ┌─ expansions.toml:11:6
+   │
+11 │     "$/empty", # fails due to empty variable
+   │      ^
+
+
+error: variable name cannot be empty
+   ┌─ expansions.toml:12:18
+   │
+12 │     "/also-empty/${}", # ditto
+   │                  ^^^
+
+
+/has-trailing/trail
+C:/Users/me/windows/works
+error: variable name cannot be empty
+   ┌─ expansions.toml:15:6
+   │
+15 │     "$!", # fails due to empty variable name
+   │      ^
+
+
+error: variable name is invalid
+   ┌─ expansions.toml:16:6
+   │
+16 │     "${!}", # fails due to invalid character in variable name
+   │      ^^^^
+
+
+/expands/stuff-in-the-middle-like-this
+/expands/furst-item/secund-item/multiple

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -406,7 +406,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
             ctx.push(
                 Deprecated {
                     reason: DeprecationReason::WillBeRemoved(Some(
-                        "https://github.com/EmbarkStudios/cargo-deny/pull/606",
+                        "https://github.com/EmbarkStudios/cargo-deny/pull/611",
                     )),
                     key: dep,
                     file_id: ctx.cfg_id,

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
@@ -11,10 +11,8 @@ error: a license id was specified in both `allow` and `deny`
 11 │    "MIT",
    │     --- deny
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
    ┌─ license-in-allow-and-deny:10:1
    │
 10 │ deny = [
    │ ^^^^
-
-

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
@@ -2,34 +2,32 @@
 source: src/licenses/cfg.rs
 expression: diags
 ---
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/licenses.toml:2:1
   │
 2 │ unlicensed = "warn"
   │ ^^^^^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/licenses.toml:3:1
   │
 3 │ allow-osi-fsf-free = "both"
   │ ^^^^^^^^^^^^^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/licenses.toml:4:1
   │
 4 │ copyleft = "deny"
   │ ^^^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/licenses.toml:5:1
   │
 5 │ default = "warn"
   │ ^^^^^^^
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/606 for details
+warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ tests/cfg/licenses.toml:8:1
   │
 8 │ deny = [
   │ ^^^^
-
-

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -37,7 +37,7 @@ fn load() -> TestCtx {
 
     let db = {
         advisories::DbSet::load(
-            Some("tests/advisory-db"),
+            "tests/advisory-db".into(),
             vec![],
             advisories::Fetch::Disallow(time::Duration::days(100)),
         )
@@ -368,7 +368,7 @@ fn to_path(td: &tempfile::TempDir) -> Option<&cargo_deny::Path> {
 #[test]
 fn fails_on_stale_advisory_database() {
     assert!(advisories::DbSet::load(
-        Some("tests/advisory-db"),
+        "tests/advisory-db".into(),
         vec![],
         advisories::Fetch::Disallow(time::Duration::seconds(0)),
     )
@@ -394,8 +394,12 @@ const EXPECTED_TWO_ID: &str = "BOOP-2023-0002";
 const EXPECTED_TWO_DATE: &str = "2023-07-10";
 
 fn do_open(td: &tempfile::TempDir, f: Fetch) -> advisories::AdvisoryDb {
-    let mut db_set =
-        advisories::DbSet::load(to_path(td), vec![TEST_DB_URL.parse().unwrap()], f).unwrap();
+    let mut db_set = advisories::DbSet::load(
+        to_path(td).unwrap().to_owned(),
+        vec![TEST_DB_URL.parse().unwrap()],
+        f,
+    )
+    .unwrap();
 
     db_set.dbs.pop().unwrap()
 }


### PR DESCRIPTION
`~` has been supported for a while, but this PR expands support to include bash-style environment variable expansion (to a limited degree).

Resolves: #612 