### PR TITLE
Add notes to rejected licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,15 +52,10 @@ allow = [
     "ISC",
 ]
 exceptions = [
-    { allow = [
-        "Zlib",
-    ], crate = "tinyvec" },
-    { allow = [
-        "Unicode-DFS-2016",
-    ], crate = "unicode-ident" },
-    { allow = [
-        "OpenSSL",
-    ], crate = "ring" },
+    # Use exceptions for these as they only have a single user
+    { allow = ["Zlib"], crate = "tinyvec" },
+    { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
+    { allow = ["OpenSSL"], crate = "ring" },
 ]
 
 # Sigh

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -343,6 +343,8 @@ pub(crate) fn cmd(
     let colorize = log_ctx.format == crate::Format::Human
         && crate::common::should_colorize(log_ctx.color, std::io::stderr());
 
+    let log_level = log_ctx.log_level;
+
     rayon::scope(|s| {
         // Asynchronously displays messages sent from the checks
         s.spawn(|_| {
@@ -372,6 +374,7 @@ pub(crate) fn cmd(
                 krate_spans: &krate_spans,
                 serialize_extra,
                 colorize,
+                log_level,
             };
 
             s.spawn(move |_| {
@@ -421,6 +424,7 @@ pub(crate) fn cmd(
                 krate_spans: &krate_spans,
                 serialize_extra,
                 colorize,
+                log_level,
             };
 
             s.spawn(|_| {
@@ -444,6 +448,7 @@ pub(crate) fn cmd(
                 krate_spans: &krate_spans,
                 serialize_extra,
                 colorize,
+                log_level,
             };
 
             s.spawn(|_| {
@@ -467,6 +472,7 @@ pub(crate) fn cmd(
                 krate_spans: &krate_spans,
                 serialize_extra,
                 colorize,
+                log_level,
             };
 
             s.spawn(move |_| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,6 +445,9 @@ pub struct CheckCtx<'ctx, T> {
     pub serialize_extra: bool,
     /// Allows for ANSI colorization of diagnostic content
     pub colorize: bool,
+    /// Log level specified by the user, may be used by checks to determine what
+    /// information to emit in diagnostics
+    pub log_level: log::LevelFilter,
 }
 
 /// Checks if a version satisfies the specifies the specified version requirement.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -276,6 +276,7 @@ where
                 cfg,
                 serialize_extra: true,
                 colorize: false,
+                log_level: log::LevelFilter::Info,
             };
             runner(ctx, newmap, tx, &mut files);
         },

--- a/tests/snapshots/licenses__accepts_exceptions.snap
+++ b/tests/snapshots/licenses__accepts_exceptions.snap
@@ -81,6 +81,17 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "Zlib - zlib License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"

--- a/tests/snapshots/licenses__handles_dev_dependencies.snap
+++ b/tests/snapshots/licenses__handles_dev_dependencies.snap
@@ -46,6 +46,11 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -85,6 +90,13 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "GPL-3.0 - GNU General Public License v3.0 only:",
+        "  - **DEPRECATED**",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "  - Copyleft"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"

--- a/tests/snapshots/licenses__rejects_licenses.snap
+++ b/tests/snapshots/licenses__rejects_licenses.snap
@@ -74,6 +74,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -151,6 +159,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -226,6 +242,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -316,6 +340,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -360,6 +392,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -420,6 +460,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -505,6 +553,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -634,6 +690,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -686,6 +750,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -746,6 +818,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -798,6 +878,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -842,6 +930,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -917,6 +1013,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -994,6 +1098,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1040,6 +1152,11 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1092,6 +1209,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1174,6 +1299,17 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "Zlib - zlib License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1264,6 +1400,17 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Zlib - zlib License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1332,6 +1479,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1400,6 +1555,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1452,6 +1615,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1521,6 +1692,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1573,6 +1752,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1617,6 +1804,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1669,6 +1864,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1729,6 +1932,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1781,6 +1992,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1841,6 +2060,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1893,6 +2120,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -1953,6 +2188,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -2005,6 +2248,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -2065,6 +2316,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -2117,6 +2376,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -2169,6 +2436,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -2229,6 +2504,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"
@@ -2281,6 +2564,14 @@ expression: diags
         }
       ],
       "message": "failed to satisfy license requirements",
+      "notes": [
+        "MIT - MIT License:",
+        "  - OSI approved",
+        "  - FSF Free/Libre",
+        "Apache-2.0 - Apache License 2.0:",
+        "  - OSI approved",
+        "  - FSF Free/Libre"
+      ],
       "severity": "error"
     },
     "type": "diagnostic"


### PR DESCRIPTION
With the new changes coming once #611 deprecations have been fully removed, licenses will be rejected unless explicitly allowed. To help users, rejected licenses will now have notes printed with the SPDX short id, the full license name, and metadata for the license, eg.

```
= OpenSSL - OpenSSL License:
=   - FSF Free/Libre
= GPL-3.0 - GNU General Public License v3.0 only:
=  - **DEPRECATED**
=  - OSI approved
=  - FSF Free/Libre
=  - Copyleft
```

Additionally, the diagnostic for rejected expressions now only includes the span information for rejected licenses, unless the log level is set to info or higher via `-L info`.

Old:

```
error[rejected]: failed to satisfy license requirements
   ┌─ /home/jake/code/cargo-deny/deny.toml:71:15
   │
71 │ expression = "ISC AND MIT AND OpenSSL"
   │               ^^^-----^^^-----^^^^^^^
   │               │       │       │
   │               │       │       rejected: license was not explicitly allowed
   │               │       accepted: license is explicitly allowed
   │               license expression retrieved via user override
   │               accepted: license is explicitly allowed
   │
```

New:

```
error[rejected]: failed to satisfy license requirements
   ┌─ /home/jake/code/cargo-deny/deny.toml:71:31
   │
71 │ expression = "ISC AND MIT AND OpenSSL"
   │               ----------------^^^^^^^
   │               │               │
   │               │               rejected: license was not explicitly allowed
   │               license expression retrieved via user override
   │
```