### PR TITLE
Introduce `typos` auto-checker on CI (written in Rust btw)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   # Lightweight check for typos in any files
   typos:
+    name: Typos
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Lightweight check for typos in any files
+  typos:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      # Typos check should be pinned to the very specific version
+      # to prevent sudden dictionary updates from making our CI fail
+      - uses: crate-ci/typos@v1.19.0
+
   lint:
     name: Lint
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,6 +223,6 @@ jobs:
 
   test_success:
     runs-on: ubuntu-22.04
-    needs: [lint,test,self,publish-check,doc-book]
+    needs: [typos,lint,test,self,publish-check,doc-book]
     steps:
     - run: echo "All test jobs passed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Lightweight check for typos in any files
+  # Lightweight check for typos in any files. Config lives in 'typos.toml'
   typos:
     name: Typos
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,7 +370,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#262](https://github.com/EmbarkStudios/cargo-deny/pull/262) added the `fix` subcommand, which was added to bring `cargo-deny` to feature parity with `cargo-audit` so that it can take over for `cargo-audit` as the [official frontend](https://github.com/EmbarkStudios/cargo-deny/issues/194) for the the [RustSec Advisory Database](https://github.com/RustSec/advisory-db).
 
 ### Changed
-- `advisories.db-url` has been deprecated in favor of `advisories.db-urls` since multiple databses are now supported.
+- `advisories.db-url` has been deprecated in favor of `advisories.db-urls` since multiple databases are now supported.
 - `advisories.db-path` is now no longer the directory into which the advisory database is cloned into, but rather a root directory where each unique database is placed in a canonicalized directory similar to how `.cargo/registry/index` directories work.
 - [PR#274](https://github.com/EmbarkStudios/cargo-deny/pull/274) resolved [#115](https://github.com/EmbarkStudios/cargo-deny/issues/115) by normalizing git urls. Thanks [@senden9](https://github.com/senden9)!
 
@@ -431,7 +431,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `fetch` subcommand that can be used to fetch external data, currently the crates.io index and the configured advisory database
 
 ### Changed
-- Upgraded to rustsec 0.18.0, which slighly reworks how yanked crate detection is done
+- Upgraded to rustsec 0.18.0, which slightly reworks how yanked crate detection is done
 
 ## [0.6.4] - 2020-02-08
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Feature requests will be tagged as `enhancement` and their status will be update
 
 ### Bugs
 
-When reporting a bug or unexpected behaviour in a project, make sure your issue descibes steps to reproduce the behaviour, including the platform you were using, what steps you took, and any error messages.
+When reporting a bug or unexpected behaviour in a project, make sure your issue describes steps to reproduce the behaviour, including the platform you were using, what steps you took, and any error messages.
 
 Reproducible bugs will be tagged as `bug` and their status will be updated in the comments of the issue.
 

--- a/docs/src/checks/bans/diags.md
+++ b/docs/src/checks/bans/diags.md
@@ -94,7 +94,7 @@ An [interpreted script](cfg.md#the-interpreted-field-optional) was detected.
 
 ### `unable-to-check-path`
 
-An I/O error occured when opening or reading a file from disk.
+An I/O error occurred when opening or reading a file from disk.
 
 ### `features-enabled`
 

--- a/examples/08_target_filtering/Cargo.toml
+++ b/examples/08_target_filtering/Cargo.toml
@@ -29,8 +29,8 @@ web-sys = { version = "0.3.25", default-features = false, features = ["Crypto", 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.2.8", default-features = false }
 
-# You can also use full target triples isntead of a cfg expression
-# We actually **ban** the nix package, but since we aren't targetting
+# You can also use full target triples instead of a cfg expression
+# We actually **ban** the nix package, but since we aren't targeting
 # musl, the crate is ignored :)
 [target.x86_64-unknown-linux-musl.dependencies]
 nix-xy = { package = "nix", version = "0.16.1" }

--- a/examples/08_target_filtering/README.md
+++ b/examples/08_target_filtering/README.md
@@ -13,4 +13,4 @@ targets = [
 
 ## Description
 
-By default, cargo resolves every single dependency, including for target specific dependencies. However, it's unlikely that your project is actually built for all (143 at the time of this writing) targets that are built in to rustc itself, which means that there may be crates in your graph that are never actually compiled or used in any way. By specifying the `targets = []` configuration in your `deny.toml`, you can specify a list of targets you _actually_ are targetting, removing any crates that don't match at least 1 of the targets you specify.
+By default, cargo resolves every single dependency, including for target specific dependencies. However, it's unlikely that your project is actually built for all (143 at the time of this writing) targets that are built in to rustc itself, which means that there may be crates in your graph that are never actually compiled or used in any way. By specifying the `targets = []` configuration in your `deny.toml`, you can specify a list of targets you _actually_ are targeting, removing any crates that don't match at least 1 of the targets you specify.

--- a/examples/08_target_filtering/deny.toml
+++ b/examples/08_target_filtering/deny.toml
@@ -10,7 +10,7 @@ targets = [
 [bans]
 deny = [
     # We ban the nix package, but it's in the Cargo.toml! But that's ok
-    # because it is only built when targetting x86_64-unknown-linux-musl,
+    # because it is only built when targeting x86_64-unknown-linux-musl,
     # which we aren't
     { name = "nix" },
     # If we did build for windows, we definitely would not want version 0.2!

--- a/examples/09_bans/Cargo.toml
+++ b/examples/09_bans/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 version = "0.10.1"
 # Uncomment these to "fix" cargo deny check bans.
 # 1. By disabling default features we remove the use of native-tls, which
-# is impelemented via openssl-sys on linux
+# is implemented via openssl-sys on linux
 # 2. openssl-sys also depends on an old version of autocfg, so we remove a
 # duplicate as well!
 # default-features = false

--- a/examples/09_bans/README.md
+++ b/examples/09_bans/README.md
@@ -9,7 +9,7 @@ This example shows how to ban particular crates, and handle duplicate versions.
 version = "0.10.1"
 # Uncomment these to "fix" cargo deny check bans.
 # 1. By disabling default features we remove the use of native-tls, which
-# is impelemented via openssl-sys on linux
+# is implemented via openssl-sys on linux
 # 2. openssl-sys also depends on an old version of autocfg, so we remove a
 # duplicate as well!
 # default-features = false
@@ -42,5 +42,5 @@ skip = [
 
 ## Description
 
-This examle shows how the `bans` check works. `reqwest` by default uses native-tls, which on linux uses openssl. But we've decided to **deny** openssl, so adding a dependency on it triggers the lint. It also happens to pull in multiple
+This example shows how the `bans` check works. `reqwest` by default uses native-tls, which on linux uses openssl. But we've decided to **deny** openssl, so adding a dependency on it triggers the lint. It also happens to pull in multiple
 versions of a couple of dependencies, so we skip those. To "fix" this check, we would need to disable `reqwest`'s default features, and then enable the `"rustls"` feature, because we still want TLS!

--- a/src/advisories.rs
+++ b/src/advisories.rs
@@ -118,7 +118,7 @@ pub fn check<R, S>(
         }
     }
 
-    // Check for advisory identifers that were set to be ignored, but
+    // Check for advisory identifiers that were set to be ignored, but
     // are not actually in any database.
     for ignored in &ctx.cfg.ignore {
         if !advisory_dbs.has_advisory(&ignored.id.value) {
@@ -126,7 +126,7 @@ pub fn check<R, S>(
         }
     }
 
-    // Check for advisory identifers that were set to be ignored, but
+    // Check for advisory identifiers that were set to be ignored, but
     // were not actually encountered, for cases where a crate, or specific
     // version of that crate, has been removed or replaced and the advisory
     // no longer applies to it, so that users can cleanup their configuration

--- a/src/advisories/cfg.rs
+++ b/src/advisories/cfg.rs
@@ -963,9 +963,9 @@ ignore = [
             })),
             Some(Box::new(|exp| {
                 if matches!(exp, Expand::Var("FIRST")) {
-                    expand!(exp, "FIRST", Ok(Some("furst".into())))
+                    expand!(exp, "FIRST", Ok(Some("first".into())))
                 } else {
-                    expand!(exp, "SECOND", Ok(Some("secund".into())))
+                    expand!(exp, "SECOND", Ok(Some("second".into())))
                 }
             })),
         ];
@@ -987,7 +987,7 @@ expansions = [
     "$!", # fails due to empty variable name
     "${!}", # fails due to invalid character in variable name
     "/expands/stuff-${IN_MID}-like-this", # /expands/stuff-in-the-middle-like-this
-    "/expands/$FIRST-item/${SECOND}-item/multiple", # /expands/furst-item/secund-item/multiple
+    "/expands/$FIRST-item/${SECOND}-item/multiple", # /expands/first-item/second-item/multiple
 ]
 "#;
         let mut tv = toml_span::parse(toml).unwrap();

--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -447,7 +447,7 @@ fn fetch_via_gix(url: &Url, db_path: &Path) -> anyhow::Result<()> {
             &repo.find_remote("origin").unwrap(),
         )?;
     } else {
-        // If we didn't open a fresh repo we need to peform a fetch ourselves, and
+        // If we didn't open a fresh repo we need to perform a fetch ourselves, and
         // do the work of updating the HEAD to point at the latest remote HEAD, which
         // gix doesn't currently do.
         //
@@ -531,7 +531,7 @@ fn fetch_via_cli(url: &str, db_path: &Path) -> anyhow::Result<()> {
 
 pub struct Report<'db, 'k> {
     pub advisories: Vec<(&'k Krate, krates::NodeId, &'db rustsec::Advisory)>,
-    /// For backwards compatiblity with cargo-audit, we optionally serialize the
+    /// For backwards compatibility with cargo-audit, we optionally serialize the
     /// reports to JSON and output them in addition to the normal cargo-deny
     /// diagnostics
     pub serialized_reports: Vec<serde_json::Value>,
@@ -738,7 +738,7 @@ mod test {
         }
 
         {
-            let url = Url::parse("https://example.com/countries/việt nam").unwrap();
+            let url = Url::parse("https://example.com/countries/việt name").unwrap();
 
             #[cfg(target_endian = "little")]
             assert_eq!(

--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -738,7 +738,7 @@ mod test {
         }
 
         {
-            let url = Url::parse("https://example.com/countries/việt name").unwrap();
+            let url = Url::parse("https://example.com/countries/việt nam").unwrap();
 
             #[cfg(target_endian = "little")]
             assert_eq!(

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__expands_path.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__expands_path.snap
@@ -65,4 +65,4 @@ error: variable name is invalid
 
 
 /expands/stuff-in-the-middle-like-this
-/expands/furst-item/secund-item/multiple
+/expands/first-item/second-item/multiple

--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -342,10 +342,10 @@ pub struct Config {
     /// Allows specifying features that are or are not allowed on crates
     pub features: Vec<CrateFeatures>,
     /// The default lint level for default features for external, non-workspace
-    /// crates, can be overriden in `features` on a crate by crate basis
+    /// crates, can be overridden in `features` on a crate by crate basis
     pub external_default_features: Option<Spanned<LintLevel>>,
     /// The default lint level for default features for workspace crates, can be
-    /// overriden in `features` on a crate by crate basis
+    /// overridden in `features` on a crate by crate basis
     pub workspace_default_features: Option<Spanned<LintLevel>>,
     /// If specified, disregards the crate completely
     pub skip: Vec<CrateSkip>,

--- a/src/bans/diags.rs
+++ b/src/bans/diags.rs
@@ -237,7 +237,7 @@ pub(crate) struct UnusedWrapper {
 impl From<UnusedWrapper> for Diag {
     fn from(us: UnusedWrapper) -> Self {
         Diagnostic::new(Severity::Warning)
-            .with_message("wrapper for banned crate was not enountered")
+            .with_message("wrapper for banned crate was not encountered")
             .with_code(Code::UnusedWrapper)
             .with_labels(vec![us
                 .wrapper_cfg

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -247,7 +247,7 @@ fn real_main() -> Result<(), Error> {
         mpath
     } else {
         // For now, use the context path provided by the user, but
-        // we've deprected it and it will go away at some point
+        // we've deprecated it and it will go away at some point
         let cwd =
             std::env::current_dir().context("unable to determine current working directory")?;
 

--- a/src/cfg/package_spec.rs
+++ b/src/cfg/package_spec.rs
@@ -73,7 +73,7 @@ impl<'de> Deserialize<'de> for PackageSpec {
 
                     Ctx::from_str(s, val.span)
                 } else {
-                    // Encourge user to use the 'crate' spec instead
+                    // Encourage user to use the 'crate' spec instead
                     let name = th.required("name").map_err(|e| {
                         if matches!(e.kind, toml_span::ErrorKind::MissingField(_)) {
                             (toml_span::ErrorKind::MissingField("crate"), e.span).into()

--- a/src/diag/sink.rs
+++ b/src/diag/sink.rs
@@ -38,7 +38,7 @@ impl ErrorSink {
 
 use super::Severity;
 
-/// Each diagnostic will have a default severity, but these can be overriden
+/// Each diagnostic will have a default severity, but these can be overridden
 /// by the user via the CLI so that eg. warnings can be made into errors on CI
 pub struct DiagnosticOverrides {
     pub code_overrides: std::collections::BTreeMap<&'static str, Severity>,

--- a/src/licenses/gather.rs
+++ b/src/licenses/gather.rs
@@ -201,7 +201,7 @@ impl LicensePack {
     fn get_expression(
         &self,
         file: FileId,
-        strat: &askalono::ScanStrategy<'_>,
+        strategy: &askalono::ScanStrategy<'_>,
         confidence: f32,
     ) -> Result<GatheredExpr, (String, Vec<Label>)> {
         use std::fmt::Write;
@@ -237,7 +237,7 @@ impl LicensePack {
                     write!(synth_toml, "hash = 0x{:08x}, ", data.hash).unwrap();
 
                     let text = askalono::TextData::new(&data.content);
-                    match strat.scan(&text) {
+                    match strategy.scan(&text) {
                         Ok(lic_match) => {
                             if let Some(mut identified) = lic_match.license {
                                 // See https://github.com/EmbarkStudios/cargo-deny/issues/625
@@ -753,7 +753,7 @@ impl Gatherer {
                                 notes,
                             };
                         }
-                        Err((new_toml, lic_file_lables)) => {
+                        Err((new_toml, lic_file_labels)) => {
                             // Push our synthesized license files toml content to the end of
                             // the other synthesized toml then fixup all of our spans
                             let old_end = {
@@ -768,7 +768,7 @@ impl Gatherer {
                                 old_end
                             };
 
-                            for label in lic_file_lables {
+                            for label in lic_file_labels {
                                 let span = label.range.start + old_end..label.range.end + old_end;
                                 labels.push(
                                     Label::secondary(label.file_id, span)

--- a/tests/LICENSE-RING
+++ b/tests/LICENSE-RING
@@ -113,7 +113,7 @@ some authors is recorded for use of their work:
  * The implementation was written so as to conform with Netscapes SSL.
  * 
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
+ * the following conditions are adhered to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -138,7 +138,7 @@ some authors is recorded for use of their work:
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from 
  *    the apps directory (application code) you must include an acknowledgement:
@@ -156,7 +156,7 @@ some authors is recorded for use of their work:
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  * 
- * The licence and distribution terms for any publically available version or
+ * The licence and distribution terms for any publicly available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]

--- a/tests/bans.rs
+++ b/tests/bans.rs
@@ -151,7 +151,7 @@ multiple-versions-include-dev = true
     insta::assert_json_snapshot!(diags);
 }
 
-/// Ensures that dev dependendencies are ignored
+/// Ensures that dev dependencies are ignored
 #[test]
 fn ignores_dev() {
     let diags = gather_bans(

--- a/tests/feature_bans.rs
+++ b/tests/feature_bans.rs
@@ -155,7 +155,7 @@ fn workspace_default_features_warns_and_denies() {
     insta::assert_json_snapshot!(diags);
 }
 
-/// Ensures that a workspace default ban can be overriden by a crate specific allow = 'default'
+/// Ensures that a workspace default ban can be overridden by a crate specific allow = 'default'
 #[test]
 fn workspace_default_features_allow_override() {
     let diags = gather_bans(
@@ -204,7 +204,7 @@ fn external_default_features_warns_and_denies() {
     insta::assert_json_snapshot!(diags);
 }
 
-/// Ensures that a workspace default ban can be overriden by a crate specific allow = 'default'
+/// Ensures that a workspace default ban can be overridden by a crate specific allow = 'default'
 #[test]
 fn external_default_features_allow_override() {
     let diags = gather_bans(

--- a/tests/snapshots/bans__disallows_denied_with_wrapper.snap
+++ b/tests/snapshots/bans__disallows_denied_with_wrapper.snap
@@ -119,7 +119,7 @@ expression: diags
           "span": "other-crate"
         }
       ],
-      "message": "wrapper for banned crate was not enountered",
+      "message": "wrapper for banned crate was not encountered",
       "severity": "warning"
     },
     "type": "diagnostic"

--- a/tests/snapshots/bans__warns_on_unused_wrappers.snap
+++ b/tests/snapshots/bans__warns_on_unused_wrappers.snap
@@ -61,7 +61,7 @@ expression: diags
           "span": "other-crate"
         }
       ],
-      "message": "wrapper for banned crate was not enountered",
+      "message": "wrapper for banned crate was not encountered",
       "severity": "warning"
     },
     "type": "diagnostic"

--- a/tests/test_data/features-galore/Cargo.toml
+++ b/tests/test_data/features-galore/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 parking_lot_core = "=0.9.3"
-reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
+request = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
     "brotli",
 ] }
 rgb = { version = "0.8.25", optional = true }
@@ -22,7 +22,7 @@ git = { package = "git2", version = "=0.14.4", default-features = false }
 audio = { package = "coreaudio-rs", version = "=0.11.1", default-features = false, optional = true }
 
 [build-dependencies]
-reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
+request = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
     "cookies",
 ] }
 
@@ -31,14 +31,14 @@ simple_ecs = "=0.3.2"
 
 [features]
 default = ["simple"]
-blocking = ["simple", "reqest?/blocking"]
-json = ["reqest?/json"]
+blocking = ["simple", "request?/blocking"]
+json = ["request?/json"]
 midi = ["audio?/core_midi"]
-multipart = ["reqest?/multipart"]
+multipart = ["request?/multipart"]
 serde = ["dep:serde", "rgb?/serde"]
 simple = ["json"]
 ssh = ["git/ssh", "git/ssh_key_from_memory"]
-stream = ["reqest?/stream"]
-tls = ["tls-no-reqwest", "reqest?/rustls-tls"]
+stream = ["request?/stream"]
+tls = ["tls-no-reqwest", "request?/rustls-tls"]
 tls-no-reqwest = ["rustls"]
-zlib = ["git/zlib-ng-compat", "reqest?/deflate"]
+zlib = ["git/zlib-ng-compat", "request?/deflate"]

--- a/tests/test_data/features/Cargo.toml
+++ b/tests/test_data/features/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
+request = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
     "brotli",
     "rustls-tls",
 ] }
@@ -15,17 +15,17 @@ serde = { version = "1.0.133", optional = true }
 git = { package = "git2", version = "0.15", default-features = false }
 
 [build-dependencies]
-reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
+request = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
     "cookies",
 ] }
 
 [features]
 default = ["simple"]
-blocking = ["simple", "reqest?/blocking"]
-json = ["reqest?/json"]
-multipart = ["reqest?/multipart"]
+blocking = ["simple", "request?/blocking"]
+json = ["request?/json"]
+multipart = ["request?/multipart"]
 simple = ["json"]
 serde = ["dep:serde", "rgb?/serde"]
-stream = ["reqest?/stream"]
-zlib = ["git/zlib-ng-compat", "reqest?/deflate"]
+stream = ["request?/stream"]
+zlib = ["git/zlib-ng-compat", "request?/deflate"]
 ssh = ["git/ssh", "git/ssh_key_from_memory"]

--- a/tests/test_data/wildcards/allow-git/Cargo.toml
+++ b/tests/test_data/wildcards/allow-git/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# An arbitrary choice of actually existant Git repository
+# An arbitrary choice of actually existent Git repository
 wildcards-test-allow-git = { package = "krates", git = "https://github.com/EmbarkStudios/krates", rev = "b03ecd6f3204a1b1ec04fbaead2d0d122a3a4494" }

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,17 @@
+# See documentation for this config file at https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default.extend-identifiers]
+# Crate name
+flate2 = "flate2"
+
+[files]
+extend-exclude = [
+  # We don't want `typos` to process the git submodules
+
+  # Exclude generated files that are checked in to source control
+  "Cargo.lock",
+  "/tests/test_data/features-galore/metadata.json",
+
+  # There are some typos in the advisories descriptions 😳
+  "docs/src/output/advisories.svg"
+]

--- a/typos.toml
+++ b/typos.toml
@@ -13,5 +13,13 @@ extend-exclude = [
   "/tests/test_data/features-galore/metadata.json",
 
   # There are some typos in the advisories descriptions 😳
-  "docs/src/output/advisories.svg"
+  "docs/src/output/advisories.svg",
+
+  # Specific files that contain false positives. Unfortunately
+  # we have to ignore the entire file because we can't granularly
+  # ignore a specific false positive in a specific file.
+
+  # 'việt nam' triggers a false positive because typos works at single-word
+  # level, and it wants to correct 'nam' to 'name'
+  "src/advisories/helpers/db.rs"
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -6,8 +6,6 @@ flate2 = "flate2"
 
 [files]
 extend-exclude = [
-  # We don't want `typos` to process the git submodules
-
   # Exclude generated files that are checked in to source control
   "Cargo.lock",
   "/tests/test_data/features-galore/metadata.json",


### PR DESCRIPTION
[Typos CLI repo link](https://github.com/crate-ci/typos).

Made this new CI check required to pass for merging PRs.

Here is the full typos report output from `typos` CLI call:

```
error: `descibes` should be `describes`
  --> ./CONTRIBUTING.md:23:81
   |
23 | When reporting a bug or unexpected behaviour in a project, make sure your issue descibes steps to reproduce the behaviour, including the platform you were using, what steps you took, and any error messages.
   |                                                                                 ^^^^^^^^
   |
error: `identifers` should be `identifiers`
  --> ./src/advisories.rs:121:27
    |
121 |     // Check for advisory identifers that were set to be ignored, but
    |                           ^^^^^^^^^^
    |
error: `identifers` should be `identifiers`
  --> ./src/advisories.rs:129:27
    |
129 |     // Check for advisory identifers that were set to be ignored, but
    |                           ^^^^^^^^^^
    |
error: `enountered` should be `encountered`
  --> ./src/bans/diags.rs:240:61
    |
240 |             .with_message("wrapper for banned crate was not enountered")
    |                                                             ^^^^^^^^^^
    |
error: `occured` should be `occurred`
  --> ./docs/src/checks/bans/diags.md:97:14
   |
97 | An I/O error occured when opening or reading a file from disk.
   |              ^^^^^^^
   |
error: `overriden` should be `overridden`
  --> ./src/bans/cfg.rs:345:24
    |
345 |     /// crates, can be overriden in `features` on a crate by crate basis
    |                        ^^^^^^^^^
    |
error: `overriden` should be `overridden`
  --> ./src/bans/cfg.rs:348:9
    |
348 |     /// overriden in `features` on a crate by crate basis
    |         ^^^^^^^^^
    |
error: `isntead` should be `instead`
  --> ./examples/08_target_filtering/Cargo.toml:32:40
   |
32 | # You can also use full target triples isntead of a cfg expression
   |                                        ^^^^^^^
   |
error: `targetting` should be `targeting`
  --> ./examples/08_target_filtering/Cargo.toml:33:60
   |
33 | # We actually **ban** the nix package, but since we aren't targetting
   |                                                            ^^^^^^^^^^
   |
error: `Encourge` should be `Encourage`
  --> ./src/cfg/package_spec.rs:76:24
   |
76 |                     // Encourge user to use the 'crate' spec instead
   |                        ^^^^^^^^
   |
error: `targetting` should be `targeting`
  --> ./examples/08_target_filtering/deny.toml:13:37
   |
13 |     # because it is only built when targetting x86_64-unknown-linux-musl,
   |                                     ^^^^^^^^^^
   |
error: `targetting` should be `targeting`
  --> ./examples/08_target_filtering/README.md:16:466
   |
16 | By default, cargo resolves every single dependency, including for target specific dependencies. However, it's unlikely that your project is actually built for all (143 at the time of this writing) targets that are built in to rustc itself, which means that there may be crates in your graph that are never actually compiled or used in any way. By specifying the `targets = []` configuration in your `deny.toml`, you can specify a list of targets you _actually_ are targetting, removing any crates that don't match at least 1 of the targets you specify.
   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ^^^^^^^^^^
   |
error: `impelemented` should be `implemented`
  --> ./examples/09_bans/Cargo.toml:11:6
   |
11 | # is impelemented via openssl-sys on linux
   |      ^^^^^^^^^^^^
   |
error: `impelemented` should be `implemented`
  --> ./examples/09_bans/README.md:12:6
   |
12 | # is impelemented via openssl-sys on linux
   |      ^^^^^^^^^^^^
   |
error: `examle` should be `example`
  --> ./examples/09_bans/README.md:45:6
   |
45 | This examle shows how the `bans` check works. `reqwest` by default uses native-tls, which on linux uses openssl. But we've decided to **deny** openssl, so adding a dependency on it triggers the lint. It also happens to pull in multiple
   |      ^^^^^^
   |
error: `peform` should be `perform`
  --> ./src/advisories/helpers/db.rs:450:54
    |
450 |         // If we didn't open a fresh repo we need to peform a fetch ourselves, and
    |                                                      ^^^^^^
    |
error: `compatiblity` should be `compatibility`
  --> ./src/advisories/helpers/db.rs:534:23
    |
534 |     /// For backwards compatiblity with cargo-audit, we optionally serialize the
    |                       ^^^^^^^^^^^^
    |
error: `nam` should be `name`
  --> ./src/advisories/helpers/db.rs:741:70
    |
741 |             let url = Url::parse("https://example.com/countries/việt nam").unwrap();
    |                                                                      ^^^
    |
error: `aheared` should be `adhered`
  --> ./tests/LICENSE-RING:116:33
    |
116 |  * the following conditions are aheared to.  The following conditions
    |                                 ^^^^^^^
    |
error: `rouines` should be `routines`
  --> ./tests/LICENSE-RING:141:55
    |
141 |  *    The word 'cryptographic' can be left out if the rouines from the library
    |                                                       ^^^^^^^
    |
error: `publically` should be `publicly`
  --> ./tests/LICENSE-RING:159:47
    |
159 |  * The licence and distribution terms for any publically available version or
    |                                               ^^^^^^^^^^
    |
error: `furst` should be `first`
  --> ./src/advisories/cfg.rs:966:52
    |
966 |                     expand!(exp, "FIRST", Ok(Some("furst".into())))
    |                                                    ^^^^^
    |
error: `secund` should be `second`
  --> ./src/advisories/cfg.rs:968:53
    |
968 |                     expand!(exp, "SECOND", Ok(Some("secund".into())))
    |                                                     ^^^^^^
    |
error: `overriden` should be `overridden`
  --> ./tests/feature_bans.rs:158:49
    |
158 | /// Ensures that a workspace default ban can be overriden by a crate specific allow = 'default'
    |                                                 ^^^^^^^^^
    |
error: `overriden` should be `overridden`
  --> ./tests/feature_bans.rs:207:49
    |
207 | /// Ensures that a workspace default ban can be overriden by a crate specific allow = 'default'
    |                                                 ^^^^^^^^^
    |
error: `dependendencies` should be `dependencies`
  --> ./tests/bans.rs:154:22
    |
154 | /// Ensures that dev dependendencies are ignored
    |                      ^^^^^^^^^^^^^^^
    |
error: `deprected` should be `deprecated`
  --> ./src/cargo-deny/main.rs:250:18
    |
250 |         // we've deprected it and it will go away at some point
    |                  ^^^^^^^^^
    |
error: `enountered` should be `encountered`
  --> ./tests/snapshots/bans__warns_on_unused_wrappers.snap:64:52
   |
64 |       "message": "wrapper for banned crate was not enountered",
   |                                                    ^^^^^^^^^^
   |
error: `strat` should be `start`, `strata`
  --> ./src/licenses/gather.rs:204:9
    |
204 |         strat: &askalono::ScanStrategy<'_>,
    |         ^^^^^
    |
error: `strat` should be `start`, `strata`
  --> ./src/licenses/gather.rs:240:27
    |
240 |                     match strat.scan(&text) {
    |                           ^^^^^
    |
error: `lables` should be `labels`
  --> ./src/licenses/gather.rs:756:49
    |
756 |                         Err((new_toml, lic_file_lables)) => {
    |                                                 ^^^^^^
    |
error: `lables` should be `labels`
  --> ./src/licenses/gather.rs:771:51
    |
771 |                             for label in lic_file_lables {
    |                                                   ^^^^^^
    |
error: `enountered` should be `encountered`
  --> ./tests/snapshots/bans__disallows_denied_with_wrapper.snap:122:52
    |
122 |       "message": "wrapper for banned crate was not enountered",
    |                                                    ^^^^^^^^^^
    |
error: `reqest` should be `request`
  --> ./tests/test_data/features/Cargo.toml:7:1
  |
7 | reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
  | ^^^^^^
  |
error: `reqest` should be `request`
  --> ./tests/test_data/features/Cargo.toml:18:1
   |
18 | reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
   | ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features/Cargo.toml:24:24
   |
24 | blocking = ["simple", "reqest?/blocking"]
   |                        ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features/Cargo.toml:25:10
   |
25 | json = ["reqest?/json"]
   |          ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features/Cargo.toml:26:15
   |
26 | multipart = ["reqest?/multipart"]
   |               ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features/Cargo.toml:29:12
   |
29 | stream = ["reqest?/stream"]
   |            ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features/Cargo.toml:30:32
   |
30 | zlib = ["git/zlib-ng-compat", "reqest?/deflate"]
   |                                ^^^^^^
   |
error: `overriden` should be `overridden`
  --> ./src/diag/sink.rs:41:68
   |
41 | /// Each diagnostic will have a default severity, but these can be overriden
   |                                                                    ^^^^^^^^^
   |
error: `databses` should be `databases`
  --> ./CHANGELOG.md:373:91
    |
373 | - `advisories.db-url` has been deprecated in favor of `advisories.db-urls` since multiple databses are now supported.
    |                                                                                           ^^^^^^^^
    |
error: `slighly` should be `slightly`
  --> ./CHANGELOG.md:434:37
    |
434 | - Upgraded to rustsec 0.18.0, which slighly reworks how yanked crate detection is done
    |                                     ^^^^^^^
    |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:8:1
  |
8 | reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
  | ^^^^^^
  |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:25:1
   |
25 | reqest = { version = "0.11", package = "reqwest", default-features = false, optional = true, features = [
   | ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:34:24
   |
34 | blocking = ["simple", "reqest?/blocking"]
   |                        ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:35:10
   |
35 | json = ["reqest?/json"]
   |          ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:37:15
   |
37 | multipart = ["reqest?/multipart"]
   |               ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:41:12
   |
41 | stream = ["reqest?/stream"]
   |            ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:42:27
   |
42 | tls = ["tls-no-reqwest", "reqest?/rustls-tls"]
   |                           ^^^^^^
   |
error: `reqest` should be `request`
  --> ./tests/test_data/features-galore/Cargo.toml:44:32
   |
44 | zlib = ["git/zlib-ng-compat", "reqest?/deflate"]
   |                                ^^^^^^
   |
error: `existant` should be `existent`
  --> ./tests/test_data/wildcards/allow-git/Cargo.toml:13:35
   |
13 | # An arbitrary choice of actually existant Git repository
   |                                   ^^^^^^^^
   |
```
