### PR TITLE
make SARIF output spec-compliant

### DIFF
--- a/src/diag.rs
+++ b/src/diag.rs
@@ -140,8 +140,13 @@ impl Files {
                     start_line,
                     byte_offset: label.range.start,
                     byte_length: label.range.end - label.range.start,
-                    snippet: file.source.get(label.range.clone()).map(String::from),
-                    message: (!label.message.is_empty()).then(|| label.message.clone()),
+                    snippet: file.source.get(label.range.clone()).map(|text| {
+                        model::ArtifactContent {
+                            text: String::from(text),
+                        }
+                    }),
+                    message: (!label.message.is_empty())
+                        .then(|| model::Message::text(label.message.clone())),
                 },
             },
         })

--- a/src/sarif/model.rs
+++ b/src/sarif/model.rs
@@ -134,6 +134,11 @@ pub struct Message {
     pub markdown: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct ArtifactContent {
+    pub text: String,
+}
+
 impl Message {
     #[inline]
     pub fn text(text: String) -> Self {
@@ -170,9 +175,9 @@ pub struct Region {
     pub byte_offset: usize,
     pub byte_length: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub snippet: Option<String>,
+    pub snippet: Option<ArtifactContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
+    pub message: Option<Message>,
 }
 
 /// Convert cargo-deny severity to SARIF level

--- a/src/sarif/model.rs
+++ b/src/sarif/model.rs
@@ -127,16 +127,11 @@ pub struct Result {
     pub partial_fingerprints: BTreeMap<String, String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Message {
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub markdown: Option<String>,
-}
-
-#[derive(Serialize)]
-pub struct ArtifactContent {
-    pub text: String,
 }
 
 impl Message {
@@ -147,6 +142,11 @@ impl Message {
             markdown: None,
         }
     }
+}
+
+#[derive(Serialize, Debug)]
+pub struct ArtifactContent {
+    pub text: String,
 }
 
 #[derive(Serialize)]

--- a/tests/snapshots/sarif__sarif_bans.snap
+++ b/tests/snapshots/sarif__sarif_bans.snap
@@ -18,8 +18,12 @@ expression: s
                 "region": {
                   "byteLength": 6,
                   "byteOffset": 99,
-                  "message": "feature denied here",
-                  "snippet": "simple",
+                  "message": {
+                    "text": "feature denied here"
+                  },
+                  "snippet": {
+                    "text": "simple"
+                  },
                   "startLine": 4
                 }
               }
@@ -45,8 +49,12 @@ expression: s
                 "region": {
                   "byteLength": 7,
                   "byteOffset": 208,
-                  "message": "allowed features",
-                  "snippet": "['ssh']",
+                  "message": {
+                    "text": "allowed features"
+                  },
+                  "snippet": {
+                    "text": "['ssh']"
+                  },
                   "startLine": 6
                 }
               }
@@ -72,8 +80,12 @@ expression: s
                 "region": {
                   "byteLength": 7,
                   "byteOffset": 208,
-                  "message": "allowed features",
-                  "snippet": "['ssh']",
+                  "message": {
+                    "text": "allowed features"
+                  },
+                  "snippet": {
+                    "text": "['ssh']"
+                  },
                   "startLine": 6
                 }
               }
@@ -99,8 +111,12 @@ expression: s
                 "region": {
                   "byteLength": 7,
                   "byteOffset": 208,
-                  "message": "allowed features",
-                  "snippet": "['ssh']",
+                  "message": {
+                    "text": "allowed features"
+                  },
+                  "snippet": {
+                    "text": "['ssh']"
+                  },
                   "startLine": 6
                 }
               }
@@ -126,8 +142,12 @@ expression: s
                 "region": {
                   "byteLength": 7,
                   "byteOffset": 208,
-                  "message": "allowed features",
-                  "snippet": "['ssh']",
+                  "message": {
+                    "text": "allowed features"
+                  },
+                  "snippet": {
+                    "text": "['ssh']"
+                  },
                   "startLine": 6
                 }
               }
@@ -153,8 +173,12 @@ expression: s
                 "region": {
                   "byteLength": 14,
                   "byteOffset": 148,
-                  "message": "feature denied here",
-                  "snippet": "zlib-ng-compat",
+                  "message": {
+                    "text": "feature denied here"
+                  },
+                  "snippet": {
+                    "text": "zlib-ng-compat"
+                  },
                   "startLine": 5
                 }
               }
