### PR TITLE
chore: bump jobserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,9 +1721,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08474e32172238f2827bd160c67871cdb2801430f65c3979184dc362e3ca118"
+checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
The version currently being used was [yanked as it doesn't compile on musl systems](https://github.com/rust-lang/jobserver-rs/issues/79)