### PR TITLE
Remove deprecated config fields

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -40,7 +40,6 @@ unknown-registry = "deny"
 unknown-git = "deny"
 
 [licenses]
-version = 2
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93
 allow = [

--- a/docs/src/checks/advisories/cfg.md
+++ b/docs/src/checks/advisories/cfg.md
@@ -36,9 +36,7 @@ Default: `$CARGO_HOME/advisory-dbs`
 version = 2
 ```
 
-The advisories section has an upcoming breaking change, with deprecation warnings for several fields that will be removed. Setting `version = 2` will opt-in to the future default behavior.
-
-The breaking change is as follows:
+The version field is (at the time of this writing) no longer used, the following fields have been removed and will now emit errors.
 
 - `vulnerability` - Removed, all vulnerability advisories now emit errors.
 - `unmaintained` - Removed, all unmaintained advisories now emit errors.
@@ -48,36 +46,6 @@ The breaking change is as follows:
 
 As before, if you want to ignore a specific advisory, add it to the `ignore` field.
 
-### The `vulnerability` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-Determines what happens when a crate with a security vulnerability is encountered.
-
-- `deny` (default) - Will emit an error with details about each vulnerability, and fail the check.
-- `warn` - Prints a warning for each vulnerability, but does not fail the check.
-- `allow` - Prints a note about the security vulnerability, but does not fail the check.
-
-### The `unmaintained` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-Determines what happens when a crate with an `unmaintained` advisory is encountered.
-
-- `deny` - Will emit an error with details about the unmaintained advisory, and fail the check.
-- `warn` (default) - Prints a warning for each unmaintained advisory, but does not fail the check.
-- `allow` - Prints a note about the unmaintained advisory, but does not fail the check.
-
-### The `unsound` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-Determines what happens when a crate with an `unsound` advisory is encountered.
-
-- `deny` - Will emit an error with details about the unsound advisory, and fail the check.
-- `warn` (default) - Prints a warning for each unsound advisory, but does not fail the check.
-- `allow` - Prints a note about the unsound advisory, but does not fail the check.
-
 ### The `yanked` field (optional)
 
 Determines what happens when a crate with a version that has been yanked from its source registry is encountered.
@@ -85,18 +53,6 @@ Determines what happens when a crate with a version that has been yanked from it
 - `deny` - Will emit an error with the crate name and version that was yanked, and fail the check.
 - `warn` (default) - Prints a warning with the crate name and version that was yanked, but does not fail the check.
 - `allow` - Prints a note about the yanked crate, but does not fail the check.
-
-### The `notice` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-Determines what happens when a crate with a `notice` advisory is encountered.
-
-**NOTE**: As of 2019-12-17 there are no `notice` advisories in the [RustSec Advisory DB](https://github.com/RustSec/advisory-db)
-
-- `deny` - Will emit an error with details about the notice advisory, and fail the check.
-- `warn` (default) - Prints a warning for each notice advisory, but does not fail the check.
-- `allow` - Prints a note about the notice advisory, but does not fail the check.
 
 ### The `ignore` field (optional)
 
@@ -112,18 +68,6 @@ ignore = [
 Every advisory in the advisory database contains a unique identifier, eg. `RUSTSEC-2019-0001`. Putting an identifier in this array will cause the advisory to be treated as a note, rather than a warning or error.
 
 In addition, yanked crate versions can be ignored by specifying a [PackageSpec](../cfg.md#package-spec) with an optional `reason`.
-
-### The `severity-threshold` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-The threshold for security vulnerabilities to be turned into notes instead of warnings or errors, depending upon its [CVSS](https://en.wikipedia.org/wiki/Common_Vulnerability_Scoring_System) score. So having a high threshold means some vulnerabilities might not fail the check, but having a log level `>= info` will mean that a note will be printed instead of a warning or error, depending on `[advisories.vulnerability]`.
-
-- `None` (default) - CVSS Score 0.0
-- `Low` - CVSS Score 0.1 - 3.9
-- `Medium` - CVSS Score 4.0 - 6.9
-- `High` - CVSS Score 7.0 - 8.9
-- `Critical` - CVSS Score 9.0 - 10.0
 
 ### The `git-fetch-with-cli` field (optional)
 

--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -51,9 +51,7 @@ If `true`, licenses are checked even for `dev-dependencies`. By default this is 
 version = 2
 ```
 
-The licenses section has an upcoming breaking change, with deprecation warnings for several fields that will be removed. Setting `version = 2` will opt-in to the future default behavior.
-
-The breaking change is as follows:
+The version field is (at the time of this writing) no longer used, the following fields have been removed and will now emit errors.
 
 - `unlicensed` - Removed, if a crate is unlicensed you should open an issue/PR to fix it, and in the meantime, you may add a [clarification](#the-clarify-field-optional).
 - `deny` - Removed, all licenses are denied unless explicitly allowed
@@ -61,20 +59,9 @@ The breaking change is as follows:
 - `allow-osi-fsf-free` - Removed, all licenses are denied unless explicitly allowed
 - `default` - Removed, all licenses are denied unless explicitly allowed
 
-### The `unlicensed` field (optional)
+### The `allow` field (optional)
 
-Determines what happens when a crate has not explicitly specified its license terms, and no license information could be confidently detected via `LICENSE*` files in the crate's source.
-
-- `deny` (default) - All unlicensed crates will emit an error and fail the license check
-- `allow` - All unlicensed crates will show a note, but will not fail the license check
-- `warn` - All unlicensed crates will show a warning, but will not fail the license check
-
-### The `allow` and `deny` fields (optional)
-
-The licenses that should be allowed or denied, note that the same license cannot
-appear in both the `allow` and `deny` lists.
-
-[`deny` is **DEPRECATED**](#the-version-field-optional)
+The licenses that are explicitly allowed.
 
 #### Note on GNU licenses
 
@@ -90,7 +77,6 @@ So, for example, if you wanted to disallow `GPL-2.0` licenses, but allow `GPL-3.
 ```ini
 [licenses]
 allow = [ "GPL-3.0" ]
-deny = [ "GPL-2.0" ]
 ```
 
 This gets worse with the GFDL licenses, which also have an `invariants` modifier. Before licenses are checked they are normalized to make them consistent for all licenses.
@@ -149,44 +135,6 @@ exceptions = [
     { crate = "cloudabi", allow = ["BSD-2-Clause"] },
 ]
 ```
-
-### The `copyleft` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-Determines what happens when a license that is considered [copyleft](https://www.gnu.org/licenses/license-list.html) is encountered.
-
-- `warn` (default) - Will emit a warning that a copyleft license was detected, but will not fail the license check
-- `deny` - The license is not accepted if it is copyleft, but the license check might not fail if the expression still evaluates to true
-- `allow` - The license is accepted if it is copyleft
-
-### The `allow-osi-fsf-free` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-Determines what happens when licenses aren't explicitly allowed or denied, but **are** marked as [OSI Approved](https://opensource.org/licenses) or [FSF Free/Libre](https://www.gnu.org/licenses/license-list.en.html) in version 3.23 of the [SPDX License List](https://spdx.org/licenses/).
-
-- `both` - The license is accepted if it is both OSI approved and FSF Free
-- `either` - The license is accepted if it is either OSI approved or FSF Free
-- `osi` - The license is accepted if it is OSI approved
-- `fsf` - The license is accepted if it is FSF Free
-- `osi-only` - The license is accepted if it is OSI approved and not FSF Free
-- `fsf-only` - The license is accepted if it is FSF Free and not OSI approved
-- `neither` (default) - No special consideration is given the license
-
-### The `default` field (optional)
-
-[**DEPRECATED**](#the-version-field-optional)
-
-Determines what happens when a license is encountered that:
-
-1. Isn't in the `allow` or `deny` lists
-1. Isn't `copyleft`
-1. Isn't OSI Approved nor FSF Free/Libre, or `allow-osi-fsf-free = "neither"`
-
-- `warn` - Will emit a warning that the license was detected, but will not fail the license check
-- `deny` (default) - The license is not accepted, but the license check might not fail if the expression still evaluates to true
-- `allow` - The license is accepted
 
 ### The `confidence-threshold` field (optional)
 

--- a/src/advisories/diags.rs
+++ b/src/advisories/diags.rs
@@ -123,24 +123,6 @@ impl<'a> crate::CheckCtx<'a, super::cfg::ValidConfig> {
                 );
 
                 LintLevel::Allow
-            } else if let Some(deprecated) = &self.cfg.deprecated {
-                'll: {
-                    if let (Some(st), Some(sev)) = (
-                        deprecated.severity_threshold,
-                        advisory.cvss.as_ref().map(|c| c.severity()),
-                    ) {
-                        if sev < st {
-                            break 'll LintLevel::Allow;
-                        }
-                    }
-
-                    match adv_ty {
-                        AdvisoryType::Vulnerability => deprecated.vulnerability,
-                        AdvisoryType::Unmaintained => deprecated.unmaintained,
-                        AdvisoryType::Unsound => deprecated.unsound,
-                        AdvisoryType::Notice => deprecated.notice,
-                    }
-                }
             } else {
                 LintLevel::Deny
             };

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg-2.snap
@@ -32,13 +32,6 @@ expression: validated
       "use-instead": null
     }
   ],
