### PR TITLE
Additional 1.85.0 fixup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           components: "clippy"
       - run: cargo fetch
       - name: cargo clippy

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = tests/advisory-db/github.com-c046ebb82572a8ef
 	url = https://github.com/EmbarkStudios/test-advisory-db
 [submodule "tests/advisory-db/github.com-6caef394c3b504ea"]
-	path = tests/advisory-db/github.com-6caef394c3b504ea
+	path = tests/advisory-db/advisory-db-d0afbf0b2e3a7ec0
 	url = https://github.com/rustsec/advisory-db

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = tests/advisory-db/github.com-c046ebb82572a8ef
 	url = https://github.com/EmbarkStudios/test-advisory-db
 [submodule "tests/advisory-db/github.com-6caef394c3b504ea"]
-	path = tests/advisory-db/advisory-db-d0afbf0b2e3a7ec0
+	path = tests/advisory-db/advisory-db-3157b0e258782691
 	url = https://github.com/rustsec/advisory-db

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "tests/advisory-db/github.com-c046ebb82572a8ef"]
-	path = tests/advisory-db/github.com-c046ebb82572a8ef
+	path = tests/advisory-db/test-advisory-db-c27873b782cceedc
 	url = https://github.com/EmbarkStudios/test-advisory-db
 [submodule "tests/advisory-db/github.com-6caef394c3b504ea"]
 	path = tests/advisory-db/advisory-db-3157b0e258782691

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "tests/advisory-db/github.com-c046ebb82572a8ef"]
+[submodule "tests/advisory-db/test-advisory-db-c27873b782cceedc"]
 	path = tests/advisory-db/test-advisory-db-c27873b782cceedc
 	url = https://github.com/EmbarkStudios/test-advisory-db
-[submodule "tests/advisory-db/github.com-6caef394c3b504ea"]
+[submodule "tests/advisory-db/advisory-db-3157b0e258782691"]
 	path = tests/advisory-db/advisory-db-3157b0e258782691
 	url = https://github.com/rustsec/advisory-db

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tests/advisory-db/github.com-c046ebb82572a8ef"]
 	path = tests/advisory-db/github.com-c046ebb82572a8ef
 	url = https://github.com/EmbarkStudios/test-advisory-db
-[submodule "tests/advisory-db/github.com-9b36585d9d99f7b3"]
-	path = tests/advisory-db/github.com-9b36585d9d99f7b3
+[submodule "tests/advisory-db/github.com-6caef394c3b504ea"]
+	path = tests/advisory-db/github.com-6caef394c3b504ea
 	url = https://github.com/rustsec/advisory-db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#746](https://github.com/EmbarkStudios/cargo-deny/pull/746) changed the directory naming of advisory databases, [again](https://github.com/EmbarkStudios/cargo-deny/pull/745), so the name uses the last path component and a different, but also stable, hashing algorithm. Eg. the default `https://github.com/rustsec/advisory-db` will now be placed in `$CARGO_HOME/advisory-dbs/advisory-db-3157b0e258782691`.
