### PR TITLE
Enable LTO and strip symbols in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,3 +160,8 @@ opt-level = 3
 opt-level = 3
 
 [workspace]
+
+[profile.release]
+lto = "fat"
+strip = "symbols"
+codegen-units = 1


### PR DESCRIPTION
Decreases the file size of `cargo-deny` from 23Mb down to 15Mb.