### PR TITLE
Add empty workspace to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,3 +156,5 @@ opt-level = 3
 
 [profile.dev.package.similar]
 opt-level = 3
+
+[workspace]

--- a/examples/01_allow_license/Cargo.toml
+++ b/examples/01_allow_license/Cargo.toml
@@ -12,3 +12,5 @@ path = "main.rs"
 [dependencies]
 shared = { path = "../shared" }
 las = { version = "=0.7.7", features = ["laz"] }
+
+[workspace]

--- a/examples/02_deny_license/Cargo.toml
+++ b/examples/02_deny_license/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 [[bin]]
 name = "deny-license"
 path = "main.rs"
+
+[workspace]

--- a/examples/03_deny_copyleft/Cargo.toml
+++ b/examples/03_deny_copyleft/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 [[bin]]
 name = "deny-copyleft"
 path = "main.rs"
+
+[workspace]

--- a/examples/04_gnu_licenses/Cargo.toml
+++ b/examples/04_gnu_licenses/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 [[bin]]
 name = "gnu-license"
 path = "main.rs"
+
+[workspace]

--- a/examples/06_advisories/Cargo.toml
+++ b/examples/06_advisories/Cargo.toml
@@ -31,3 +31,5 @@ static_type_map = "0.3"
 # The advisory applies to 0.10.0-alpha.1 >= && < 0.10.0-alpha.4
 # https://github.com/RustSec/advisory-db/blob/c71cfec8c3fe313c9445a9ab0ae9b7faedda850a/crates/lettre/RUSTSEC-2020-0069.md
 lettre = "0.10.0-alpha.3"
+
+[workspace]

--- a/examples/07_deny_sources/Cargo.toml
+++ b/examples/07_deny_sources/Cargo.toml
@@ -22,3 +22,5 @@ gitea-release = { git = "https://tulpa.dev/cadey/gitea-release" }
 
 # This will not be since the base path doesn't match
 mlua_serde = { git = "https://tulpa.dev/lua/mlua_serde" }
+
+[workspace]

--- a/examples/08_target_filtering/Cargo.toml
+++ b/examples/08_target_filtering/Cargo.toml
@@ -40,3 +40,5 @@ difference = "2.0.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_feature = "atomics"))'.dependencies]
 wasm-bindgen-futures = "0.4.6"
+
+[workspace]

--- a/examples/09_bans/Cargo.toml
+++ b/examples/09_bans/Cargo.toml
@@ -13,3 +13,5 @@ version = "0.10.1"
 # duplicate as well!
 # default-features = false
 # features = ["rustls"]
+
+[workspace]

--- a/examples/10_allow_build_script/Cargo.toml
+++ b/examples/10_allow_build_script/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 openssl-sys = "0.9.74"
+
+[workspace]

