### PR TITLE
Add an environment variable to control test timeout

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -294,10 +294,16 @@ where
         || {
             let mut diagnostics = Vec::new();
 
-            let timeout = match std::env::var("CARGO_DENY_TEST_TIMEOUT") {
-                Ok(timeout) => timeout.parse().unwrap_or(30),
-                _ => 30,
+            let default = if std::env::var_os("CI").is_some() {
+                60
+            } else {
+                30
             };
+
+            let timeout = std::env::var("CARGO_DENY_TEST_TIMEOUT_SECS")
+                .ok()
+                .and_then(|ts| ts.parse().ok())
+                .unwrap_or(default);
             let timeout = std::time::Duration::from_secs(timeout);
 
             let trx = crossbeam::channel::after(timeout);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -294,9 +294,13 @@ where
         || {
             let mut diagnostics = Vec::new();
 
-            const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+            let timeout = match std::env::var("CARGO_DENY_TEST_TIMEOUT") {
+                Ok(timeout) => timeout.parse().unwrap_or(30),
+                _ => 30,
+            };
+            let timeout = std::time::Duration::from_secs(timeout);
 
-            let trx = crossbeam::channel::after(TIMEOUT);
+            let trx = crossbeam::channel::after(timeout);
             loop {
                 crossbeam::select! {
                     recv(rx) -> msg => {
@@ -308,7 +312,7 @@ where
                         }
                     }
                     recv(trx) -> _ => {
-                        anyhow::bail!("Timed out after {TIMEOUT:?}");
+                        anyhow::bail!("Timed out after {timeout:?}");
                     }
                 }
             }


### PR DESCRIPTION
The environment variable name is `CARGO_DENY_TEST_TIMEOUT`, it should be able to be parsed into `u64`, otherwise still use 30s as timeout by default.

cargo-deny failed to build for [archriscv](https://archriscv.felixc.at) because of timeout, and I notice that the timeout has been changed before, so I think it may be useful to be able to control the timeout without updating the source code.

And I want to ask if we can increase the timeout? this PR still use the 30s by default. My primary goal is to make cargo-deny build for archriscv. But I'm not sure how long is the minimal time to make it pass. Build log is at [archriscv.felixc.at/.status/log.htm?url=logs/cargo-deny/cargo-deny-0.15.1-1.log](https://archriscv.felixc.at/.status/log.htm?url=logs/cargo-deny/cargo-deny-0.15.1-1.log). Based on a simple comparison of the passed tests between my local machine and the log, 120s (upper bound) may be enough to make it pass.