### PR TITLE
Fix pre-commit hook snippet in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ You can use `cargo-deny` with [pre-commit](https://pre-commit.com). Add it to yo
 
 ```yaml
 - repo: https://github.com/EmbarkStudios/cargo-deny
-  rev: 0.14.11 # choose your preferred tag
+  rev: 0.14.16 # choose your preferred tag
   hooks:
     - id: cargo-deny
-    - args: ["--all-features", "check"] # optionally modify the arguments for cargo-deny (default arguments shown here)
+      args: ["--all-features", "check"] # optionally modify the arguments for cargo-deny (default arguments shown here)
 ```
 
 ## Contributing


### PR DESCRIPTION
Sorry, I just noticed that the snippet I added in #603 contained a small error.

This also updates the tag in that snippet to the latest one.