### PR TITLE
Fix ^ and ~ version matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#864](https://github.com/EmbarkStudios/cargo-deny/pull/864) fixed matching of `^` and `~` with on prerelease versions for when checking if a crate is affected by an advisory. As of the time of the PR, this literally affected none of published versions of any crate with an advisory, but this just ensures such a case will be handled in the future.
+
 ## [0.19.7] - 2026-05-22
 ### Changed
 - [PR#860](https://github.com/EmbarkStudios/cargo-deny/pull/860) updated crates, resolving [krates#111](https://github.com/EmbarkStudios/krates/issues/111).

--- a/src/advisories/helpers/db.rs
+++ b/src/advisories/helpers/db.rs
@@ -721,7 +721,7 @@ pub fn find_unaffected_req<'v>(
                             return false;
                         }
 
-                        true
+                        cmp_pre(comp, vers) != Or::Less
                     }
                     Op::Tilde => {
                         if comp.major != vers.major {
@@ -740,7 +740,7 @@ pub fn find_unaffected_req<'v>(
                             return patch < vers.patch;
                         }
 
-                        true
+                        cmp_pre(comp, vers) != Or::Less
                     }
                     _ => unreachable!("fucking non-exhaustive"),
                 }
@@ -849,5 +849,45 @@ mod test {
         ]) {
             assert!(!super::is_affected(&vs, &version), "{version}");
         }
+
+        for version in v!([
+            "2.0.0-alpha.1",
+            "2.0.0-alpha.2",
+            "2.0.0-alpha.3",
+            "2.0.0-alpha.4",
+            "2.0.0-beta.1",
+            "2.0.0-beta.2",
+            "2.0.0-beta.3",
+            "2.0.0-beta.4",
+            // This version doesn't actually exist it is here to ensure that pre-releases are not considered as patched
+            // even if they match the major, minor, and patch versions
+            "2.2.1-alpha.1",
+            "3.0.0-beta.8",
+        ]) {
+            assert!(super::is_affected(&vs, &version), "{version}");
+        }
+
+        // Note there is no case of patched or unaffected versions using `~` in the official rustsec advisory DB, so the
+        // following checks are just based on rustsec's own unit tests
+        fn assert_tilde(
+            vs: Vec<semver::VersionReq>,
+            versions: impl Iterator<Item = semver::Version>,
+        ) {
+            let vs = super::model::Versions {
+                patched: vs,
+                unaffected: Vec::new(),
+            };
+
+            for version in versions {
+                assert!(!super::is_affected(&vs, &version), "{version}");
+            }
+        }
+
+        assert_tilde(vr!(["~1.2.3"]), v!(["1.2.3", "1.2.999"]));
+        assert_tilde(vr!(["~1.2"]), v!(["1.2.0", "1.2.3", "1.2.999"]));
+        assert_tilde(
+            vr!(["~1"]),
+            v!(["1.0.0", "1.2.0", "1.2.3", "1.2.999", "1.3.0", "1.99.999"]),
+        );
     }
 }


### PR DESCRIPTION
cargo-deny's goal is to match rustsec/cargo audit 100% when it comes to flagging affected versions of a package, the code as is currently works for every published version of every crate that has one or more advisories, but if a future advisory used a ^ or ~ on a prelease version then we wouldn't have matched rustsec.