### PR TITLE
Fix unused workspace dependency for current dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#691](https://github.com/EmbarkStudios/cargo-deny/pull/691) fixed an issue where workspace dependencies that used the current dir '.' path component would incorrectly trigger the `unused-workspace-dependency` lint.
+
 ## [0.16.0] - 2024-08-02
 ### Removed
 - [PR#681](https://github.com/EmbarkStudios/cargo-deny/pull/681) finished the deprecation introduced in [PR#611](https://github.com/EmbarkStudios/cargo-deny/pull/611), making the usage of the deprecated fields into errors.

--- a/src/diag/krate_spans.rs
+++ b/src/diag/krate_spans.rs
@@ -766,7 +766,9 @@ fn read_workspace_deps<'k>(
                     // situations
                     let dir = km.krate.manifest_path.parent()?;
                     let path = crate::Path::new(path);
-                    if path.as_str().contains("..") {
+
+                    // Handle cases of current '.' or parent '..' directories
+                    if path.as_str().contains('.') {
                         let mut pb = krates.workspace_root().to_owned();
                         for comp in path.components() {
                             match comp {

--- a/tests/test_data/workspace/Cargo.toml
+++ b/tests/test_data/workspace/Cargo.toml
@@ -17,7 +17,7 @@ spdx = "0.10"
 spdx-old = { version = "0.9", package = "spdx" }
 spdx-very-old = { version = "0.8", package = "spdx" }
 spdx-git = { git = "https://github.com/EmbarkStudios/spdx.git", tag = "0.7.0", package = "spdx" }
-member-one = { path = "crates/member-one" }
+member-one = { path = "./crates/member-one" }
 member-two = { path = "crates/member-two" }
 # Validates we can find workspace dependency sources from non-crates.io registries
 crate-two = { version = "0.1.0", registry = "embark-deny-git" }


### PR DESCRIPTION
This fixes a bug where using the current dir '.' component would cause an incorrect unused-workspace-dependency lint to be triggered.