@@ -180,8 +204,12 @@ expression: s
                 "region": {
                   "byteLength": 5,
                   "byteOffset": 37,
-                  "message": "banned here",
-                  "snippet": "vcpkg",
+                  "message": {
+                    "text": "banned here"
+                  },
+                  "snippet": {
+                    "text": "vcpkg"
+                  },
                   "startLine": 2
                 }
               }

--- a/tests/snapshots/sarif__sarif_licenses.snap
+++ b/tests/snapshots/sarif__sarif_licenses.snap
@@ -18,8 +18,12 @@ expression: s
                 "region": {
                   "byteLength": 7,
                   "byteOffset": 131,
-                  "message": "a deprecated license identifier was used",
-                  "snippet": "GPL-2.0",
+                  "message": {
+                    "text": "a deprecated license identifier was used"
+                  },
+                  "snippet": {
+                    "text": "GPL-2.0"
+                  },
                   "startLine": 4
                 }
               }
@@ -45,7 +49,9 @@ expression: s
                 "region": {
                   "byteLength": 51,
                   "byteOffset": 120,
-                  "snippet": "Apache-2.0/GPL-2.0+ AND LGPL-3.0-only or gnu gpl v3",
+                  "snippet": {
+                    "text": "Apache-2.0/GPL-2.0+ AND LGPL-3.0-only or gnu gpl v3"
+                  },
                   "startLine": 4
                 }
               }
@@ -58,8 +64,12 @@ expression: s
                 "region": {
                   "byteLength": 10,
                   "byteOffset": 120,
-                  "message": "rejected: license is not explicitly allowed",
-                  "snippet": "Apache-2.0",
+                  "message": {
+                    "text": "rejected: license is not explicitly allowed"
+                  },
+                  "snippet": {
+                    "text": "Apache-2.0"
+                  },
                   "startLine": 4
                 }
               }
@@ -72,8 +82,12 @@ expression: s
                 "region": {
                   "byteLength": 7,
                   "byteOffset": 131,
-                  "message": "accepted: license is explicitly allowed",
-                  "snippet": "GPL-2.0",
+                  "message": {
+                    "text": "accepted: license is explicitly allowed"
+                  },
+                  "snippet": {
+                    "text": "GPL-2.0"
+                  },
                   "startLine": 4
                 }
               }
@@ -86,8 +100,12 @@ expression: s
                 "region": {
                   "byteLength": 13,
                   "byteOffset": 144,
-                  "message": "rejected: license is not explicitly allowed",
-                  "snippet": "LGPL-3.0-only",
+                  "message": {
+                    "text": "rejected: license is not explicitly allowed"
+                  },
+                  "snippet": {
+                    "text": "LGPL-3.0-only"
+                  },
                   "startLine": 4
                 }
               }
@@ -100,8 +118,12 @@ expression: s
                 "region": {
                   "byteLength": 10,
                   "byteOffset": 161,
-                  "message": "rejected: license is not explicitly allowed",
-                  "snippet": "gnu gpl v3",
+                  "message": {
+                    "text": "rejected: license is not explicitly allowed"
+                  },
+                  "snippet": {
+                    "text": "gnu gpl v3"
+                  },
                   "startLine": 4
                 }
               }

--- a/tests/snapshots/sarif__sarif_sources.snap
+++ b/tests/snapshots/sarif__sarif_sources.snap
@@ -43,8 +43,12 @@ expression: s
                 "region": {
                   "byteLength": 9,
                   "byteOffset": 134,
-                  "message": "no crate source fell under this organization",
-                  "snippet": "bizzlepop",
+                  "message": {
+                    "text": "no crate source fell under this organization"
+                  },
+                  "snippet": {
+                    "text": "bizzlepop"
+                  },
                   "startLine": 5
                 }
               }


### PR DESCRIPTION
The SARIF 2.1.0 spec requires region.snippet to be an artifactContent object and region.message to be a message object. cargo-deny was emitting them as bare strings, causing GitHub's upload-sarif action to reject the output.

Fixes: #818
Refs: #820