### PR TITLE
README: Add repology packaging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ cargo install --locked cargo-deny && cargo deny init && cargo deny check
 
 ## Usage
 
+<a href="https://repology.org/project/cargo-deny/versions"><img align="right" src="https://repology.org/badge/vertical-allrepos/cargo-deny.svg" alt="Packaging status"></a>
+
 ### [Install](https://embarkstudios.github.io/cargo-deny/cli/index.html) cargo-deny
 
 If you want to use `cargo-deny` without having `cargo` installed, build `cargo-deny` with the `standalone` feature. This can be useful in Docker Images.


### PR DESCRIPTION
This adds a dynamically updated image for the packaging status to the README:

![image](https://github.com/user-attachments/assets/bcc96505-dd81-44c0-9d63-f8b5f8382d1a)
