### PR TITLE
feat: cargo metadata path

### DIFF
--- a/src/cargo-deny/common.rs
+++ b/src/cargo-deny/common.rs
@@ -109,6 +109,7 @@ impl KrateContext {
 
     pub fn gather_krates(
         self,
+        metadata: Option<krates::cm::Metadata>,
         cfg_targets: Vec<cargo_deny::root_cfg::Target>,
         cfg_excludes: Vec<String>,
     ) -> Result<cargo_deny::Krates, anyhow::Error> {
@@ -116,7 +117,7 @@ impl KrateContext {
         let start = std::time::Instant::now();
 
         log::debug!("gathering crate metadata");
-        let metadata = Self::get_metadata(MetadataOptions {
+        let metadata = metadata.map(Ok).unwrap_or_else(|| Self::get_metadata(MetadataOptions {
             no_default_features: self.no_default_features,
             all_features: self.all_features,
             features: self.features,
@@ -124,7 +125,7 @@ impl KrateContext {
             frozen: self.frozen,
             locked: self.locked,
             offline: self.offline,
-        })?;
+        }))?;
         log::debug!(
             "gathered crate metadata in {}ms",
             start.elapsed().as_millis()

--- a/src/cargo-deny/list.rs
+++ b/src/cargo-deny/list.rs
@@ -24,6 +24,13 @@ pub struct Args {
     /// Defaults to a deny.toml in the same folder as the manifest path, or a deny.toml in a parent directory.
     #[arg(short, long)]
     config: Option<PathBuf>,
+    /// Path to cargo metadata json
+    /// 
+    /// By default we use `cargo metadata` to generate
+    /// the metadata json, but you can override that behaviour by
+    /// providing the path to cargo metadata.
+    #[arg(long)]
+    metadata_path: Option<PathBuf>,
     /// Minimum confidence threshold for license text
     ///
     /// When determining the license from file contents, a confidence score is assigned according to how close the contents are to the canonical license text. If the confidence score is below this threshold, they license text will ignored, which might mean the crate is treated as unlicensed.
@@ -57,8 +64,15 @@ pub fn cmd(
         log_ctx,
     )?;
 
+    let metadata = if let Some(metadata_path) = args.metadata_path {
+        let data = std::fs::read_to_string(metadata_path).context("metadata path")?;
+        Some(serde_json::from_str(&data).context("cargo metadata")?)
+    } else {
+        None
+    };
+
     let (krates, store) = rayon::join(
-        || krate_ctx.gather_krates(graph.targets, graph.exclude),
+        || krate_ctx.gather_krates(metadata, graph.targets, graph.exclude),
         crate::common::load_license_store,
     );
 


### PR DESCRIPTION
Add support for providing metadata via `--metadata-path` to allow support for cargo-less setups like bazel.

Fixes: #777