+- [PR#746](https://github.com/EmbarkStudios/cargo-deny/pull/746) changed the MSRV to 1.85.0 and uses edition 2024.
+
+### Fixed
+- [PR#746](https://github.com/EmbarkStudios/cargo-deny/pull/746) fixes an issue when using cargo 1.85.0 where source urls were not being properly assigned to crates.io due to the constant being used no longer matching the new path used in cargo 1.85.0 causing eg. workspace dependency checks to fail.
+
 ## [0.17.0] - 2025-02-20
 ### Changed
 - [PR#745](https://github.com/EmbarkStudios/cargo-deny/pull/745) updated `tame-index` to [0.18.0](https://github.com/EmbarkStudios/tame-index/releases/tag/0.18.0) so that cargo 1.85.0 is transparently supported along with older cargo versions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4ba6e40bd1184518716a6e1a781bf9160e286d219ccdb8ab2612e74cfe4789"
+checksum = "1a2b34126159980f92da2a08bdec0694fd80fb5eb9e48aff25d20a0d8dfa710d"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -576,9 +576,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "encode_unicode"
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1975,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "krates"
-version = "0.17.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5bdd9794c39f6eb77da784fdcd065cc730a95fd0ca7d88ec945ed26c3c5109"
+checksum = "f9cff905a7fe94eb764ffe3fc772ef0116bbf2a76fff737a30e3c673c0f15e6f"
 dependencies = [
  "camino",
  "cfg-expr",
@@ -2004,9 +2004,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libredox"
@@ -2049,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "maybe-async"
@@ -2087,9 +2087,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -2187,9 +2187,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -2416,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags",
 ]
@@ -2504,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2980,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "tame-index"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bfcad7f766f01a7bd209ac43309c99a1c0a22c641828a42e7e2ee6c0cb46646"
+checksum = "ffce9e61c14d088a18efafe197ce1906e639cc1980e21e7e09e45c3cb0bfc50c"
 dependencies = [
  "bytes",
  "camino",
@@ -3014,9 +3014,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
@@ -3774,27 +3774,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "Embark <opensource@embark-studios.com>",
   "Jake Shadle <jake.shadle@embark-studios.com>",
 ]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 documentation = "https://docs.rs/cargo-deny"
@@ -15,7 +15,7 @@ homepage = "https://github.com/EmbarkStudios/cargo-deny"
 categories = ["development-tools::cargo-plugins"]
 keywords = ["cargo", "license", "spdx", "ci", "advisories"]
 exclude = ["docs/", "examples/", ".github/", "tests"]
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ askalono = { version = "0.5", default-features = false }
 bitvec = { version = "1.0", features = ["alloc"] }
 # Much nicer paths
 camino = "1.1"
-cfg-expr = "0.17"
+cfg-expr = "0.18"
 # Allows us to do eg cargo metadata operations without relying on an external cargo
 #cargo = { version = "0.71", optional = true }
 # Argument parsing, kept aligned with cargo
@@ -77,7 +77,7 @@ goblin = { version = "0.9", default-features = false, features = [
 # We need to figure out HOME/CARGO_HOME in some cases
 home = "0.5"
 # Provides graphs on top of cargo_metadata
-krates = { version = "0.17", features = ["targets"] }
+krates = { version = "0.18", features = ["targets"] }
 # Log macros
 log = "0.4"
 # Faster char searching

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.84.1"
+msrv = "1.85.0"
 
 disallowed-types = [
     { path = "std::sync::Mutex", reason = "Use the faster & simpler non-poisonable primitives in `parking_lot` instead" },

--- a/deny.toml
+++ b/deny.toml
@@ -56,21 +56,7 @@ allow = [
 exceptions = [
     # Use exceptions for these as they only have a single user
     { allow = ["Zlib"], crate = "tinyvec" },
-    { allow = ["OpenSSL"], crate = "ring" },
 ]
-
-# Sigh
-[[licenses.clarify]]
-crate = "ring"
-# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
-# https://spdx.org/licenses/OpenSSL.html
-# ISC - Both BoringSSL and ring use this for their new files
-# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
-# license, for third_party/fiat, which, unlike other third_party directories, is
-# compiled into non-test libraries, is included below."
-# OpenSSL - Obviously
-expression = "ISC AND MIT AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [[licenses.clarify]]
 crate = "webpki"

--- a/src/advisories.rs
+++ b/src/advisories.rs
@@ -2,7 +2,7 @@ pub mod cfg;
 pub(crate) mod diags;
 mod helpers;
 
-use crate::{diag, LintLevel};
+use crate::{LintLevel, diag};
 pub use diags::Code;
 pub use helpers::{
     db::{AdvisoryDb, DbSet, Fetch, Id, Report},

--- a/src/advisories/cfg.rs
+++ b/src/advisories/cfg.rs
@@ -1,12 +1,13 @@
 use crate::{
+    LintLevel, PathBuf, Span, Spanned,
     cfg::{PackageSpecOrExtended, Reason, ValidationContext},
     diag::{Diagnostic, FileId, Label},
-    utf8path, LintLevel, PathBuf, Span, Spanned,
+    utf8path,
 };
 use anyhow::Context as _;
 use rustsec::advisory;
 use time::Duration;
-use toml_span::{de_helpers::*, value::ValueInner, Deserialize, Value};
+use toml_span::{Deserialize, Value, de_helpers::*, value::ValueInner};
 use url::Url;
 
 pub(crate) type AdvisoryId = Spanned<advisory::Id>;
@@ -465,7 +466,9 @@ fn parse_rfc3339_duration(value: &str) -> anyhow::Result<Duration> {
     // of the function
     for c in value.chars() {
         if c == ',' {
-            anyhow::bail!("'{c}' is valid in the RFC-3339 duration format but not supported by this implementation, use '.' instead");
+            anyhow::bail!(
+                "'{c}' is valid in the RFC-3339 duration format but not supported by this implementation, use '.' instead"
+            );
         }
 
         if c != '.' && c != 'T' && !c.is_ascii_digit() && !UNITS.iter().any(|(uc, _)| c == *uc) {
@@ -720,7 +723,7 @@ fn shellexpand(
 mod test {
 
     use super::{parse_rfc3339_duration as dur_parse, *};
-    use crate::test_utils::{write_diagnostics, ConfigData};
+    use crate::test_utils::{ConfigData, write_diagnostics};
 
     struct Advisories {
         advisories: Config,

--- a/src/advisories/diags.rs
+++ b/src/advisories/diags.rs
@@ -1,7 +1,7 @@
 use super::cfg::IgnoreId;
 use crate::{
-    diag::{Check, Diagnostic, FileId, Label, Pack, Severity},
     LintLevel,
+    diag::{Check, Diagnostic, FileId, Label, Pack, Severity},
 };
 use rustsec::advisory::{Informational, Metadata, Versions};
 
@@ -160,11 +160,13 @@ impl crate::CheckCtx<'_, super::cfg::ValidConfig> {
         let diag = pack.push(
             Diagnostic::new(severity)
                 .with_message(advisory.title.clone())
-                .with_labels(vec![Label::primary(
-                    self.krate_spans.lock_id,
-                    self.krate_spans.lock_span(&krate.id).total,
-                )
-                .with_message(message)])
+                .with_labels(vec![
+                    Label::primary(
+                        self.krate_spans.lock_id,
+                        self.krate_spans.lock_span(&krate.id).total,
+                    )
+                    .with_message(message),
+                ])
                 .with_code(code)
                 .with_notes(notes),
         );
@@ -185,11 +187,13 @@ impl crate::CheckCtx<'_, super::cfg::ValidConfig> {
                     krate.name
                 ))
                 .with_code(Code::Yanked)
-                .with_labels(vec![Label::primary(
-                    self.krate_spans.lock_id,
-                    self.krate_spans.lock_span(&krate.id).total,
-                )
-                .with_message("yanked version")]),
+                .with_labels(vec![
+                    Label::primary(
+                        self.krate_spans.lock_id,
+                        self.krate_spans.lock_span(&krate.id).total,
+                    )
+                    .with_message("yanked version"),
+                ]),
         );
 
         pack
@@ -212,11 +216,13 @@ impl crate::CheckCtx<'_, super::cfg::ValidConfig> {
         krate: &crate::Krate,
         error: D,
     ) -> Pack {
-        let mut labels = vec![Label::secondary(
-            self.krate_spans.lock_id,
-            self.krate_spans.lock_span(&krate.id).total,
-        )
-        .with_message("crate whose registry we failed to query")];
+        let mut labels = vec![
+            Label::secondary(
+                self.krate_spans.lock_id,
+                self.krate_spans.lock_span(&krate.id).total,
+            )
+            .with_message("crate whose registry we failed to query"),
+        ];
 
         // Don't show the config location if it's the default, since it just points
         // to the beginning and confuses users

--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -94,6 +94,7 @@ impl DbSet {
 /// identifier, but then hash the url as the user provides it to ensure the
 /// directory name is unique
 fn url_to_db_path(mut db_path: PathBuf, url: &Url) -> anyhow::Result<PathBuf> {
+    let url = Url::parse(&url.as_str().to_lowercase())?;
     let name = url
         .path_segments()
         .and_then(|mut ps| ps.next_back())

--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -1,7 +1,7 @@
 use crate::{Krate, Krates, Path, PathBuf};
 use anyhow::Context as _;
 use log::{debug, info};
-pub use rustsec::{advisory::Id, Database};
+pub use rustsec::{Database, advisory::Id};
 use std::fmt;
 use url::Url;
 
@@ -270,7 +270,7 @@ fn fetch_and_checkout(repo: &mut gix::Repository) -> anyhow::Result<()> {
         let remote_head_id = tame_index::utils::git::write_fetch_head(&repo, &outcome, &remote)
             .context("failed to write FETCH_HEAD")?;
 
-        use gix::refs::{transaction as tx, Target};
+        use gix::refs::{Target, transaction as tx};
 
         // In all (hopefully?) cases HEAD is a symbolic reference to
         // refs/heads/<branch> which is a peeled commit id, if that's the case

--- a/src/advisories/helpers/index.rs
+++ b/src/advisories/helpers/index.rs
@@ -1,7 +1,7 @@
 use crate::{Krate, Krates, Source};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use std::collections::BTreeMap;
-use tame_index::{index::ComboIndexCache, Error, IndexLocation, IndexUrl};
+use tame_index::{Error, IndexLocation, IndexUrl, index::ComboIndexCache};
 
 type YankMap = Vec<(semver::Version, bool)>;
 

--- a/src/bans.rs
+++ b/src/bans.rs
@@ -4,9 +4,9 @@ mod graph;
 
 use self::cfg::{ValidBuildConfig, ValidConfig, ValidTreeSkip};
 use crate::{
+    Kid, Krate, Krates, LintLevel,
     cfg::{PackageSpec, Reason, Span, Spanned},
     diag::{self, CfgCoord, FileId, KrateCoord},
-    Kid, Krate, Krates, LintLevel,
 };
 use anyhow::Error;
 pub use diags::Code;

--- a/src/bans/cfg.rs
+++ b/src/bans/cfg.rs
@@ -1,9 +1,9 @@
 use crate::{
+    LintLevel, Spanned,
     cfg::{PackageSpec, PackageSpecOrExtended, Reason, ValidationContext},
     diag::{Diagnostic, FileId, Label},
-    LintLevel, Spanned,
 };
-use toml_span::{de_helpers::TableHelper, value::Value, DeserError, Deserialize};
+use toml_span::{DeserError, Deserialize, de_helpers::TableHelper, value::Value};
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct CrateBanExtended {
@@ -605,8 +605,10 @@ impl crate::cfg::UnvalidatedConfig for Config {
                         ctx.diagnostics.push(
                             Diagnostic::error()
                                 .with_message("non-ascii file extension provided")
-                                .with_labels(vec![Label::primary(ctx.cfg_id, ext.span)
-                                    .with_message("invalid extension")]),
+                                .with_labels(vec![
+                                    Label::primary(ctx.cfg_id, ext.span)
+                                        .with_message("invalid extension"),
+                                ]),
                         );
                         continue;
                     }
@@ -635,8 +637,10 @@ impl crate::cfg::UnvalidatedConfig for Config {
                             ctx.diagnostics.push(
                                 Diagnostic::error()
                                     .with_message(format!("invalid glob pattern: {err}"))
-                                    .with_labels(vec![Label::primary(ctx.cfg_id, ext.span)
-                                        .with_message("extension")]),
+                                    .with_labels(vec![
+                                        Label::primary(ctx.cfg_id, ext.span)
+                                            .with_message("extension"),
+                                    ]),
                             );
                         }
                     }

--- a/src/bans/diags.rs
+++ b/src/bans/diags.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 
 use crate::{
-    bans::{cfg, SpecAndReason},
+    Krate, Spanned,
+    bans::{SpecAndReason, cfg},
     diag::{
         CfgCoord, Check, Diag, Diagnostic, FileId, GraphNode, KrateCoord, Label, Pack, Severity,
     },
-    Krate, Spanned,
 };
 
 #[derive(
@@ -146,10 +146,9 @@ impl<'a> From<Duplicates<'a>> for Diag {
                 dup.num_dupes, dup.krate_name,
             ))
             .with_code(Code::Duplicate)
-            .with_labels(vec![dup
-                .krates_coord
-                .into_label()
-                .with_message("lock entries")])
+            .with_labels(vec![
+                dup.krates_coord.into_label().with_message("lock entries"),
+            ])
             .into()
     }
 }
@@ -252,10 +251,11 @@ impl From<UnusedWrapper> for Diag {
         Diagnostic::new(Severity::Warning)
             .with_message("wrapper for banned crate was not encountered")
             .with_code(Code::UnusedWrapper)
-            .with_labels(vec![us
-                .wrapper_cfg
-                .into_label()
-                .with_message("unmatched wrapper")])
+            .with_labels(vec![
+                us.wrapper_cfg
+                    .into_label()
+                    .with_message("unmatched wrapper"),
+            ])
             .into()
     }
 }
@@ -328,10 +328,11 @@ impl From<UnmatchedSkipRoot> for Diag {
         Diagnostic::new(Severity::Warning)
             .with_message("skip tree root was not found in the dependency graph")
             .with_code(Code::UnmatchedSkipRoot)
-            .with_labels(vec![usr
-                .skip_root_cfg
-                .into_label()
-                .with_message("no crate matched these criteria")])
+            .with_labels(vec![
+                usr.skip_root_cfg
+                    .into_label()
+                    .with_message("no crate matched these criteria"),
+            ])
             .into()
     }
 }
@@ -361,10 +362,11 @@ pub(crate) struct ExactFeaturesMismatch<'a> {
 
 impl From<ExactFeaturesMismatch<'_>> for Diag {
     fn from(efm: ExactFeaturesMismatch<'_>) -> Self {
-        let mut labels = vec![efm
-            .exact_coord
-            .into_label()
-            .with_message("exact enabled here")];
+        let mut labels = vec![
+            efm.exact_coord
+                .into_label()
+                .with_message("exact enabled here"),
+        ];
 
         labels.extend(
             efm.missing_allowed
@@ -424,10 +426,9 @@ impl From<FeatureNotExplicitlyAllowed<'_>> for Diag {
                 fna.feature, fna.krate,
             ))
             .with_code(Code::FeatureNotExplicitlyAllowed)
-            .with_labels(vec![fna
-                .allowed
-                .into_label()
-                .with_message("allowed features")]);
+            .with_labels(vec![
+                fna.allowed.into_label().with_message("allowed features"),
+            ]);
 
         Diag {
             diag,
@@ -457,7 +458,7 @@ impl From<FeatureBanned<'_>> for Diag {
             ))
             .with_code(Code::FeatureBanned)
             .with_labels(vec![
-                Label::primary(fed.file_id, fed.feature.span).with_message("feature denied here")
+                Label::primary(fed.file_id, fed.feature.span).with_message("feature denied here"),
             ]);
 
         Diag {
@@ -488,7 +489,7 @@ impl From<UnknownFeature<'_>> for Diag {
             ))
             .with_code(Code::UnknownFeature)
             .with_labels(vec![
-                Label::primary(uf.file_id, uf.feature.span).with_message("unknown feature")
+                Label::primary(uf.file_id, uf.feature.span).with_message("unknown feature"),
             ]);
 
         Diag {
@@ -519,7 +520,7 @@ impl From<DefaultFeatureEnabled<'_>> for Diag {
             ))
             .with_code(Code::DefaultFeatureEnabled)
             .with_labels(vec![
-                Label::primary(dfe.file_id, dfe.level.span).with_message("lint level")
+                Label::primary(dfe.file_id, dfe.level.span).with_message("lint level"),
             ]);
 
         Diag {
@@ -637,7 +638,7 @@ impl From<ChecksumMatch<'_>> for Diag {
             .with_notes(vec![format!("path = '{}'", cm.path)])
             .with_code(Code::ChecksumMatch)
             .with_labels(vec![
-                Label::primary(cm.file_id, cm.checksum.span).with_message("checksum")
+                Label::primary(cm.file_id, cm.checksum.span).with_message("checksum"),
             ]);
 
         Diag {
@@ -672,7 +673,7 @@ impl From<ChecksumMismatch<'_>> for Diag {
             .with_notes(notes)
             .with_code(Code::ChecksumMismatch)
             .with_labels(vec![
-                Label::primary(cm.file_id, cm.checksum.span).with_message("expected checksum")
+                Label::primary(cm.file_id, cm.checksum.span).with_message("expected checksum"),
             ]);
 
         Diag {
@@ -824,11 +825,10 @@ impl<'a> From<UnmatchedBypass<'a>> for Diag {
         Diagnostic::new(Severity::Warning)
             .with_message("crate build bypass was not encountered")
             .with_code(Code::UnmatchedBypass)
-            .with_labels(vec![Label::primary(
-                ubc.file_id,
-                ubc.unmatched.spec.name.span,
-            )
-            .with_message("unmatched bypass")])
+            .with_labels(vec![
+                Label::primary(ubc.file_id, ubc.unmatched.spec.name.span)
+                    .with_message("unmatched bypass"),
+            ])
             .into()
     }
 }

--- a/src/bans/graph.rs
+++ b/src/bans/graph.rs
@@ -5,7 +5,7 @@ use krates::petgraph as pg;
 use semver::Version;
 use std::{
     borrow::Cow,
-    collections::{btree_map::Entry, BTreeMap, HashSet},
+    collections::{BTreeMap, HashSet, btree_map::Entry},
     fmt,
 };
 

--- a/src/cargo-deny/check.rs
+++ b/src/cargo-deny/check.rs
@@ -3,9 +3,9 @@ use crate::{
     stats::{AllStats, Stats},
 };
 use cargo_deny::{
-    advisories, bans,
+    CheckCtx, PathBuf, advisories, bans,
     diag::{DiagnosticCode, DiagnosticOverrides, ErrorSink, Files, Severity},
-    licenses, sources, CheckCtx, PathBuf,
+    licenses, sources,
 };
 use log::error;
 use std::time::Instant;
@@ -187,7 +187,9 @@ pub(crate) fn cmd(
                     match cl {
                         CodeOrLevel::Code(code) => {
                             if let Some(current) = code_overrides.get(code.as_str()) {
-                                anyhow::bail!("unable to override code '{code}' to '{severity:?}', it has already been overridden to '{current:?}'");
+                                anyhow::bail!(
+                                    "unable to override code '{code}' to '{severity:?}', it has already been overridden to '{current:?}'"
+                                );
                             }
 
                             code_overrides.insert(code.as_str(), severity);
@@ -196,14 +198,12 @@ pub(crate) fn cmd(
                             let ls = level.into();
                             if let Some(current) =
                                 level_overrides.iter().find_map(|(input, output)| {
-                                    if ls == *input {
-                                        Some(*output)
-                                    } else {
-                                        None
-                                    }
+                                    if ls == *input { Some(*output) } else { None }
                                 })
                             {
-                                anyhow::bail!("unable to override level '{level:?}' to '{severity:?}', it has already been overridden to '{current:?}'");
+                                anyhow::bail!(
+                                    "unable to override level '{level:?}' to '{severity:?}', it has already been overridden to '{current:?}'"
+                                );
                             }
 
                             level_overrides.push((ls, severity));

--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -1,7 +1,7 @@
 use cargo_deny::{
+    PathBuf,
     diag::{self, FileId, Files, Severity},
     licenses::LicenseStore,
-    PathBuf,
 };
 
 mod cfg;
@@ -186,7 +186,9 @@ impl KrateContext {
         // what this can look like in practice if we don't have the index metadata
         // to supplement/fix the cargo metadata
         if let Err(err) = cargo_deny::krates_with_index(&mut gb, None, None) {
-            log::error!("failed to open the local crates.io index, feature sets for crates may not be correct: {err}");
+            log::error!(
+                "failed to open the local crates.io index, feature sets for crates may not be correct: {err}"
+            );
         }
 
         let graph = gb.build_with_metadata(metadata, |filtered: krates::cm::Package| {

--- a/src/cargo-deny/common/cfg.rs
+++ b/src/cargo-deny/common/cfg.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context as _, Result};
 use cargo_deny::{
+    PathBuf,
     diag::{Diagnostic, Files, Severity},
     root_cfg::{GraphConfig, OutputConfig},
-    PathBuf, {advisories, bans, licenses, sources},
+    {advisories, bans, licenses, sources},
 };
 
 pub struct ValidConfig {

--- a/src/cargo-deny/fetch.rs
+++ b/src/cargo-deny/fetch.rs
@@ -1,6 +1,6 @@
 use crate::common::ValidConfig;
 use anyhow::{Context as _, Error};
-use cargo_deny::{advisories, diag::Files, PathBuf};
+use cargo_deny::{PathBuf, advisories, diag::Files};
 
 #[derive(clap::ValueEnum, Debug, PartialEq, Eq, Copy, Clone)]
 pub enum FetchSource {

--- a/src/cargo-deny/init.rs
+++ b/src/cargo-deny/init.rs
@@ -1,5 +1,5 @@
 use crate::PathBuf;
-use anyhow::{ensure, Context, Error};
+use anyhow::{Context, Error, ensure};
 
 #[derive(clap::Parser, Debug, Clone)]
 pub struct Args {

--- a/src/cargo-deny/list.rs
+++ b/src/cargo-deny/list.rs
@@ -1,6 +1,6 @@
 use crate::common::ValidConfig;
 use anyhow::{Context as _, Error};
-use cargo_deny::{diag::Files, licenses, Kid, PathBuf};
+use cargo_deny::{Kid, PathBuf, diag::Files, licenses};
 use nu_ansi_term::Color;
 use serde::Serialize;
 

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -235,13 +235,9 @@ fn setup_logger(
 fn real_main() -> Result<(), Error> {
     let args =
         Opts::parse_from({
-            std::env::args().enumerate().filter_map(|(i, a)| {
-                if i == 1 && a == "deny" {
-                    None
-                } else {
-                    Some(a)
-                }
-            })
+            std::env::args()
+                .enumerate()
+                .filter_map(|(i, a)| if i == 1 && a == "deny" { None } else { Some(a) })
         });
 
     let log_level = args.log_level;
@@ -331,7 +327,9 @@ fn real_main() -> Result<(), Error> {
             let show_stats = cargs.show_stats;
 
             if args.ctx.offline {
-                log::info!("network access disabled via --offline flag, disabling advisory database fetching");
+                log::info!(
+                    "network access disabled via --offline flag, disabling advisory database fetching"
+                );
                 cargs.disable_fetch = true;
             }
 

--- a/src/cargo-deny/main.rs
+++ b/src/cargo-deny/main.rs
@@ -233,12 +233,11 @@ fn setup_logger(
 }
 
 fn real_main() -> Result<(), Error> {
-    let args =
-        Opts::parse_from({
-            std::env::args()
-                .enumerate()
-                .filter_map(|(i, a)| if i == 1 && a == "deny" { None } else { Some(a) })
-        });
+    let args = Opts::parse_from({
+        std::env::args()
+            .enumerate()
+            .filter_map(|(i, a)| if i == 1 && a == "deny" { None } else { Some(a) })
+    });
 
     let log_level = args.log_level;
 

--- a/src/cargo-deny/stats.rs
+++ b/src/cargo-deny/stats.rs
@@ -197,7 +197,7 @@ fn write_full_stats(summary: &mut String, stats: &AllStats, color: bool) {
 
 #[cfg(test)]
 mod test {
-    use super::{stats_to_exit_code as ec, AllStats, Stats};
+    use super::{AllStats, Stats, stats_to_exit_code as ec};
 
     #[test]
     fn exit_code() {

--- a/src/cfg/package_spec.rs
+++ b/src/cfg/package_spec.rs
@@ -1,10 +1,10 @@
-use crate::{cfg::Span, Spanned};
+use crate::{Spanned, cfg::Span};
 use semver::VersionReq;
 use std::fmt;
 use toml_span::{
-    de_helpers::{expected, TableHelper},
-    value::{Value, ValueInner},
     DeserError, Deserialize,
+    de_helpers::{TableHelper, expected},
+    value::{Value, ValueInner},
 };
 
 /// A package identifier, consisting of a package name and a version requirement
@@ -178,7 +178,9 @@ impl Ord for PackageSpec {
                                             semver::Op::Caret => Self::Caret,
                                             semver::Op::Wildcard => Self::Wildcard,
                                             // I fucking despise non_exhaustive
-                                            _ => panic!("semver has added a new Op, but non_exhaustive means we can't detect that at compile time, so please open an issue so that the additional match arm can be added"),
+                                            _ => panic!(
+                                                "semver has added a new Op, but non_exhaustive means we can't detect that at compile time, so please open an issue so that the additional match arm can be added"
+                                            ),
                                         }
                                     }
                                 }

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -3,7 +3,7 @@ mod grapher;
 pub mod krate_spans;
 mod sink;
 
-pub use grapher::{cs_diag_to_json, diag_to_json, write_graph_as_text, InclusionGrapher};
+pub use grapher::{InclusionGrapher, cs_diag_to_json, diag_to_json, write_graph_as_text};
 pub use sink::{DiagnosticOverrides, ErrorSink};
 
 use std::{collections::BTreeMap, ops::Range};

--- a/src/diag/general.rs
+++ b/src/diag/general.rs
@@ -1,8 +1,8 @@
 //! Contains general diagnostics that are shared between various checks
 
 use crate::{
-    diag::{Diagnostic, FileId, Label, Severity},
     Span,
+    diag::{Diagnostic, FileId, Label, Severity},
 };
 use std::fmt;
 

--- a/src/diag/grapher.rs
+++ b/src/diag/grapher.rs
@@ -1,7 +1,7 @@
 use super::NodePrint;
 use crate::{DepKind, Krates};
 use anyhow::Context;
-use krates::{petgraph as pg, Edge, Node};
+use krates::{Edge, Node, petgraph as pg};
 use std::collections::HashSet;
 
 #[derive(serde::Serialize)]

--- a/src/diag/krate_spans.rs
+++ b/src/diag/krate_spans.rs
@@ -214,7 +214,9 @@ impl<'k> Manifest<'k> {
                     err
                 }).ok().map(|vr| toml_span::Spanned::with_span(vr, dep_value.span)), None)
             } else {
-                log::error!("dependency {krate} -> {dep_krate} is not a string nor table, this should be invalid...");
+                log::error!(
+                    "dependency {krate} -> {dep_krate} is not a string nor table, this should be invalid..."
+                );
                 (None, None, None)
             };
 
@@ -867,7 +869,10 @@ fn read_workspace_deps<'k>(
                         .rename
                         .as_ref()
                         .map_or(&ws_dep.krate.name, |r| r.as_ref());
-                    log::error!("[workspace.dependencies.{name}] was resolved to {}...which wasn't in the list of available crates. This should be impossible", ws_dep.krate.id);
+                    log::error!(
+                        "[workspace.dependencies.{name}] was resolved to {}...which wasn't in the list of available crates. This should be impossible",
+                        ws_dep.krate.id
+                    );
                 }
             }
             WsDep::Unresolved(unresolved) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use cfg::UnvalidatedConfig;
 use krates::cm;
 pub use krates::{DepKind, Kid};
 pub use toml_span::{
-    span::{Span, Spanned},
     Deserialize, Error,
+    span::{Span, Spanned},
 };
 
 /// The possible lint levels for the various lints. These function similarly
@@ -668,12 +668,14 @@ mod test {
                 && crates_io_sparse_but_git.is_crates_io()
         );
 
-        assert!(Source::from_metadata(
-            "registry+https://my-own-my-precious.com/".to_owned(),
-            empty_dir
-        )
-        .unwrap()
-        .is_registry());
+        assert!(
+            Source::from_metadata(
+                "registry+https://my-own-my-precious.com/".to_owned(),
+                empty_dir
+            )
+            .unwrap()
+            .is_registry()
+        );
         assert!(
             Source::from_metadata("sparse+https://my-registry.rs/".to_owned(), empty_dir)
                 .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,30 @@ pub enum Source {
 
 /// The directory name under which crates sourced from the crates.io sparse
 /// registry are placed
-#[cfg(target_endian = "little")]
-const CRATES_IO_SPARSE_DIR: &str = "index.crates.io-6f17d22bba15001f";
-#[cfg(target_endian = "big")]
-const CRATES_IO_SPARSE_DIR: &str = "index.crates.io-d11c229612889eed";
+fn crates_io_sparse_dir() -> &'static str {
+    static mut CRATES_IO_SPARSE_DIR: String = String::new();
+    static CRATES_IO_INIT: parking_lot::Once = parking_lot::Once::new();
+
+    #[allow(unsafe_code)]
+    // SAFETY: We're mutating a static, but we only allow one mutation
+    unsafe {
+        CRATES_IO_INIT.call_once(|| {
+            let Ok(version) = tame_index::utils::cargo_version(None) else {
+                return;
+            };
+            let Ok(url_dir) = tame_index::utils::url_to_local_dir(
+                tame_index::CRATES_IO_HTTP_INDEX,
+                version >= semver::Version::new(1, 85, 0),
+            ) else {
+                return;
+            };
+            CRATES_IO_SPARSE_DIR = url_dir.dir_name;
+        });
+
+        #[allow(static_mut_refs)]
+        &CRATES_IO_SPARSE_DIR
+    }
+}
 
 impl Source {
     pub fn crates_io(is_sparse: bool) -> Self {
@@ -137,7 +157,7 @@ impl Source {
                     // registry/src/index.crates.io-6f17d22bba15001f/crate-version/Cargo.toml
                     let is_sparse = manifest_path.ancestors().nth(2).is_some_and(|dir| {
                         dir.file_name()
-                            .is_some_and(|dir_name| dir_name == CRATES_IO_SPARSE_DIR)
+                            .is_some_and(|dir_name| dir_name == crates_io_sparse_dir())
                     });
                     Ok(Self::crates_io(is_sparse))
                 } else {
@@ -632,7 +652,7 @@ mod test {
             format!("registry+{}", tame_index::CRATES_IO_INDEX),
             super::Path::new(&format!(
                 "registry/src/{}/cargo-deny-0.69.0/Cargo.toml",
-                super::CRATES_IO_SPARSE_DIR
+                super::crates_io_sparse_dir(),
             )),
         )
         .unwrap();
@@ -676,7 +696,7 @@ mod test {
             tame_index::utils::url_to_local_dir(tame_index::CRATES_IO_HTTP_INDEX, stable)
                 .unwrap()
                 .dir_name,
-            super::CRATES_IO_SPARSE_DIR
+            super::crates_io_sparse_dir(),
         );
     }
 

--- a/src/licenses/cfg.rs
+++ b/src/licenses/cfg.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(docsrs, doc(include = "../../docs/licenses/cfg.md"))]
 
 use crate::{
-    cfg::{deprecated, PackageSpec, ValidationContext},
-    diag::{Diagnostic, FileId, Label},
     LintLevel, PathBuf, Span, Spanned,
+    cfg::{PackageSpec, ValidationContext, deprecated},
+    diag::{Diagnostic, FileId, Label},
 };
-use toml_span::{de_helpers::TableHelper, value::Value, DeserError, Deserialize};
+use toml_span::{DeserError, Deserialize, de_helpers::TableHelper, value::Value};
 
 const DEFAULT_CONFIDENCE_THRESHOLD: f32 = 0.8;
 
@@ -296,7 +296,7 @@ impl crate::cfg::UnvalidatedConfig for Config {
                         Diagnostic::error()
                             .with_message("failed to parse url")
                             .with_labels(vec![
-                                Label::primary(ctx.cfg_id, aurl.span).with_message(pe.to_string())
+                                Label::primary(ctx.cfg_id, aurl.span).with_message(pe.to_string()),
                             ]),
                     );
                 }
@@ -324,8 +324,10 @@ impl crate::cfg::UnvalidatedConfig for Config {
                     ctx.push(
                         Diagnostic::error()
                             .with_message("unable to parse license expression")
-                            .with_labels(vec![Label::primary(ctx.cfg_id, expr_span)
-                                .with_message(err.reason.to_string())]),
+                            .with_labels(vec![
+                                Label::primary(ctx.cfg_id, expr_span)
+                                    .with_message(err.reason.to_string()),
+                            ]),
                     );
 
                     continue;
@@ -469,7 +471,7 @@ pub struct ValidConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_utils::{write_diagnostics, ConfigData};
+    use crate::test_utils::{ConfigData, write_diagnostics};
 
     struct Licenses {
         licenses: Config,

--- a/src/licenses/diags.rs
+++ b/src/licenses/diags.rs
@@ -1,6 +1,6 @@
 use crate::{
-    diag::{CfgCoord, Diag, Diagnostic, Label, Severity},
     Krate,
+    diag::{CfgCoord, Diag, Diagnostic, Label, Severity},
 };
 
 #[derive(
@@ -70,10 +70,11 @@ impl From<UnmatchedLicenseAllowance> for Diag {
         Diagnostic::new(ula.severity)
             .with_message("license was not encountered")
             .with_code(Code::LicenseNotEncountered)
-            .with_labels(vec![ula
-                .allowed_license_cfg
-                .into_label()
-                .with_message("unmatched license allowance")])
+            .with_labels(vec![
+                ula.allowed_license_cfg
+                    .into_label()
+                    .with_message("unmatched license allowance"),
+            ])
             .into()
     }
 }
@@ -87,10 +88,11 @@ impl From<UnmatchedLicenseException> for Diag {
         Diagnostic::new(Severity::Warning)
             .with_message("license exception was not encountered")
             .with_code(Code::LicenseExceptionNotEncountered)
-            .with_labels(vec![ule
-                .license_exc_cfg
-                .into_label()
-                .with_message("unmatched license exception")])
+            .with_labels(vec![
+                ule.license_exc_cfg
+                    .into_label()
+                    .with_message("unmatched license exception"),
+            ])
             .into()
     }
 }

--- a/src/licenses/gather.rs
+++ b/src/licenses/gather.rs
@@ -1,7 +1,7 @@
 use super::cfg::{FileSource, ValidClarification, ValidConfig};
 use crate::{
-    diag::{FileId, Files, Label},
     Krate, Path, PathBuf,
+    diag::{FileId, Files, Label},
 };
 use rayon::prelude::*;
 use smallvec::SmallVec;
@@ -64,7 +64,7 @@ fn get_file_source(root: &Path, path: PathBuf) -> PackFile {
                 return PackFile {
                     path,
                     data: PackFileData::Bad(e),
-                }
+                };
             }
         };
 
@@ -145,7 +145,7 @@ impl LicensePack {
                     license_files: Vec::new(),
                     root: root.to_owned(),
                     err: Some(e),
-                }
+                };
             }
         };
 
@@ -214,8 +214,10 @@ impl LicensePack {
             let len = synth_toml.len();
             return Err((
                 synth_toml,
-                vec![Label::secondary(file, 17..len - 1)
-                    .with_message("unable to gather license files")],
+                vec![
+                    Label::secondary(file, 17..len - 1)
+                        .with_message("unable to gather license files"),
+                ],
             ));
         }
 
@@ -308,7 +310,9 @@ impl LicensePack {
                             }
                         }
                         Err(err) => {
-                            panic!("askalono's elimination strategy failed (this used to be impossible): {err}");
+                            panic!(
+                                "askalono's elimination strategy failed (this used to be impossible): {err}"
+                            );
                         }
                     }
                 }

--- a/src/root_cfg.rs
+++ b/src/root_cfg.rs
@@ -1,11 +1,11 @@
 use crate::{
-    advisories::cfg::Config as AdvisoriesConfig, bans::cfg::Config as BansConfig,
-    licenses::cfg::Config as LicensesConfig, sources::cfg::Config as SourcesConfig, Spanned,
+    Spanned, advisories::cfg::Config as AdvisoriesConfig, bans::cfg::Config as BansConfig,
+    licenses::cfg::Config as LicensesConfig, sources::cfg::Config as SourcesConfig,
 };
 use toml_span::{
+    DeserError, Deserialize,
     de_helpers::TableHelper,
     value::{Value, ValueInner},
-    DeserError, Deserialize,
 };
 
 pub struct Target {
@@ -28,7 +28,7 @@ impl<'de> Deserialize<'de> for Target {
             other => {
                 return Err(
                     toml_span::de_helpers::expected("a string or table", other, value.span).into(),
-                )
+                );
             }
         };
 

--- a/src/root_cfg.rs
+++ b/src/root_cfg.rs
@@ -26,9 +26,12 @@ impl<'de> Deserialize<'de> for Target {
                 (triple, features)
             }
             other => {
-                return Err(
-                    toml_span::de_helpers::expected("a string or table", other, value.span).into(),
-                );
+                return Err(toml_span::de_helpers::expected(
+                    "a string or table",
+                    other,
+                    value.span,
+                )
+                .into());
             }
         };
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -4,8 +4,8 @@ use cfg::ValidConfig;
 pub use diags::Code;
 
 use crate::{
-    diag::{CfgCoord, Check, ErrorSink, Label, Pack},
     LintLevel,
+    diag::{CfgCoord, Check, ErrorSink, Label, Pack},
 };
 
 const CRATES_IO_URL: &str = "https://github.com/rust-lang/crates.io-index";

--- a/src/sources/cfg.rs
+++ b/src/sources/cfg.rs
@@ -1,10 +1,10 @@
 use super::OrgType;
 use crate::{
+    LintLevel, Spanned,
     cfg::{self, ValidationContext},
     diag::FileId,
-    LintLevel, Spanned,
 };
-use toml_span::{de_helpers::TableHelper, value::Value, DeserError, Deserialize};
+use toml_span::{DeserError, Deserialize, de_helpers::TableHelper, value::Value};
 
 #[derive(Default)]
 pub struct Orgs {
@@ -180,7 +180,7 @@ impl cfg::UnvalidatedConfig for Config {
                         Diagnostic::error()
                             .with_message("failed to parse url")
                             .with_labels(vec![
-                                Label::primary(ctx.cfg_id, aurl.span).with_message(pe.to_string())
+                                Label::primary(ctx.cfg_id, aurl.span).with_message(pe.to_string()),
                             ]),
                     );
                 }
@@ -240,7 +240,7 @@ pub struct ValidConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_utils::{write_diagnostics, ConfigData};
+    use crate::test_utils::{ConfigData, write_diagnostics};
 
     #[test]
     fn deserializes_sources_cfg() {

--- a/src/sources/diags.rs
+++ b/src/sources/diags.rs
@@ -1,6 +1,6 @@
 use crate::{
-    diag::{CfgCoord, Diag, Diagnostic, Label, Severity},
     LintLevel,
+    diag::{CfgCoord, Diag, Diagnostic, Label, Severity},
 };
 
 #[derive(
@@ -122,10 +122,11 @@ impl From<UnmatchedAllowSource> for Diag {
         Diagnostic::new(Severity::Warning)
             .with_message("allowed source was not encountered")
             .with_code(Code::UnmatchedSource)
-            .with_labels(vec![uas
-                .allow_src_cfg
-                .into_label()
-                .with_message("no crate source matched these criteria")])
+            .with_labels(vec![
+                uas.allow_src_cfg
+                    .into_label()
+                    .with_message("no crate source matched these criteria"),
+            ])
             .into()
     }
 }
@@ -143,10 +144,11 @@ impl From<UnmatchedAllowOrg> for Diag {
                 uao.org_type
             ))
             .with_code(Code::UnmatchedOrganization)
-            .with_labels(vec![uao
-                .allow_org_cfg
-                .into_label()
-                .with_message("no crate source fell under this organization")])
+            .with_labels(vec![
+                uao.allow_org_cfg
+                    .into_label()
+                    .with_message("no crate source fell under this organization"),
+            ])
             .into()
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::{
+    CheckCtx, PathBuf,
     cfg::ValidationContext,
     diag::{self, ErrorSink, FileId, Files, KrateSpans, PackChannel},
-    CheckCtx, PathBuf,
 };
 
 #[derive(Default, Clone)]

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -375,9 +375,9 @@ fn fails_on_stale_advisory_database() {
 use advisories::Fetch;
 
 const TEST_DB_URL: &str = "https://github.com/EmbarkStudios/test-advisory-db";
-const TEST_DB_PATH: &str = "tests/advisory-db/github.com-c046ebb82572a8ef";
-const GIT_PATH: &str = "github.com-c046ebb82572a8ef/.git";
-const GIT_SUB_PATH: &str = ".git/modules/tests/advisory-db/github.com-c046ebb82572a8ef";
+const TEST_DB_PATH: &str = "tests/advisory-db/test-advisory-db-c27873b782cceedc";
+const GIT_PATH: &str = "test-advisory-db-c27873b782cceedc/.git";
+const GIT_SUB_PATH: &str = ".git/modules/tests/advisory-db/test-advisory-db-c27873b782cceedc";
 
 /// Expected HEAD without fetch
 const EXPECTED_ONE: &str = "1f44d565d81692a44b8c7af8a80f587e19757f8c";

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -1,8 +1,8 @@
 use cargo_deny::{
+    Krates,
     advisories::{self, cfg},
     field_eq, func_name,
     test_utils::{self as tu},
-    Krates,
 };
 
 struct TestCtx {
@@ -343,10 +343,12 @@ fn warns_on_ignored_and_withdrawn() {
             );
         });
 
-    insta::assert_json_snapshot!(diags
-        .iter()
-        .find(|diag| field_eq!(diag, "/fields/code", "advisory-not-detected"))
-        .unwrap());
+    insta::assert_json_snapshot!(
+        diags
+            .iter()
+            .find(|diag| field_eq!(diag, "/fields/code", "advisory-not-detected"))
+            .unwrap()
+    );
 }
 
 #[inline]
@@ -362,14 +364,16 @@ fn to_path(td: &tempfile::TempDir) -> Option<&cargo_deny::Path> {
 /// Validates that stale advisory databases result in an error
 #[test]
 fn fails_on_stale_advisory_database() {
-    assert!(advisories::DbSet::load(
-        "tests/advisory-db".into(),
-        vec![],
-        advisories::Fetch::Disallow(time::Duration::seconds(0)),
-    )
-    .unwrap_err()
-    .to_string()
-    .contains("repository is stale"));
+    assert!(
+        advisories::DbSet::load(
+            "tests/advisory-db".into(),
+            vec![],
+            advisories::Fetch::Disallow(time::Duration::seconds(0)),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("repository is stale")
+    );
 }
 
 use advisories::Fetch;

--- a/tests/licenses.rs
+++ b/tests/licenses.rs
@@ -1,7 +1,7 @@
 use cargo_deny::{
-    diag, field_eq, func_name,
+    Krates, diag, field_eq, func_name,
     licenses::{self, cfg::Config},
-    test_utils as tu, Krates,
+    test_utils as tu,
 };
 use std::sync::{Arc, OnceLock};
 

--- a/tests/snapshots/bans_build__allows_build_scripts_or_bypass.snap
+++ b/tests/snapshots/bans_build__allows_build_scripts_or_bypass.snap
@@ -96,7 +96,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/build.rs'"
       ],
       "severity": "help"
     },

--- a/tests/snapshots/bans_build__allows_by_glob.snap
+++ b/tests/snapshots/bans_build__allows_by_glob.snap
@@ -32,7 +32,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-armv4.pl'"
       ],
       "severity": "help"
     },
@@ -67,7 +67,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-armv8.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-armv8.pl'"
       ],
       "severity": "help"
     },
@@ -102,7 +102,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-x86.pl'"
       ],
       "severity": "help"
     },
@@ -137,7 +137,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-x86_64.pl'"
       ],
       "severity": "help"
     },