-  "deprecated": {
-    "vulnerability": "deny",
-    "unmaintained": "warn",
-    "unsound": "warn",
-    "notice": "warn",
-    "severity_threshold": "medium"
-  },
   "yanked": "warn",
   "git_fetch_with_cli": false,
   "disable_yank_checking": false,

--- a/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg.snap
+++ b/src/advisories/snapshots/cargo_deny__advisories__cfg__test__deserializes_advisories_cfg.snap
@@ -2,32 +2,4 @@
 source: src/advisories/cfg.rs
 expression: diags
 ---
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/advisories.toml:4:1
-  │
-4 │ vulnerability = "deny"
-  │ ━━━━━━━━━━━━━
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/advisories.toml:5:1
-  │
-5 │ unmaintained = "warn"
-  │ ━━━━━━━━━━━━
-
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/advisories.toml:6:1
-  │
-6 │ unsound = "warn"
-  │ ━━━━━━━
-
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/advisories.toml:8:1
-  │
-8 │ notice = "warn"
-  │ ━━━━━━
-
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-   ┌─ tests/cfg/advisories.toml:14:1
-   │
-14 │ severity-threshold = "medium"
-   │ ━━━━━━━━━━━━━━━━━━

--- a/src/diag/general.rs
+++ b/src/diag/general.rs
@@ -75,7 +75,13 @@ pub struct Deprecated {
 
 impl From<Deprecated> for Diagnostic {
     fn from(dep: Deprecated) -> Self {
-        Diagnostic::new(Severity::Warning)
+        let severity = if matches!(dep.reason, DeprecationReason::Removed(_)) {
+            Severity::Error
+        } else {
+            Severity::Warning
+        };
+
+        Diagnostic::new(severity)
             .with_message(dep.reason.to_string())
             .with_labels(vec![Label::primary(dep.file_id, dep.key)])
             .with_code(Code::Deprecated)

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -499,33 +499,4 @@ mod test {
 
         insta::assert_json_snapshot!(validated);
     }
-
-    #[test]
-    fn correct_duplicate_license_spans() {
-        let cfg = r#"[licenses]
-allow = [
-    "MIT",
-    "Apache-2.0",
-    "BSD-3-Clause",
-    "ISC",
-    "CC0-1.0",
-    "Unicode-DFS-2016",
-]
-deny = [
-    "MIT",
-    "GPL-1.0",
-    "GPL-2.0",
-    "GPL-3.0",
-    "AGPL-3.0",
-]"#;
-
-        let cd = ConfigData::<Licenses>::load_str("license-in-allow-and-deny", cfg);
-        let _validated = cd.validate_with_diags(
-            |l| l.licenses,
-            |files, diags| {
-                let diags = write_diagnostics(files, diags.into_iter());
-                insta::assert_snapshot!(diags);
-            },
-        );
-    }
 }

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -194,23 +194,6 @@ impl serde::Serialize for Licensee {
     }
 }
 
-#[cfg_attr(test, derive(serde::Serialize))]
-pub(crate) struct Deprecated {
-    /// Determines what happens when license information cannot be determined
-    /// for a crate
-    pub unlicensed: LintLevel,
-    /// Accepts license requirements based on whether they are OSI Approved or
-    /// FSF/Free Libre
-    pub allow_osi_fsf_free: BlanketAgreement,
-    /// Determines what happens when a copyleft license is detected
-    pub copyleft: LintLevel,
-    /// Determines what happens when a license doesn't match any previous
-    /// predicates
-    pub default: LintLevel,
-    /// Licenses that will be rejected in a license expression
-    pub deny: Vec<Licensee>,
-}
-
 /// Top level configuration for the a license check
 pub struct Config {
     pub private: Private,
@@ -231,7 +214,6 @@ pub struct Config {
     /// If true, performs license checks for dev-dependencies for workspace
     /// crates as well
     pub include_dev: bool,
-    deprecated: Option<Deprecated>,
     deprecated_spans: Vec<Span>,
 }
 
@@ -245,7 +227,6 @@ impl Default for Config {
             clarify: Vec::new(),
             exceptions: Vec::new(),
             include_dev: false,
-            deprecated: None,
             deprecated_spans: Vec::new(),
         }
     }
@@ -255,20 +236,20 @@ impl<'de> Deserialize<'de> for Config {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
         let mut th = TableHelper::new(value)?;
 
-        let version = th.optional("version").unwrap_or(1);
+        let _version = th.optional("version").unwrap_or(1);
 
         let mut fdeps = Vec::new();
 
         let private = th.optional("private").unwrap_or_default();
-        let unlicensed = deprecated(&mut th, "unlicensed", &mut fdeps).unwrap_or(LintLevel::Deny);
-        let allow_osi_fsf_free =
-            deprecated(&mut th, "allow-osi-fsf-free", &mut fdeps).unwrap_or_default();
-        let copyleft = deprecated(&mut th, "copyleft", &mut fdeps).unwrap_or(LintLevel::Warn);
-        let default = deprecated(&mut th, "default", &mut fdeps).unwrap_or(LintLevel::Deny);
+        let _unlicensed = deprecated(&mut th, "unlicensed", &mut fdeps).unwrap_or(LintLevel::Deny);
+        let _allow_osi_fsf_free = deprecated(&mut th, "allow-osi-fsf-free", &mut fdeps)
+            .unwrap_or(BlanketAgreement::default());
+        let _copyleft = deprecated(&mut th, "copyleft", &mut fdeps).unwrap_or(LintLevel::Warn);
+        let _default = deprecated(&mut th, "default", &mut fdeps).unwrap_or(LintLevel::Deny);
         let confidence_threshold = th
             .optional("confidence-threshold")
             .unwrap_or(DEFAULT_CONFIDENCE_THRESHOLD);
-        let deny = deprecated(&mut th, "deny", &mut fdeps).unwrap_or_default();
+        let _deny: Vec<Licensee> = deprecated(&mut th, "deny", &mut fdeps).unwrap_or_default();
         let allow = th.optional("allow").unwrap_or_default();
         let unused_allowed_license = th
             .optional("unused-allowed-license")
@@ -279,18 +260,6 @@ impl<'de> Deserialize<'de> for Config {
 
         th.finalize(None)?;
 
-        let deprecated = if version <= 1 {
-            Some(Deprecated {
-                unlicensed,
-                allow_osi_fsf_free,
-                copyleft,
-                default,
-                deny,
-            })
-        } else {
-            None
-        };
-
         Ok(Self {
             private,
             confidence_threshold,
@@ -299,7 +268,6 @@ impl<'de> Deserialize<'de> for Config {
             clarify,
             exceptions,
             include_dev,
-            deprecated,
             deprecated_spans: fdeps,
         })
     }
@@ -335,14 +303,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
             }
         }
 
-        let mut deprecated = self.deprecated;
-
-        let mut denied = deprecated
-            .as_mut()
-            .map_or(Vec::new(), |d| std::mem::take(&mut d.deny));
         let mut allowed = self.allow;
-
-        denied.par_sort();
         allowed.par_sort();
 
         let mut exceptions = Vec::with_capacity(self.exceptions.len());
@@ -351,22 +312,6 @@ impl crate::cfg::UnvalidatedConfig for Config {
             allowed: exc.allow,
             file_id: ctx.cfg_id,
         }));
