### PR TITLE
Update goblin to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+checksum = "53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923"
 dependencies = [
  "log",
  "plain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,13 +65,14 @@ fern = "0.6"
 # Glob matching
 globset = "0.4"
 # Native executable detection
-goblin = { version = "0.8", default-features = false, features = [
+goblin = { version = "0.9", default-features = false, features = [
   "elf32",
   "elf64",
   "mach32",
   "mach64",
   "pe32",
   "pe64",
+  "te",
 ] }
 # We need to figure out HOME/CARGO_HOME in some cases
 home = "0.5"


### PR DESCRIPTION
Update goblin to 0.9.

The breaking change from 0.8.0 appears to be the addition of a value to a pub enum associated with [TE (terse executable)](https://uefi.org/specs/PI/1.8/V1_TE_Image.html) support; at first glance, it does not look like this should affect cargo-deny’s usage of goblin since it doesn’t match exhaustively on this enum, but it turns out that we do need to add the new `te` feature to the requested `goblin` features in order for the `peek_bytes` API function to be available; see https://github.com/m4b/goblin/blob/d096260201158ed34d64728fd1ab0ca125e2f956/src/lib.rs#L240 and: https://github.com/EmbarkStudios/cargo-deny/blob/69f1f598e057d4d059da4bb91bfeaa94fc29a73f/src/bans.rs#L1461

With that small change, everything compiles and `cargo test` passes.

https://github.com/m4b/goblin/blob/d096260201158ed34d64728fd1ab0ca125e2f956/CHANGELOG.md#092----2024-10-26