@@ -172,7 +172,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl'"
       ],
       "severity": "help"
     },
@@ -207,7 +207,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86.pl'"
       ],
       "severity": "help"
     },
@@ -242,7 +242,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86_64.pl'"
       ],
       "severity": "help"
     },
@@ -277,7 +277,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesv8-armx.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesv8-armx.pl'"
       ],
       "severity": "help"
     },
@@ -312,7 +312,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/bsaes-armv7.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/bsaes-armv7.pl'"
       ],
       "severity": "help"
     },
@@ -347,7 +347,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86.pl'"
       ],
       "severity": "help"
     },
@@ -382,7 +382,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl'"
       ],
       "severity": "help"
     },
@@ -417,7 +417,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv4-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv4-mont.pl'"
       ],
       "severity": "help"
     },
@@ -452,7 +452,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv8-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv8-mont.pl'"
       ],
       "severity": "help"
     },
@@ -487,7 +487,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86-mont.pl'"
       ],
       "severity": "help"
     },
@@ -522,7 +522,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont.pl'"
       ],
       "severity": "help"
     },
@@ -557,7 +557,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont5.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont5.pl'"
       ],
       "severity": "help"
     },
@@ -592,7 +592,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv4.pl'"
       ],
       "severity": "help"
     },
@@ -627,7 +627,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv8.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv8.pl'"
       ],
       "severity": "help"
     },
