### PR TITLE
Fix building on Alpine

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -75,6 +75,3 @@ rustflags = [
     "-Wrust_2018_idioms",
     # END - Embark standard lints v6 for Rust 1.55+
 ]
-
-[target.'cfg(target_env = "musl")']
-rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Hey,

The current version on main doesn't build on Alpine linux, failing with the error:
```
cannot produce proc-macro for `clap_derive v4.5.49` as the target `x86_64-unknown-linux-musl` does not support these crate types
```
Researching a little into this issue ([one](https://github.com/rust-lang/rust/issues/40174#issuecomment-538791091), [two](https://stackoverflow.com/questions/57965805/alpine-dockerfile-cannot-produce-proc-macro-does-not-support-these-crate-typ)) seems to point to the fact that proc-macro crates cannot be compiled statically. This is not usually a problem because proc-macro crates are built to the host's target, and I assume your hosts are all `x86_64-unknown-linux-gnu`, and thus they don't get the `target.'cfg(target_env = "musl")'` clause applied to them even when cross-compiling to musl. However, when building on Alpine, the host's target is in fact musl and cargo tries to statically link proc-macro creates (and build scripts).

I am not sure if your CI somehow relies on this clause - to the best of my knowledge, cross-compiling musl binaries on non-musl systems (e.g. running `cargo build --target x86_64-unknown-linux-musl` on a Debian machine) already uses static linking by default, and thus explicitly specifying `+crt-static` here should be redundant. However, if you do need to somehow pass `-C target-feature=+crt-static` explicitly, you should do this in the CI pipeline where it is required and not in Cargo's global config.toml (note that when cross compiling with `--target` and passing custom `rustflags` at the same time, Cargo has [a useful feature](https://github.com/rust-lang/cargo/blob/master/src/doc/src/reference/config.md#buildrustflags) where it passes these rustflags only to binaries targeting the destination architecture, and not to host-triplet targets, thus preventing breakage of this sort in that case).