### PR TITLE
Add ability to ignore `build-dependencies` when checking for licenses

### DIFF
--- a/docs/src/checks/licenses/cfg.md
+++ b/docs/src/checks/licenses/cfg.md
@@ -45,6 +45,10 @@ allow = [
 
 If `true`, licenses are checked even for `dev-dependencies`. By default this is false as `dev-dependencies` are not used by downstream crates, nor part of binary artifacts.
 
+### The `include-build` field (optional)
+
+If `true`, licenses are checked for `build-dependencies`. By default this is true because build-dependencies can influence build artifacts and are often relevant to licensing. Set this to `false` if you wish to exclude `build-dependencies` from license checks.
+
 ### The `version` field (optional)
 
 ```ini

--- a/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
+++ b/src/licenses/snapshots/cargo_deny__licenses__cfg__test__deserializes_licenses_cfg-2.snap
@@ -46,5 +46,6 @@ expression: validated
     }
   ],
   "ignore_sources": [],
-  "include_dev": false
+  "include_dev": false,
+  "include_build": true
 }


### PR DESCRIPTION
This PR (AI generated) for issue #744 adds a new include-build configuration option to the [licenses] section, allowing users to opt out of checking build-dependencies for license checks.

What changed:

    src/licenses/cfg.rs: added include_build (TOML key: include-build) with default true and validation.
    src/licenses/gather.rs: respect include-build (in combination with include-dev) when selecting which crates to check for licenses.
    docs/src/checks/licenses/cfg.md: documented include-build.
    Added a unit test and updated snapshots for deserialization.

Notes:

    Default behavior preserved: build-dependencies are included by default to avoid breaking existing usage.

Please review and comment.

Resolves: #744 