@@ -662,7 +662,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-x86.pl'"
       ],
       "severity": "help"
     },
@@ -697,7 +697,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl'"
       ],
       "severity": "help"
     },
@@ -732,7 +732,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl'"
       ],
       "severity": "help"
     },
@@ -767,7 +767,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-armv4.pl'"
       ],
       "severity": "help"
     },
@@ -802,7 +802,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86.pl'"
       ],
       "severity": "help"
     },
@@ -837,7 +837,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86_64.pl'"
       ],
       "severity": "help"
     },
@@ -872,7 +872,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghashv8-armx.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghashv8-armx.pl'"
       ],
       "severity": "help"
     },
@@ -907,7 +907,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha256-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha256-armv4.pl'"
       ],
       "severity": "help"
     },
@@ -942,7 +942,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv4.pl'"
       ],
       "severity": "help"
     },
@@ -977,7 +977,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv8.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv8.pl'"
       ],
       "severity": "help"
     },
@@ -1012,7 +1012,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-x86_64.pl'"
       ],
       "severity": "help"
     },
@@ -1047,7 +1047,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/arm-xlate.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/arm-xlate.pl'"
       ],
       "severity": "help"
     },
@@ -1082,7 +1082,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86_64-xlate.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86_64-xlate.pl'"
       ],
       "severity": "help"
     },
