### PR TITLE
Fix `unmatched-organization` warnings for deny template

### DIFF
--- a/deny.template.toml
+++ b/deny.template.toml
@@ -227,9 +227,9 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []
 
 [sources.allow-org]
-# 1 or more github.com organizations to allow git sources for
-github = [""]
-# 1 or more gitlab.com organizations to allow git sources for
-gitlab = [""]
-# 1 or more bitbucket.org organizations to allow git sources for
-bitbucket = [""]
+# github.com organizations to allow git sources for
+github = []
+# gitlab.com organizations to allow git sources for
+gitlab = []
+# bitbucket.org organizations to allow git sources for
+bitbucket = []

--- a/docs/src/checks/sources/cfg.md
+++ b/docs/src/checks/sources/cfg.md
@@ -94,11 +94,11 @@ Generally, I think most projects in the Rust space probably follow a similar pro
 
 When working in a company or organization, it is often the case that all crates will be forked to a shared organization account rather than a personal Github account. However, if you lint your git sources, every new and deleted fork needs to keep that list updated, which is tedious, even if all the forks fall under the same organization (in Github terminology), even though presumably only people you trust have permission to create forks there, and you would like to just blanket trust any repo under that org.
 
-The `allow-org` object allows you to specify 1 or more organizations or users in several VCS providers to more easily configure git sources for your projects.
+The `allow-org` object allows you to specify multiple organizations or users in several VCS providers to more easily configure git sources for your projects.
 
 #### The `github` field (optional)
 
-Allows you to specify one or more `github.com` organizations to allow as git sources.
+Allows you to specify multiple `github.com` organizations to allow as git sources.
 
 ```ini
 [sources.allow-org]
@@ -107,7 +107,7 @@ github = ["YourCoolOrgGoesHere"]
 
 #### The `gitlab` field (optional)
 
-Allows you to specify one or more `gitlab.com` organizations to allow as git sources.
+Allows you to specify multiple `gitlab.com` organizations to allow as git sources.
 
 ```ini
 [sources.allow-org]
@@ -116,7 +116,7 @@ gitlab = ["YourCoolOrgGoesHere"]
 
 #### The `bitbucket` field (optional)
 
-Allows you to specify one or more `bitbucket.org` organizations to allow as git sources.
+Allows you to specify multiple `bitbucket.org` organizations to allow as git sources.
 
 ```ini
 [sources.allow-org]


### PR DESCRIPTION
With the current `deny.template.toml` https://github.com/EmbarkStudios/cargo-deny-action prints the following warnings:
```
 warning[unmatched-organization]: allowed 'github.com' organization  was not encountered
    ┌─ ./deny.toml:235:11
    │
235 │ github = [""]
    │           ━ no crate source fell under this organization

warning[unmatched-organization]: allowed 'gitlab.com' organization  was not encountered
    ┌─ ./deny.toml:237:11
    │
237 │ gitlab = [""]
    │           ━ no crate source fell under this organization

warning[unmatched-organization]: allowed 'bitbucket.org' organization  was not encountered
    ┌─ ./deny.toml:239:14
    │
239 │ bitbucket = [""]
    │              ━ no crate source fell under this organization
```

Note: I have marked this as draft for now because I am not sure if the approach of changing the documentation to allow 0 Git sources is good here; an alternative would be to just comment out `github = ["..."]`, ...
Though it seems 0 Git sources are currently permitted, see also #689.