### PR TITLE
Improve workspace dependencies lints

### DIFF
--- a/docs/src/checks/bans/cfg.md
+++ b/docs/src/checks/bans/cfg.md
@@ -43,8 +43,8 @@ Being limited to private crates is due to crates.io not allowing packages to be 
 Determines what happens when a more than 1 direct workspace dependency is resolved to the same crate and 1 or more declarations do not use `workspace = true`
 
 * `deny` - Will emit an error for each dependency declaration that does not use `workspace = true`
-* `warn` (default) - Will emit a warning for each dependency declaration that does not use `workspace = true`, but does not fail the check.
-* `allow` - Ignores checking for `workspace = true`
+* `warn` - Will emit a warning for each dependency declaration that does not use `workspace = true`, but does not fail the check.
+* `allow` (default) - Ignores checking for `workspace = true` for workspace crates
 
 ### The `unused-workspace-dependencies` field (optional)
 

--- a/docs/src/checks/bans/cfg.md
+++ b/docs/src/checks/bans/cfg.md
@@ -38,15 +38,30 @@ If specified, alters how the `wildcard` field behaves:
 
 Being limited to private crates is due to crates.io not allowing packages to be published with `path` or `git` dependencies except for `dev-dependencies`.
 
-### The `workspace-duplicates` field (optional)
+### The `workspace-dependencies` field (optional)
 
-Determines what happens when a more than 1 direct workspace dependency is resolved to the same crate and 1 or more declarations do not use `workspace = true`
+Used to configure how [`[workspace.dependencies]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) are treated.
 
-* `deny` - Will emit an error for each dependency declaration that does not use `workspace = true`
+```ini
+[bans.workspace-dependencies]
+duplicates = 'deny'
+include-path-dependencies = true
+unused = 'deny'
+```
+
+#### The `duplicates` field (optional)
+
+Determines what happens when more than 1 direct workspace dependency is resolved to the same crate and 1 or more declarations do not use `workspace = true`
+
+* `deny` (default) - Will emit an error for each dependency declaration that does not use `workspace = true`
 * `warn` - Will emit a warning for each dependency declaration that does not use `workspace = true`, but does not fail the check.
-* `allow` (default) - Ignores checking for `workspace = true` for workspace crates
+* `allow` - Ignores checking for `workspace = true` for dependencies in workspace crates
 
-### The `unused-workspace-dependencies` field (optional)
+#### The `include-path-dependencies` field (optional)
+
+If true, path dependencies will be included in the duplication check, otherwise they are completely ignored.
+
+#### The `unused` field (optional)
 
 Determines what happens when a dependency in [`[workspace.dependencies]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) is not used in the workspace.
 

