### PR TITLE
Add `markdown` output format to the list command

### DIFF
--- a/docs/src/cli/list.md
+++ b/docs/src/cli/list.md
@@ -16,6 +16,7 @@ The format of the output
 
 * `human` (default) - Simple format where each crate or license is its own line
 * `json`
+* `markdown`
 * `tsv`
 
 ### [`--color`](../cli/common.md#--color)

--- a/tests/snapshots/cargo_deny__test__cargo_deny-list.snap
+++ b/tests/snapshots/cargo_deny__test__cargo_deny-list.snap
@@ -30,7 +30,7 @@ Options:
           The format of the output
           
           [default: human]
-          [possible values: human, json, tsv]
+          [possible values: human, json, markdown, tsv]
 
   -l, --layout <LAYOUT>
           The layout for the output, does not apply to TSV


### PR DESCRIPTION
This format follows the existing 'human' option, but makes it easier to render as a table in Markdown viewers. Both layouts are present:
 - Crate
 - License

The backtick (`) is used to make it easier to visually parse the long list of elements in the second column. This design is partially inspired by the cabal-plan license-report tool [1],[2].

Sources:
[1] https://hackage.haskell.org/package/cabal-plan
[2] https://hackage.haskell.org/package/cabal-plan-0.7.6.1/src/example/cabal-plan.md