-
-        // Ensure the config doesn't contain the same exact license as both
-        // denied and allowed, that's confusing and probably not intended, so
-        // they should pick one
-        for (di, d) in denied.iter().enumerate() {
-            if let Ok(ai) = allowed.binary_search(d) {
-                ctx.push(
-                    Diagnostic::error()
-                        .with_message("a license id was specified in both `allow` and `deny`")
-                        .with_labels(vec![
-                            Label::secondary(ctx.cfg_id, denied[di].0.span).with_message("deny"),
-                            Label::secondary(ctx.cfg_id, allowed[ai].0.span).with_message("allow"),
-                        ]),
-                );
-            }
-        }
 
         let mut clarifications = Vec::with_capacity(self.clarify.len());
         for c in self.clarify {
@@ -405,9 +350,9 @@ impl crate::cfg::UnvalidatedConfig for Config {
         for dep in self.deprecated_spans {
             ctx.push(
                 Deprecated {
-                    reason: DeprecationReason::WillBeRemoved(Some(
+                    reason: DeprecationReason::Removed(
                         "https://github.com/EmbarkStudios/cargo-deny/pull/611",
-                    )),
+                    ),
                     key: dep,
                     file_id: ctx.cfg_id,
                 }
@@ -422,10 +367,8 @@ impl crate::cfg::UnvalidatedConfig for Config {
             confidence_threshold: self.confidence_threshold,
             clarifications,
             exceptions,
-            denied,
             allowed,
             ignore_sources,
-            deprecated,
             include_dev: self.include_dev,
         }
     }
@@ -516,12 +459,10 @@ pub struct ValidConfig {
     pub private: Private,
     pub unused_allowed_license: LintLevel,
     pub confidence_threshold: f32,
-    pub denied: Vec<Licensee>,
     pub allowed: Vec<Licensee>,
     pub clarifications: Vec<ValidClarification>,
     pub exceptions: Vec<ValidException>,
     pub ignore_sources: Vec<url::Url>,
-    pub(crate) deprecated: Option<Deprecated>,
     pub include_dev: bool,
 }
 
@@ -571,7 +512,7 @@ allow = [
     "Unicode-DFS-2016",
 ]
 deny = [
-   "MIT",
+    "MIT",
     "GPL-1.0",
     "GPL-2.0",
     "GPL-3.0",

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
@@ -2,16 +2,7 @@
 source: src/licenses/cfg.rs
 expression: diags
 ---
-error: a license id was specified in both `allow` and `deny`
-   ┌─ license-in-allow-and-deny:3:6
-   │
- 3 │     "MIT",
-   │      ─── allow
-   ·
-11 │    "MIT",
-   │     ─── deny
-
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
+warning[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
    ┌─ license-in-allow-and-deny:10:1
    │
 10 │ deny = [

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__correct_duplicate_license_spans.snap
@@ -1,9 +1,0 @@
----
-source: src/licenses/cfg.rs
-expression: diags
----
-warning[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
-   ┌─ license-in-allow-and-deny:10:1
-   │
-10 │ deny = [
-   │ ━━━━

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
@@ -13,10 +13,6 @@ expression: validated
   },
   "unused_allowed_license": "warn",
   "confidence_threshold": 0.95,
-  "denied": [
-    "BSD-2-Clause",
-    "Nokia"
-  ],
   "allowed": [
     "Apache-2.0 WITH LLVM-exception",
     "EUPL-1.2"
@@ -49,12 +45,5 @@ expression: validated
     }
   ],
   "ignore_sources": [],
-  "deprecated": {
-    "unlicensed": "warn",
-    "allow_osi_fsf_free": "Both",
-    "copyleft": "deny",
-    "default": "warn",
-    "deny": []
-  },
   "include_dev": false
 }

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg.snap
@@ -2,32 +2,4 @@
 source: src/licenses/cfg.rs
 expression: diags
 ---
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/licenses.toml:2:1
-  │
-2 │ unlicensed = "warn"
-  │ ━━━━━━━━━━
 
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/licenses.toml:3:1
-  │
-3 │ allow-osi-fsf-free = "both"
-  │ ━━━━━━━━━━━━━━━━━━
-
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/licenses.toml:4:1
-  │
-4 │ copyleft = "deny"
-  │ ━━━━━━━━
-
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/licenses.toml:5:1
-  │
-5 │ default = "warn"
-  │ ━━━━━━━
-
-warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
-  ┌─ tests/cfg/licenses.toml:8:1
-  │
-8 │ deny = [
-  │ ━━━━

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -65,7 +65,7 @@ fn find_by_code<'a>(diags: &'a [serde_json::Value], code: &str) -> Option<&'a se
 fn detects_vulnerabilities() {
     let TestCtx { dbs, krates } = load();
 
-    let cfg = tu::Config::new("vulnerability = 'deny'");
+    let cfg = tu::Config::new("");
 
     let diags =
         tu::gather_diagnostics::<cfg::Config, _, _>(&krates, func_name!(), cfg, |ctx, tx| {
@@ -88,7 +88,7 @@ fn detects_vulnerabilities() {
 fn detects_unmaintained() {
     let TestCtx { dbs, krates } = load();
 
-    let cfg = tu::Config::new("unmaintained = 'warn'");
+    let cfg = tu::Config::new("");
 
     let diags =
         tu::gather_diagnostics::<cfg::Config, _, _>(&krates, func_name!(), cfg, |ctx, tx| {
@@ -110,7 +110,7 @@ fn detects_unmaintained() {
 fn detects_unsound() {
     let TestCtx { dbs, krates } = load();
 
-    let cfg = tu::Config::new("unsound = 'warn'");
+    let cfg = tu::Config::new("");
 
     let diags =
         tu::gather_diagnostics::<cfg::Config, _, _>(&krates, func_name!(), cfg, |ctx, tx| {
@@ -135,7 +135,6 @@ fn downgrades_lint_levels() {
 
     let cfg = tu::Config::new(
         r#"
-unmaintained = "warn"
 ignore = [
     "RUSTSEC-2016-0004",
     { id = "RUSTSEC-2019-0001", reason = "this is a test" },
@@ -206,8 +205,7 @@ fn detects_yanked() {
     let dbs = advisories::DbSet { dbs: Vec::new() };
 
     {
-        let cfg =
-            tu::Config::new("yanked = 'deny'\nunmaintained = 'allow'\nvulnerability = 'allow'");
+        let cfg = tu::Config::new("yanked = 'deny'");
 
         let indices = advisories::Indices {
             indices: Vec::new(),
@@ -247,8 +245,6 @@ ignore = [
     # This crate is not in the graph, so we should get a warning about it
     "boop",
 ]
-unmaintained = "allow"
-vulnerability = "allow"
 "#,
         );
 
@@ -284,7 +280,7 @@ vulnerability = "allow"
 fn warns_on_index_failures() {
     let TestCtx { dbs, krates } = load();
 
-    let cfg = tu::Config::new("yanked = 'deny'\nunmaintained = 'allow'\nvulnerability = 'allow'");
+    let cfg = tu::Config::new("yanked = 'deny'");
 
     let source = cargo_deny::Source::crates_io(false);
 
@@ -334,9 +330,7 @@ fn warns_on_index_failures() {
 fn warns_on_ignored_and_withdrawn() {
     let TestCtx { dbs, krates } = load();
 
-    let cfg = tu::Config::new(
-        "yanked = 'deny'\nunmaintained = 'deny'\nvulnerability = 'deny'\nignore = ['RUSTSEC-2020-0053']",
-    );
+    let cfg = tu::Config::new("yanked = 'deny'\nignore = ['RUSTSEC-2020-0053']");
 
     let diags =
         tu::gather_diagnostics::<cfg::Config, _, _>(&krates, func_name!(), cfg, |ctx, tx| {
@@ -681,7 +675,7 @@ fn crates_io_source_replacement() {
 
     let indices = advisories::Indices::load(&krates, cargo_home.clone());
 
-    let cfg = tu::Config::new("yanked = 'deny'\nunmaintained = 'allow'\nvulnerability = 'allow'");
+    let cfg = tu::Config::new("yanked = 'deny'");
 
     let dbs = advisories::DbSet { dbs: Vec::new() };
 
@@ -793,7 +787,7 @@ fn crates_io_source_replacement() {
 
     let indices = advisories::Indices::load(&krates, cargo_home.clone());
 
-    let cfg = tu::Config::new("yanked = 'deny'\nunmaintained = 'allow'\nvulnerability = 'allow'");
+    let cfg = tu::Config::new("yanked = 'deny'");
 
     let diags =
         tu::gather_diagnostics::<cfg::Config, _, _>(&krates, func_name!(), cfg, |ctx, tx| {

--- a/tests/cfg/advisories.toml
+++ b/tests/cfg/advisories.toml
@@ -1,14 +1,8 @@
 [advisories]
 db-path = "~/.cargo/advisory-dbs"
 db-urls = ["https://github.com/RustSec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
-unsound = "warn"
-yanked = "warn"
-notice = "warn"
 ignore = [
     "RUSTSEC-0000-0000",
     "crate@0.1",
     { crate = "yanked", reason = "a new version has not been released" },
 ]
-severity-threshold = "medium"

--- a/tests/cfg/licenses.toml
+++ b/tests/cfg/licenses.toml
@@ -1,14 +1,6 @@
 [licenses]
-unlicensed = "warn"
-allow-osi-fsf-free = "both"
-copyleft = "deny"
-default = "warn"
 unused-allowed-license = "warn"
 confidence-threshold = 0.95
-deny = [
-    "Nokia",
-    "BSD-2-Clause",
-]
 allow = [
     "EUPL-1.2",
     "Apache-2.0 WITH LLVM-exception",

--- a/tests/licenses.rs
+++ b/tests/licenses.rs
@@ -106,21 +106,18 @@ fn accepts_exceptions() {
 
 #[test]
 fn detects_unlicensed() {
-    let cfg = tu::Config::new("unlicensed = 'warn'");
+    let cfg = tu::Config::new("");
 
     let mut diags = gather_licenses_with_overrides(func_name!(), cfg, None);
 
-    diags.retain(|d| field_eq!(d, "/fields/severity", "warning"));
+    diags.retain(|d| field_eq!(d, "/fields/code", "unlicensed"));
 
     insta::assert_json_snapshot!(diags);
 }
 
 #[test]
 fn flags_unencountered_licenses() {
-    let cfg = tu::Config::new(
-        "allow = ['Aladdin', 'MIT']
-    unlicensed = 'allow'",
-    );
+    let cfg = tu::Config::new("allow = ['Aladdin', 'MIT']");
 
     // Override the warning to be a failure
     let overrides = cargo_deny::overrides! {
@@ -129,7 +126,7 @@ fn flags_unencountered_licenses() {
 
     let mut diags = gather_licenses_with_overrides(func_name!(), cfg, Some(overrides));
 
-    diags.retain(|d| field_eq!(d, "/fields/severity", "error"));
+    diags.retain(|d| field_eq!(d, "/fields/code", "license-not-encountered"));
 
     insta::assert_json_snapshot!(diags);
 }
@@ -138,7 +135,6 @@ fn flags_unencountered_licenses() {
 fn flags_unencountered_exceptions() {
     let cfg = tu::Config::new(
         "allow = ['MIT']
-    unlicensed = 'allow'
     exceptions = [{name='bippity-boppity-boop', allow = ['Aladdin']}]",
     );
 
@@ -149,7 +145,7 @@ fn flags_unencountered_exceptions() {
 
     let mut diags = gather_licenses_with_overrides(func_name!(), cfg, Some(overrides));
 
-    diags.retain(|d| field_eq!(d, "/fields/severity", "error"));
+    diags.retain(|d| field_eq!(d, "/fields/code", "license-exception-not-encountered"));
 
     insta::assert_json_snapshot!(diags);
 }
@@ -165,10 +161,7 @@ fn lax_fallback() {
         .build(cmd, krates::NoneFilter)
         .unwrap();
 
-    let cfg = tu::Config::<Config>::new(
-        "allow = ['GPL-2.0', 'LGPL-3.0']
-    unlicensed = 'deny'",
-    );
+    let cfg = tu::Config::<Config>::new("allow = ['GPL-2.0', 'LGPL-3.0']");
 
     let (ctx, summary) = setup(&krates, func_name!(), cfg);
 
@@ -248,7 +241,6 @@ fn handles_dev_dependencies() {
     let cfg = tu::Config::new(
         r#"
 allow = ['Apache-2.0']
-deny = ['GPL-3.0']
 include-dev = true
 "#,
     );

--- a/tests/snapshots/advisories__detects_unmaintained.snap
+++ b/tests/snapshots/advisories__detects_unmaintained.snap
@@ -56,7 +56,7 @@ expression: unmaintained_diag
       "Announcement: https://github.com/dcuddeback/libusb-rs/issues/33",
       "Solution: No safe upgrade is available!"
     ],
-    "severity": "warning"
+    "severity": "error"
   },
   "type": "diagnostic"
 }

--- a/tests/snapshots/advisories__detects_unsound.snap
+++ b/tests/snapshots/advisories__detects_unsound.snap
@@ -63,7 +63,7 @@ expression: unsound_diag
       "Announcement: https://github.com/rust-lang-nursery/failure/issues/336",
       "Solution: No safe upgrade is available!"
     ],
-    "severity": "warning"
+    "severity": "error"
   },
   "type": "diagnostic"
 }

--- a/tests/snapshots/advisories__downgrades_lint_levels-2.snap
+++ b/tests/snapshots/advisories__downgrades_lint_levels-2.snap
@@ -25,13 +25,13 @@ expression: ignored
       "labels": [
         {
           "column": 13,
-          "line": 5,
+          "line": 4,
           "message": "advisory ignored here",
           "span": "RUSTSEC-2019-0001"
         },
         {
           "column": 43,
-          "line": 5,
+          "line": 4,
           "message": "ignore reason",
           "span": "this is a test"
         }
@@ -71,13 +71,13 @@ expression: ignored
       "labels": [
         {
           "column": 13,
-          "line": 5,
+          "line": 4,
           "message": "advisory ignored here",
           "span": "RUSTSEC-2019-0001"
         },
         {
           "column": 43,
-          "line": 5,
+          "line": 4,
           "message": "ignore reason",
           "span": "this is a test"
         }
@@ -109,7 +109,7 @@ expression: ignored
       "labels": [
         {
           "column": 6,
-          "line": 4,
+          "line": 3,
           "message": "advisory ignored here",
           "span": "RUSTSEC-2016-0004"
         }

--- a/tests/snapshots/advisories__warns_on_ignored_and_withdrawn.snap
+++ b/tests/snapshots/advisories__warns_on_ignored_and_withdrawn.snap
@@ -9,7 +9,7 @@ expression: "diags.iter().find(|diag|\n            field_eq!(diag, \"/fields/cod
     "labels": [
       {
         "column": 12,
-        "line": 4,
+        "line": 2,
         "message": "no crate matched advisory criteria",
         "span": "RUSTSEC-2020-0053"
       }

--- a/tests/snapshots/licenses__accepts_exceptions.snap
+++ b/tests/snapshots/licenses__accepts_exceptions.snap
@@ -64,19 +64,19 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Zlib"
         },
         {
           "column": 20,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         },
         {
           "column": 34,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         }
       ],
@@ -165,13 +165,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         },
         {

--- a/tests/snapshots/licenses__accepts_licenses.snap
+++ b/tests/snapshots/licenses__accepts_licenses.snap
@@ -1157,7 +1157,7 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Zlib"
         },
         {

--- a/tests/snapshots/licenses__detects_unlicensed.snap
+++ b/tests/snapshots/licenses__detects_unlicensed.snap
@@ -29,7 +29,7 @@ expression: diags
         }
       ],
       "message": "features-galore = 0.1.0 is unlicensed",
-      "severity": "warning"
+      "severity": "error"
     },
     "type": "diagnostic"
   }

--- a/tests/snapshots/licenses__flags_unencountered_exceptions.snap
+++ b/tests/snapshots/licenses__flags_unencountered_exceptions.snap
@@ -10,7 +10,7 @@ expression: diags
       "labels": [
         {
           "column": 26,
-          "line": 3,
+          "line": 2,
           "message": "unmatched license exception",
           "span": "bippity-boppity-boop"
         }

--- a/tests/snapshots/licenses__forces_apache_over_pixar.snap
+++ b/tests/snapshots/licenses__forces_apache_over_pixar.snap
@@ -36,7 +36,7 @@ expression: diags
         {
           "column": 30,
           "line": 5,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Pixar"
         }
       ],

--- a/tests/snapshots/licenses__handles_dev_dependencies.snap
+++ b/tests/snapshots/licenses__handles_dev_dependencies.snap
@@ -41,7 +41,7 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         }
       ],
@@ -85,7 +85,7 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: explicitly denied",
+          "message": "rejected: license is not explicitly allowed",
           "span": "GPL-3.0"
         }
       ],

--- a/tests/snapshots/licenses__lax_fallback.snap
+++ b/tests/snapshots/licenses__lax_fallback.snap
@@ -30,7 +30,7 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         },
         {

--- a/tests/snapshots/licenses__rejects_licenses.snap
+++ b/tests/snapshots/licenses__rejects_licenses.snap
@@ -63,13 +63,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -148,13 +148,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -231,13 +231,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -329,13 +329,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -381,13 +381,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -449,13 +449,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -542,13 +542,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -679,13 +679,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -739,13 +739,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -807,13 +807,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -867,13 +867,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -919,13 +919,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1002,13 +1002,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1087,13 +1087,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1147,7 +1147,7 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         }
       ],
@@ -1198,13 +1198,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1282,19 +1282,19 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Zlib"
         },
         {
           "column": 20,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         },
         {
           "column": 34,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         }
       ],
@@ -1383,19 +1383,19 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         },
         {
           "column": 33,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Zlib"
         }
       ],
@@ -1468,13 +1468,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1544,13 +1544,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1604,13 +1604,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1681,13 +1681,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1741,13 +1741,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1793,13 +1793,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1853,13 +1853,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1921,13 +1921,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -1981,13 +1981,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2049,13 +2049,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2109,13 +2109,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2177,13 +2177,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2237,13 +2237,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2305,13 +2305,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2365,13 +2365,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2425,13 +2425,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2493,13 +2493,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],
@@ -2553,13 +2553,13 @@ expression: diags
         {
           "column": 12,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "MIT"
         },
         {
           "column": 19,
           "line": 4,
-          "message": "rejected: not explicitly allowed",
+          "message": "rejected: license is not explicitly allowed",
           "span": "Apache-2.0"
         }
       ],


### PR DESCRIPTION
This finishes up the deprecation's of advisories and licenses config fields done in #611, turning them into errors.