--- a/examples/11_feature_bans/Cargo.toml
+++ b/examples/11_feature_bans/Cargo.toml
@@ -10,3 +10,5 @@ reqwest = { version = "=0.11.11", default-features = false, features = [
 
 [features]
 foo = []
+
+[workspace]

--- a/examples/12_yank_check/Cargo.toml
+++ b/examples/12_yank_check/Cargo.toml
@@ -14,3 +14,5 @@ spdx = "=0.3.1"
 crate-two = { version = "=0.1.0", registry = "embark-deny" }
 # This one is not
 crate-one = { version = "=0.1.0", registry = "embark-deny-sparse" }
+
+[workspace]

--- a/examples/13_license_clarification/Cargo.toml
+++ b/examples/13_license_clarification/Cargo.toml
@@ -11,3 +11,5 @@ path = "main.rs"
 
 [dependencies]
 rustls-webpki = "=0.100.1"
+
+[workspace]

--- a/examples/shared/Cargo.toml
+++ b/examples/shared/Cargo.toml
@@ -7,3 +7,5 @@ publish = false
 
 [lib]
 path = "lib.rs"
+
+[workspace]

--- a/tests/test_data/allow_wrappers/dangerous-dep/Cargo.toml
+++ b/tests/test_data/allow_wrappers/dangerous-dep/Cargo.toml
@@ -7,3 +7,5 @@ license = "MIT"
 
 [features]
 not-dangerous-at-all = []
+
+[workspace]

--- a/tests/test_data/allow_wrappers/maincrate/Cargo.toml
+++ b/tests/test_data/allow_wrappers/maincrate/Cargo.toml
@@ -7,3 +7,5 @@ license = "MIT"
 
 [dependencies]
 safe-wrapper = { path = "../safe-wrapper", version = "0.1.0" }
+
+[workspace]

--- a/tests/test_data/allow_wrappers/safe-wrapper/Cargo.toml
+++ b/tests/test_data/allow_wrappers/safe-wrapper/Cargo.toml
@@ -9,3 +9,5 @@ license = "MIT"
 dangerous-dep = { version = "0.1.0", path = "../dangerous-dep", features = [
     "not-dangerous-at-all",
 ] }
+
+[workspace]

--- a/tests/test_data/build-bans/Cargo.toml
+++ b/tests/test_data/build-bans/Cargo.toml
@@ -19,3 +19,5 @@ prost-build = { version = "<0.10", optional = true }
 ring = { version = "0.16.20", optional = true }
 # The shot heard around the world
 serde = { version = "=1.0.172", features = ["derive"], optional = true }
+
+[workspace]

--- a/tests/test_data/duplicates/Cargo.toml
+++ b/tests/test_data/duplicates/Cargo.toml
@@ -8,3 +8,5 @@ sqlx = "0.5"
 
 [dev-dependencies]
 async-graphql = "3.0"
+
+[workspace]

--- a/tests/test_data/features-galore/Cargo.toml
+++ b/tests/test_data/features-galore/Cargo.toml
@@ -42,3 +42,5 @@ stream = ["request?/stream"]
 tls = ["tls-no-reqwest", "request?/rustls-tls"]
 tls-no-reqwest = ["rustls"]
 zlib = ["git/zlib-ng-compat", "request?/deflate"]
+
+[workspace]

--- a/tests/test_data/features/Cargo.toml
+++ b/tests/test_data/features/Cargo.toml
@@ -33,3 +33,5 @@ serde = ["dep:serde", "rgb?/serde"]
 stream = ["request?/stream"]
 zlib = ["git/zlib-ng-compat", "request?/deflate"]
 ssh = ["git/ssh", "git/ssh_key_from_memory"]
+
+[workspace]

--- a/tests/test_data/non-crates-io/Cargo.toml
+++ b/tests/test_data/non-crates-io/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 from-git = { version = "*", package = "crate-one", registry = "embark-deny-git" }
 from-sparse = { version = "*", package = "crate-two", registry = "embark-deny-sparse" }
+
+[workspace]

--- a/tests/test_data/non-crates-io/crate-one/Cargo.toml
+++ b/tests/test_data/non-crates-io/crate-one/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[workspace]

--- a/tests/test_data/non-crates-io/crate-two/Cargo.toml
+++ b/tests/test_data/non-crates-io/crate-two/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
+
+[workspace]

--- a/tests/test_data/so-annoying/Cargo.toml
+++ b/tests/test_data/so-annoying/Cargo.toml
@@ -3,3 +3,5 @@ name = "so-annoying"
 version = "0.1.0"
 edition = "2021"
 publish = false
+
+[workspace]

--- a/tests/test_data/sources/Cargo.toml
+++ b/tests/test_data/sources/Cargo.toml
@@ -26,3 +26,5 @@ amethyst_core = { git = "https://gitlab.com/amethyst-engine/amethyst", rev = "0c
 krates = { git = "https://github.com/EmbarkStudios/krates", branch = "main" }
 line-wrap = { git = "https://bitbucket.org/marshallpierce/line-wrap-rs" }
 spdx = { git = "https://github.com/EmbarkStudios/spdx", tag = "0.3.4" }
+
+[workspace]

--- a/tests/test_data/wildcards/allow-git/Cargo.toml
+++ b/tests/test_data/wildcards/allow-git/Cargo.toml
@@ -12,3 +12,5 @@ publish = false
 [dependencies]
 # An arbitrary choice of actually existent Git repository
 wildcards-test-allow-git = { package = "krates", git = "https://github.com/EmbarkStudios/krates", rev = "b03ecd6f3204a1b1ec04fbaead2d0d122a3a4494" }
+
+[workspace]

--- a/tests/test_data/wildcards/allow-paths-dependency/Cargo.toml
+++ b/tests/test_data/wildcards/allow-paths-dependency/Cargo.toml
@@ -9,3 +9,5 @@ license = "MIT"
 
 [dependencies]
 sqlx = "0.5"
+
+[workspace]

--- a/tests/test_data/wildcards/allow-paths-private/Cargo.toml
+++ b/tests/test_data/wildcards/allow-paths-private/Cargo.toml
@@ -9,3 +9,5 @@ publish = false
 
 [dependencies]
 wildcards-test-allow-paths-dependency = { path = "../allow-paths-dependency" }
+
+[workspace]

--- a/tests/test_data/wildcards/allow-paths-public/Cargo.toml
+++ b/tests/test_data/wildcards/allow-paths-public/Cargo.toml
@@ -7,3 +7,5 @@ license = "MIT"
 
 [dependencies]
 wildcards-test-allow-paths-dependency = { path = "../allow-paths-dependency" }
+
+[workspace]

--- a/tests/test_data/wildcards/dependency/Cargo.toml
+++ b/tests/test_data/wildcards/dependency/Cargo.toml
@@ -7,3 +7,5 @@ license = "MIT"
 
 [dependencies]
 itoa = "*"
+
+[workspace]

--- a/tests/test_data/wildcards/maincrate/Cargo.toml
+++ b/tests/test_data/wildcards/maincrate/Cargo.toml
@@ -8,3 +8,5 @@ license = "MIT"
 [dependencies]
 ansi_term = "*"
 wildcards-test-dep = { path = "../dependency", version = "0.1.0" }
+
+[workspace]


### PR DESCRIPTION
This fixes an issue that arises when the package is installed with pre-commit into a cache directory that is itself a subdirectory of a Cargo workspace, making Cargo think it's a package that should have been a part of the parent workspace.

```
An unexpected error has occurred: CalledProcessError: command: ('/usr/local/cargo/bin/cargo', 'install', '--bins', '--root', '/builds/project/.cache/pre-commit/repot501w21b/rustenv-system', '--path', '.')
return code: 101
stdout: (none)
stderr:
    error: current package believes it's in a workspace when it's not:
    current:   /builds/project/.cache/pre-commit/repot501w21b/Cargo.toml
    workspace: /builds/project/Cargo.toml
    
    this may be fixable by adding `.cache/pre-commit/repot501w21b` to the `workspace.members` array of the manifest located at: /builds/project/Cargo.toml
    Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
Check the log at /builds/project/.cache/pre-commit/pre-commit.log
```