@@ -1117,7 +1117,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86asm.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86asm.pl'"
       ],
       "severity": "help"
     },
@@ -1152,7 +1152,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86gas.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86gas.pl'"
       ],
       "severity": "help"
     },
@@ -1187,7 +1187,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86nasm.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86nasm.pl'"
       ],
       "severity": "help"
     },
@@ -1222,7 +1222,7 @@ expression: diags
       ],
       "message": "file allowed by glob",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/src/rsa/convert_nist_rsa_test_vectors.py'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/src/rsa/convert_nist_rsa_test_vectors.py'"
       ],
       "severity": "help"
     },

--- a/tests/snapshots/bans_build__allows_by_path.snap
+++ b/tests/snapshots/bans_build__allows_by_path.snap
@@ -32,7 +32,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-linux-aarch_64'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-linux-aarch_64'"
       ],
       "severity": "help"
     },
@@ -67,7 +67,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-linux-x86_64'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-linux-x86_64'"
       ],
       "severity": "help"
     },
@@ -102,7 +102,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-osx-aarch64'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-osx-aarch64'"
       ],
       "severity": "help"
     },
@@ -137,7 +137,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-osx-x86_64'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-osx-x86_64'"
       ],
       "severity": "help"
     },
@@ -172,7 +172,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-win32.exe'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-win32.exe'"
       ],
       "severity": "help"
     },