--- a/docs/src/checks/bans/cfg.md
+++ b/docs/src/checks/bans/cfg.md
@@ -65,9 +65,9 @@ If true, path dependencies will be included in the duplication check, otherwise 
 
 Determines what happens when a dependency in [`[workspace.dependencies]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) is not used in the workspace.
 
-* `deny` - Will emit an error for each dependency that is not actually used in the workspace.
+* `deny` (default) - Will emit an error for each dependency that is not actually used in the workspace.
 * `warn` - Will emit a warning for each dependency that is not actually used in the workspace, but does not fail the check.
-* `allow` - (default) Ignores checking for unused workspace dependencies.
+* `allow` - Ignores checking for unused workspace dependencies.
 
 ### The `highlight` field (optional)
 

--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -406,7 +406,7 @@ impl<'de> Deserialize<'de> for Config {
             .unwrap_or_default();
         let workspace_duplicates = th
             .optional("workspace-duplicates")
-            .unwrap_or(LintLevel::Warn);
+            .unwrap_or(LintLevel::Allow);
         let unused_workspace_dependencies = th
             .optional("unused-workspace-dependencies")
             .unwrap_or(LintLevel::Allow);

--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -345,9 +345,8 @@ impl<'de> Deserialize<'de> for WorkspaceDepsConfig {
         let mut th = TableHelper::new(value)?;
 
         let duplicates = th.optional("duplicates").unwrap_or(LintLevel::Deny);
-        let include_path_dependencies =
-            th.optional("include-path-dependencies").unwrap_or_default();
-        let unused = th.optional("unused").unwrap_or(LintLevel::Allow);
+        let include_path_dependencies = th.optional("include-path-dependencies").unwrap_or(true);
+        let unused = th.optional("unused").unwrap_or(LintLevel::Deny);
 
         th.finalize(None)?;
 

--- a/src/bans/diags.rs
+++ b/src/bans/diags.rs
@@ -860,7 +860,7 @@ impl<'k> From<WorkspaceDuplicate<'k>> for Diag {
                 if wd.has_workspace_declaration {
                     "but not all declarations use the shared workspace dependency"
                 } else {
-                    "and there was no shared workspace dependency for it"
+                    "and there is no shared workspace dependency for it"
                 }
             ))
             .with_code(Code::WorkspaceDuplicate)

--- a/src/bans/snapshots/cargo_deny__bans__cfg__test__deserializes_ban_cfg.snap
+++ b/src/bans/snapshots/cargo_deny__bans__cfg__test__deserializes_ban_cfg.snap
@@ -6,8 +6,11 @@ expression: validated
   "file_id": 0,
   "multiple_versions": "deny",
   "multiple_versions_include_dev": false,
-  "workspace_duplicates": "warn",
-  "unused_workspace_dependencies": "allow",
+  "workspace_dependencies": {
+    "duplicates": "allow",
+    "include_path_dependencies": false,
+    "unused": "allow"
+  },
   "highlight": "SimplestPath",
   "denied": [
     {

--- a/tests/bans.rs
+++ b/tests/bans.rs
@@ -284,8 +284,10 @@ fn deny_duplicate_workspace_items() {
         },
         r#"
 multiple-versions = 'allow'
-workspace-duplicates = 'deny'
-unused-workspace-dependencies = 'warn'
+
+[workspace-dependencies]
+include-path-dependencies = true
+unused = 'warn'
 "#,
     );
 

--- a/tests/bans_build.rs
+++ b/tests/bans_build.rs
@@ -1,12 +1,20 @@
-// Ignore these tests on macos since they are only run in CI, which is actually just
-// a potato masquerading as a computer
-#![cfg(not(target_os = "macos"))]
-
 use cargo_deny::{field_eq, func_name, test_utils::*};
+
+macro_rules! ci_ignore {
+    () => {
+        #[allow(clippy::disallowed_macros)]
+        if std::env::var_os("CI").is_some() {
+            eprintln!("potato detected, ignoring test");
+            return;
+        }
+    };
+}
 
 /// Verifies we can detect and error on builtin globs
 #[test]
 fn detects_scripts_by_builtin_glob() {
+    ci_ignore!();
+
     let mut diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -36,6 +44,8 @@ include-dependencies = true
 /// Verifies we can detect and error on extensions provided by the user
 #[test]
 fn detects_scripts_by_user_extension() {
+    ci_ignore!();
+
     let mut diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -56,6 +66,8 @@ fn detects_scripts_by_user_extension() {
 /// Verifies we detect and error on scripts detected by shebang
 #[test]
 fn detects_scripts_by_shebang() {
+    ci_ignore!();
+
     let mut diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -79,6 +91,8 @@ fn detects_scripts_by_shebang() {
 /// Verifies we detect and error on native executables
 #[test]
 fn detects_native_executables() {
+    ci_ignore!();
+
     let mut diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -105,6 +119,8 @@ include-dependencies = true
 /// Verifies user provided builscript checksums are always validated correctly
 #[test]
 fn detects_build_script_mismatch() {
+    ci_ignore!();
+
     let mut diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -135,6 +151,8 @@ build-script = "00abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef00
 /// skipped
 #[test]
 fn skips_matching_build_scripts() {
+    ci_ignore!();
+
     let diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -166,6 +184,8 @@ build-script = "1a850d791184374f614d01c86c8d6c9ba0500e64cb746edc9720ceaaa1cd8eaf
 /// Verifies that build scripts are denied if not allowed nor bypassed
 #[test]
 fn allows_build_scripts_or_bypass() {
+    ci_ignore!();
+
     let diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -194,6 +214,8 @@ build-script = "1a850d791184374f614d01c86c8d6c9ba0500e64cb746edc9720ceaaa1cd8eaf
 /// Verifies executables are allowed by glob patterns
 #[test]
 fn allows_by_glob() {
+    ci_ignore!();
+
     let diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -225,6 +247,8 @@ allow-globs = [
 /// Verifies executables are allowed by path/checksum
 #[test]
 fn allows_by_path() {
+    ci_ignore!();
+
     let mut diags = gather_bans(
         func_name!(),
         KrateGather {
@@ -261,6 +285,8 @@ allow = [
 /// Verifies unmatched configs emit diagnostics
 #[test]
 fn emits_unmatched_warnings() {
+    ci_ignore!();
+
     let mut diags = gather_bans(
         func_name!(),
         KrateGather {

--- a/tests/cfg/bans.toml
+++ b/tests/cfg/bans.toml
@@ -1,6 +1,5 @@
 [bans]
 multiple-versions = "deny"
-workspace-duplicates = "warn"
 wildcards = "deny"
 allow-wildcard-paths = true
 highlight = "simplest-path"
@@ -19,6 +18,11 @@ deny = [
     ], reason = "we want to get rid of this crate but there is still one user of it" },
 ]
 skip-tree = [{ name = "blah", depth = 20 }]
+
+[bans.workspace-dependencies]
+duplicates = "allow"
+include-path-dependencies = false
+unused = "allow"
 
 [[bans.skip]]
 name = "rand"


### PR DESCRIPTION
This moves `workspace-duplicates` and `unused-workspace-dependencies` to be in the `[bans.workspace-dependencies]` section, and adds an additional `include-path-dependencies` field (defaults to true) that determines if path dependencies in workspace members are checked for using `workspace = true`. Since the whole section is now opt-in, both `duplicates` and `unused` are `deny` by default.

Resolves: #682 