### PR TITLE
Add a config option to suppress `warning[unmatched-source]: allowed source was not encountered`

### DIFF
--- a/docs/src/checks/sources/cfg.md
+++ b/docs/src/checks/sources/cfg.md
@@ -122,3 +122,11 @@ Allows you to specify multiple `bitbucket.org` organizations to allow as git sou
 [sources.allow-org]
 bitbucket = ["YourCoolOrgGoesHere"]
 ```
+
+### The `unused-allowed-source` field (optional)
+
+Determines what happens when one of the sources that appears in the `allow` list is not encountered in the dependency graph.
+
+- `warn` (default) - A warning is emitted for each source that appears in `sources.allow` but which is not used in any crate.
+- `allow` - Unused sources in the `sources.allow` list are ignored.
+- `deny` - An unused source in the `sources.allow` list triggers an error, and cause the source check to fail.

--- a/docs/src/checks/sources/diags.md
+++ b/docs/src/checks/sources/diags.md
@@ -21,6 +21,8 @@ A crate's source was not explicitly allowed.
 
 An allowed source in [`sources.allow-git`](cfg.md#the-allow-git-field-optional) or [`sources.allow-registry`](cfg.md#the-allow-registry-field-optional) was not encountered.
 
+This diagnostic can be silenced by configuring the [`sources.unused-allowed-source`](cfg.md#the-unused-allowed-source-field-optional) field to "allow".
+
 ### `unmatched-organization`
 
 An allowed source in [`sources.allow-org`](cfg.md#the-allow-org-field-optional) was not encountered.

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -161,6 +161,7 @@ pub fn check(ctx: crate::CheckCtx<'_, ValidConfig>, sink: impl Into<ErrorSink>) 
         }
 
         pack.push(diags::UnmatchedAllowSource {
+            severity: ctx.cfg.unused_allowed_source.into(),
             allow_src_cfg: CfgCoord {
                 span: src.url.span,
                 file: ctx.cfg.file_id,

--- a/src/sources/cfg.rs
+++ b/src/sources/cfg.rs
@@ -92,6 +92,9 @@ pub struct Config {
     /// The minimum specification required for git sources. Defaults to allowing
     /// any.
     pub required_git_spec: Option<Spanned<GitSpec>>,
+    /// Determines the response to sources in th `allow`ed list which do not
+    /// exist in the dependency tree.
+    pub unused_allowed_source: LintLevel,
 }
 
 impl<'de> Deserialize<'de> for Config {
@@ -106,6 +109,7 @@ impl<'de> Deserialize<'de> for Config {
         let allow_org = th.optional("allow-org").unwrap_or_default();
         let private = th.optional("private").unwrap_or_default();
         let required_git_spec = th.optional("required-git-spec");
+        let unused_allowed_source = th.optional("unused-allowed-source").unwrap_or(LintLevel::Warn);
 
         th.finalize(None)?;
 
@@ -117,6 +121,7 @@ impl<'de> Deserialize<'de> for Config {
             allow_org,
             private,
             required_git_spec,
+            unused_allowed_source,
         })
     }
 }
@@ -131,6 +136,7 @@ impl Default for Config {
             allow_org: Orgs::default(),
             private: Vec::new(),
             required_git_spec: None,
+            unused_allowed_source: LintLevel::Warn,
         }
     }
 }
@@ -213,6 +219,7 @@ impl cfg::UnvalidatedConfig for Config {
             allowed_sources,
             allowed_orgs,
             required_git_spec: self.required_git_spec,
+            unused_allowed_source: self.unused_allowed_source,
         }
     }
 }
@@ -235,6 +242,7 @@ pub struct ValidConfig {
     pub allowed_sources: Vec<UrlSource>,
     pub allowed_orgs: Vec<(OrgType, Spanned<String>)>,
     pub required_git_spec: Option<Spanned<GitSpec>>,
+    pub unused_allowed_source: LintLevel,
 }
 
 #[cfg(test)]

--- a/src/sources/diags.rs
+++ b/src/sources/diags.rs
@@ -117,12 +117,13 @@ impl<'a> From<SourceNotExplicitlyAllowed<'a>> for Diag {
 }
 
 pub(crate) struct UnmatchedAllowSource {
+    pub(crate) severity: Severity,
     pub(crate) allow_src_cfg: CfgCoord,
 }
 
 impl From<UnmatchedAllowSource> for Diag {
     fn from(uas: UnmatchedAllowSource) -> Self {
-        Diagnostic::new(Severity::Warning)
+        Diagnostic::new(uas.severity)
             .with_message("allowed source was not encountered")
             .with_code(Code::UnmatchedSource)
             .with_labels(vec![

--- a/src/sources/snapshots/cargo_deny__sources__cfg__test__deserializes_sources_cfg-2.snap
+++ b/src/sources/snapshots/cargo_deny__sources__cfg__test__deserializes_sources_cfg-2.snap
@@ -45,4 +45,5 @@ ValidConfig {
     required_git_spec: Some(
         Tag,
     ),
+    unused_allowed_source: Warn,
 }

--- a/tests/cfg/sources.toml
+++ b/tests/cfg/sources.toml
@@ -12,6 +12,7 @@ allow-git = [
 private = [
     "https://internal-host/repos",
 ]
+unused-allowed-source = "warn"
 [sources.allow-org]
 github = [
     "yourghid",


### PR DESCRIPTION
Thank you for the nice project!
This is my first PR for this project.
Therefore if I have any mistakes for contribution, please let me know...

---

There are several reasons you might want this:

1. If the `allow` list represents the set sources for a project that have gone through some external approval process, such as vetting it with a legal department.
2. You're checking a single project in a workspace that shares its `deny.toml` for all members, but not all members have identical dependency sets.
3. You'd like to use `deny.toml` as part of a project template, and configure it with some default set of sources you find acceptable
4. ... others, for sure...

As it is, this warning isn't a huge deal, but is annoying/unhelpful if you don't care about it. I suspect that it's useful for catching typos or keeping configuration tight (and so I think "warn" is the right default for it), but there are enough reasons to want to turn it off that it seems justified to me for it to be an option.

It was easy to add support for a config property which controls the lint level for this check, so I just did that. I guess setting it to `deny` could be desirable in some cases, although it seems a little dodgy to me for various reasons... That said, I didn't see a reason to forbid that sort of thing, and allowing it to be configured as a `LintLevel` seemed more consistent.

### Additional Information

- This PR is for #781 
- This PR modification is very similar with #368 
- config name, `unused-allowed-source` is inspired by `licenses.unused-allowed-licens` in #368 