--- a/tests/snapshots/bans_build__detects_build_script_mismatch.snap
+++ b/tests/snapshots/bans_build__detects_build_script_mismatch.snap
@@ -32,7 +32,7 @@ expression: diags
       ],
       "message": "file did not match the expected checksum",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/build.rs'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/build.rs'",
         "error = build script failed checksum: checksum mismatch, calculated 474a3eb189a698475d8a6f4b358eb0790db6379aea8b8a85ac925102784cd520"
       ],
       "severity": "warning"

--- a/tests/snapshots/bans_build__detects_native_executables.snap
+++ b/tests/snapshots/bans_build__detects_native_executables.snap
@@ -24,7 +24,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-linux-aarch_64'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-linux-aarch_64'",
         "executable-kind = 'elf'"
       ],
       "severity": "error"
@@ -52,7 +52,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-linux-x86_32'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-linux-x86_32'",
         "executable-kind = 'elf'"
       ],
       "severity": "error"
@@ -80,7 +80,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-linux-x86_64'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-linux-x86_64'",
         "executable-kind = 'elf'"
       ],
       "severity": "error"
@@ -108,7 +108,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-osx-aarch64'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-osx-aarch64'",
         "executable-kind = 'mach'"
       ],
       "severity": "error"
@@ -136,7 +136,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-osx-x86_64'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-osx-x86_64'",
         "executable-kind = 'mach'"
       ],
       "severity": "error"
