### PR TITLE
Feature `--exclude-unpublished`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,8 +1928,7 @@ dependencies = [
 [[package]]
 name = "krates"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac9a4a6857b3732e7504712e2d41d5edaad70424d3dcb7166868e57094f06c"
+source = "git+https://github.com/Tastaturtaste/krates?branch=fix-include-workspace-crates#b6224f46b236476506666d449eee53149860e496"
 dependencies = [
  "camino",
  "cfg-expr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,6 +1930,8 @@ dependencies = [
 [[package]]
 name = "krates"
 version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0e34dcebfd130ff62396179e65d781fb313cc186a6607b6c34f500d89e9672"
 dependencies = [
  "camino",
  "cfg-expr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,18 +198,18 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5327f6c99920069d1fe374aa743be1af0031dea9f250852cdf1ae6a0861ee24"
+checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
 dependencies = [
  "cfg_aliases",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.37"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -334,9 +334,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "clru"
@@ -435,9 +435,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -755,8 +755,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -816,7 +818,7 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -829,7 +831,7 @@ dependencies = [
  "gix-date",
  "gix-utils",
  "itoa",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -846,7 +848,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-bom",
 ]
 
@@ -856,7 +858,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f78312288bd02052be5dbc2ecbc342c9f4eb791986d86c0a5c06b92dc72efa"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -865,7 +867,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28b58ba04f0c004722344390af9dbc85888fbb84be1981afb934da4114d4cf"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -891,7 +893,7 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -910,7 +912,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-bom",
  "winnow",
 ]
@@ -925,7 +927,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -942,7 +944,7 @@ dependencies = [
  "gix-sec",
  "gix-trace",
  "gix-url",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -954,7 +956,7 @@ dependencies = [
  "bstr",
  "itoa",
  "jiff",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -966,7 +968,7 @@ dependencies = [
  "bstr",
  "gix-hash",
  "gix-object",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -982,7 +984,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1001,7 +1003,7 @@ dependencies = [
  "once_cell",
  "prodash",
  "sha1_smol",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 
@@ -1023,7 +1025,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1056,7 +1058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "952c3a29f1bc1007cc901abce7479943abfa42016db089de33d0a4fa3c85bfe8"
 dependencies = [
  "faster-hex",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1108,7 +1110,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1119,7 +1121,7 @@ checksum = "5102acdf4acae2644e38dbbd18cdfba9597a218f7d85f810fe5430207e03c2de"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1135,7 +1137,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1154,7 +1156,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -1176,7 +1178,7 @@ dependencies = [
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1196,7 +1198,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1208,7 +1210,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1220,7 +1222,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1233,7 +1235,7 @@ dependencies = [
  "gix-trace",
  "home",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1248,7 +1250,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1261,7 +1263,7 @@ dependencies = [
  "gix-config-value",
  "parking_lot",
  "rustix",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1278,7 +1280,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -1290,7 +1292,7 @@ checksum = "f89f9a1525dcfd9639e282ea939f5ab0d09d93cf2b90c1fc6104f1b9582a8e49"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1310,7 +1312,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -1325,7 +1327,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1340,7 +1342,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1355,7 +1357,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1382,7 +1384,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1422,7 +1424,7 @@ dependencies = [
  "gix-sec",
  "gix-url",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1439,7 +1441,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1451,7 +1453,7 @@ dependencies = [
  "bstr",
  "gix-features",
  "gix-path",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -1472,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e187b263461bc36cea17650141567753bc6207d036cedd1de6e81a52f277ff68"
 dependencies = [
  "bstr",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1511,7 +1513,7 @@ dependencies = [
  "gix-path",
  "gix-worktree",
  "io-close",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1927,8 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "krates"
-version = "0.17.2"
-source = "git+https://github.com/Tastaturtaste/krates?branch=fix-include-workspace-crates#b6224f46b236476506666d449eee53149860e496"
+version = "0.17.4"
 dependencies = [
  "camino",
  "cfg-expr",
@@ -2216,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -2227,26 +2228,29 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
+ "getrandom",
  "rand",
  "ring",
  "rustc-hash",
  "rustls",
+ "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.3",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -2351,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2518,6 +2522,9 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2542,7 +2549,7 @@ dependencies = [
  "platforms",
  "semver",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "toml",
  "url",
 ]
@@ -2637,18 +2644,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2911,7 +2918,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml-span",
  "twox-hash",
@@ -2957,7 +2964,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -2965,6 +2981,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3320,6 +3347,16 @@ name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,3 +156,6 @@ opt-level = 3
 
 [profile.dev.package.similar]
 opt-level = 3
+
+[patch.crates-io]
+krates = { git = "https://github.com/Tastaturtaste/krates", branch = "fix-include-workspace-crates", version = "0.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,3 @@ opt-level = 3
 
 [profile.dev.package.similar]
 opt-level = 3
-
-[patch.crates-io]
-krates = { path = "../krates" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,4 +158,4 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-krates = { git = "https://github.com/Tastaturtaste/krates", branch = "fix-include-workspace-crates", version = "0.17" }
+krates = { path = "../krates" }

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -161,6 +161,7 @@ pub(crate) fn cmd(
     krate_ctx.all_features |= graph.all_features;
     krate_ctx.no_default_features |= graph.no_default_features;
     krate_ctx.exclude_dev |= graph.exclude_dev | args.exclude_dev;
+    krate_ctx.exclude_unpublished |= graph.exclude_unpublished;
 
     // If not specified on the cmd line, fallback to the feature related config options
     if krate_ctx.features.is_empty() {

--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -24,6 +24,7 @@ pub struct KrateContext {
     pub locked: bool,
     pub offline: bool,
     pub exclude_dev: bool,
+    pub exclude_unpublished: bool,
 }
 
 impl KrateContext {
@@ -169,7 +170,14 @@ impl KrateContext {
                     }),
             );
         }
-
+        if self.exclude_unpublished {
+            gb.include_workspace_crates(metadata.workspace_packages().iter().filter_map(
+                |package| match package.publish {
+                    Some(ref registries) if registries.is_empty() => None,
+                    _ => Some(package.manifest_path.as_std_path()),
+                },
+            ));
+        }
         // Attempt to open the crates.io index so that the feature sets for every
         // crate in the graph are correct, however, don't consider it a hard failure
         // if we can't for some reason, as the graph will _probably_ still be accurate

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -98,6 +98,12 @@ pub(crate) struct GraphContext {
     #[arg(long)]
     /// If set, excludes all dev-dependencies, not just ones for non-workspace crates
     pub(crate) exclude_dev: bool,
+    #[arg(long)]
+    /// If set, prune all unpublished workspace members from the cargo metadata.
+    /// Workspace members are considered unpublished if they they are explicitly marked with `publish = false` as such.
+    /// The pruned crates are still used for the initial dependency resolution by cargo,
+    /// but are not used as roots in the crate graph.
+    pub(crate) exclude_unpublished: bool,
 }
 
 /// Lints your project's crate graph
@@ -296,6 +302,7 @@ fn real_main() -> Result<(), Error> {
         locked: args.ctx.locked,
         offline: args.ctx.offline,
         exclude_dev: args.ctx.exclude_dev,
+        exclude_unpublished: args.ctx.exclude_unpublished,
     };
 
     let log_ctx = crate::common::LogContext {

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -99,10 +99,10 @@ pub(crate) struct GraphContext {
     /// If set, excludes all dev-dependencies, not just ones for non-workspace crates
     pub(crate) exclude_dev: bool,
     #[arg(long)]
-    /// If set, prune all unpublished workspace members from the cargo metadata.
+    /// If set, exclude unpublished workspace members from graph roots.
     /// Workspace members are considered unpublished if they they are explicitly marked with `publish = false` as such.
-    /// The pruned crates are still used for the initial dependency resolution by cargo,
-    /// but are not used as roots in the crate graph.
+    /// Note that the excluded workspace members are still used for the initial dependency resolution by cargo,
+    /// which might affect the exact version of used dependencies.
     pub(crate) exclude_unpublished: bool,
 }
 

--- a/src/root_cfg.rs
+++ b/src/root_cfg.rs
@@ -48,6 +48,7 @@ pub struct GraphConfig {
     pub no_default_features: bool,
     /// By default, dev dependencies for workspace crates are not ignored
     pub exclude_dev: bool,
+    pub exclude_unpublished: bool,
 }
 
 impl<'de> Deserialize<'de> for GraphConfig {
@@ -59,6 +60,7 @@ impl<'de> Deserialize<'de> for GraphConfig {
         let all_features = th.optional("all-features").unwrap_or_default();
         let no_default_features = th.optional("no-default-features").unwrap_or_default();
         let exclude_dev = th.optional("exclude-dev").unwrap_or_default();
+        let exclude_unpublished = th.optional("exclude-unpublished").unwrap_or_default();
         th.finalize(None)?;
 
         Ok(Self {
@@ -68,6 +70,7 @@ impl<'de> Deserialize<'de> for GraphConfig {
             all_features,
             no_default_features,
             exclude_dev,
+            exclude_unpublished,
         })
     }
 }

--- a/tests/snapshots/bans__ignores_unpublished_crates.snap
+++ b/tests/snapshots/bans__ignores_unpublished_crates.snap
@@ -1,0 +1,6 @@
+---
+source: tests/bans.rs
+expression: diags
+snapshot_kind: text
+---
+[]

--- a/tests/snapshots/cargo_deny__test__cargo_deny.snap
+++ b/tests/snapshots/cargo_deny__test__cargo_deny.snap
@@ -89,9 +89,11 @@ Options:
       --exclude-dev
           If set, excludes all dev-dependencies, not just ones for non-workspace crates
 
+      --exclude-unpublished
+          If set, exclude unpublished workspace members from graph roots. Workspace members are considered unpublished if they they are explicitly marked with `publish = false` as such. Note that the excluded workspace members are still used for the initial dependency resolution by cargo, which might affect the exact version of used dependencies
+
   -h, --help
           Print help (see a summary with '-h')
 
   -V, --version
           Print version
-

--- a/tests/test_data/wildcards/allow-paths-private/Cargo.toml
+++ b/tests/test_data/wildcards/allow-paths-private/Cargo.toml
@@ -7,7 +7,5 @@ license = "MIT"
 
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 wildcards-test-allow-paths-dependency = { path = "../allow-paths-dependency" }


### PR DESCRIPTION
This PR adds a new command line flag `--exclude-unpublished`. If the flag is set, the construction of the crate graph does not use explicitly unpublished crates as roots. Workspace members are considered explicitly unpublished if their manifest specifies `publish = false`. For motivation please see the [associated issue](https://github.com/EmbarkStudios/cargo-deny/issues/708).

This PR depends on https://github.com/EmbarkStudios/krates/pull/94 to fix the workspace filters mechanism of https://github.com/EmbarkStudios/krates. Documentation for the flag will follow as soon as I find the time. 