@@ -164,7 +164,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.9.0/third-party/protobuf/protoc-win32.exe'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/prost-build-0.9.0/third-party/protobuf/protoc-win32.exe'",
         "executable-kind = 'pe'"
       ],
       "severity": "error"
@@ -200,7 +200,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/serde_derive-1.0.172/serde_derive-x86_64-unknown-linux-gnu'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/serde_derive-1.0.172/serde_derive-x86_64-unknown-linux-gnu'",
         "executable-kind = 'elf'"
       ],
       "severity": "error"

--- a/tests/snapshots/bans_build__detects_scripts_by_builtin_glob.snap
+++ b/tests/snapshots/bans_build__detects_scripts_by_builtin_glob.snap
@@ -32,7 +32,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-armv4.pl'"
       ],
       "severity": "error"
     },
@@ -67,7 +67,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-armv8.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-armv8.pl'"
       ],
       "severity": "error"
     },
@@ -102,7 +102,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-x86.pl'"
       ],
       "severity": "error"
     },
@@ -137,7 +137,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/chacha/asm/chacha-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/chacha/asm/chacha-x86_64.pl'"
       ],
       "severity": "error"
     },
@@ -172,7 +172,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl'"
       ],
       "severity": "error"
     },
@@ -207,7 +207,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86.pl'"
       ],
       "severity": "error"
     },
@@ -242,7 +242,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesni-x86_64.pl'"
       ],
       "severity": "error"
     },
@@ -277,7 +277,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesv8-armx.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/aesv8-armx.pl'"
       ],
       "severity": "error"
     },
@@ -312,7 +312,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/bsaes-armv7.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/bsaes-armv7.pl'"
       ],
       "severity": "error"
     },
@@ -347,7 +347,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86.pl'"
       ],
       "severity": "error"
     },
@@ -382,7 +382,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl'"
       ],
       "severity": "error"
     },
@@ -417,7 +417,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv4-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv4-mont.pl'"
       ],
       "severity": "error"
     },
@@ -452,7 +452,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv8-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/armv8-mont.pl'"
       ],
       "severity": "error"
     },
@@ -487,7 +487,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86-mont.pl'"
       ],
       "severity": "error"
     },
@@ -522,7 +522,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont.pl'"
       ],
       "severity": "error"
     },
@@ -557,7 +557,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont5.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/bn/asm/x86_64-mont5.pl'"
       ],
       "severity": "error"
     },
@@ -592,7 +592,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv4.pl'"
       ],
       "severity": "error"
     },
@@ -627,7 +627,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv8.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-armv8.pl'"
       ],
       "severity": "error"
     },
@@ -662,7 +662,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/ecp_nistz256-x86.pl'"
       ],
       "severity": "error"
     },
@@ -697,7 +697,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl'"
       ],
       "severity": "error"
     },
@@ -732,7 +732,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl'"
       ],
       "severity": "error"
     },
@@ -767,7 +767,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-armv4.pl'"
       ],
       "severity": "error"
     },
@@ -802,7 +802,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86.pl'"
       ],
       "severity": "error"
     },
@@ -837,7 +837,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghash-x86_64.pl'"
       ],
       "severity": "error"
     },
@@ -872,7 +872,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghashv8-armx.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/modes/asm/ghashv8-armx.pl'"
       ],
       "severity": "error"
     },
@@ -907,7 +907,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha256-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha256-armv4.pl'"
       ],
       "severity": "error"
     },
@@ -942,7 +942,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv4.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv4.pl'"
       ],
       "severity": "error"
     },
@@ -977,7 +977,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv8.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-armv8.pl'"
       ],
       "severity": "error"
     },
@@ -1012,7 +1012,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-x86_64.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/fipsmodule/sha/asm/sha512-x86_64.pl'"
       ],
       "severity": "error"
     },
@@ -1047,7 +1047,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/arm-xlate.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/arm-xlate.pl'"
       ],
       "severity": "error"
     },
@@ -1082,7 +1082,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86_64-xlate.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86_64-xlate.pl'"
       ],
       "severity": "error"
     },
@@ -1117,7 +1117,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86asm.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86asm.pl'"
       ],
       "severity": "error"
     },
@@ -1152,7 +1152,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86gas.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86gas.pl'"
       ],
       "severity": "error"
     },
@@ -1187,7 +1187,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/perlasm/x86nasm.pl'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/crypto/perlasm/x86nasm.pl'"
       ],
       "severity": "error"
     },
@@ -1222,7 +1222,7 @@ expression: diags
       ],
       "message": "path disallowed by extension",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/src/rsa/convert_nist_rsa_test_vectors.py'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/src/rsa/convert_nist_rsa_test_vectors.py'"
       ],
       "severity": "error"
     },

--- a/tests/snapshots/bans_build__detects_scripts_by_shebang.snap
+++ b/tests/snapshots/bans_build__detects_scripts_by_shebang.snap
@@ -24,7 +24,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/applypatch-msg.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/applypatch-msg.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -52,7 +52,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/commit-msg.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/commit-msg.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -80,7 +80,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/fsmonitor-watchman.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/fsmonitor-watchman.sample'",
         "interpreter = 'perl'"
       ],
       "severity": "error"
@@ -108,7 +108,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/post-update.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/post-update.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -136,7 +136,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-applypatch.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-applypatch.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -164,7 +164,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-commit.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-commit.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -192,7 +192,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-push.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-push.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -220,7 +220,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-rebase.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-rebase.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -248,7 +248,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-receive.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/pre-receive.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -276,7 +276,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/prepare-commit-msg.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/prepare-commit-msg.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"
@@ -304,7 +304,7 @@ expression: diags
       ],
       "message": "detected executable",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/c-library/.git/hooks/update.sample'",
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/c-library/.git/hooks/update.sample'",
         "interpreter = 'sh'"
       ],
       "severity": "error"

--- a/tests/snapshots/bans_build__skips_matching_build_scripts.snap
+++ b/tests/snapshots/bans_build__skips_matching_build_scripts.snap
@@ -32,7 +32,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ittapi-sys-0.3.3/build.rs'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ittapi-sys-0.3.3/build.rs'"
       ],
       "severity": "help"
     },
@@ -67,7 +67,7 @@ expression: diags
       ],
       "message": "file checksum matched",
       "notes": [
-        "path = '$CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs'"
+        "path = '$CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.16.20/build.rs'"
       ],
       "severity": "help"
     },


### PR DESCRIPTION
This fixes an issue where crate sources were not being correctly determined as crates.io when using cargo 1.85.0 due to the change in how directory names are calculated, which would cause eg. workspace dependency checks to fail.

The advisory databases no longer use tame_index to perform the directory naming as it doesn't really make sense in the first place, so now it just uses a similar method, but using xxhash instead which gives the same properties as the cargo 1.85.0 change, namely that the hash is the same for the same url regardless of the host platform (endianness/pointer width/arch). It also now uses the last path component as the start of the name which is a much nicer way to name the directory.

This also updates to the rust-version to 1.85.0 and moves to edition 2024.