### PR TITLE
docs: fix unclarities

### DIFF
--- a/docs/src/checks/cfg.md
+++ b/docs/src/checks/cfg.md
@@ -1,6 +1,6 @@
 # config
 
-The top level config for cargo-deny, by default called `deny.toml`.  The config can also live in the `.config` directory, i.e. `.config/deny.toml`.
+The top level config for cargo-deny, by default called `deny.toml`.  The config can be hidden (`.deny.toml`) or live in the `.cargo` directory, i.e. `.cargo/deny.toml`.
 
 ## Example - cargo-deny's own configuration
 

--- a/docs/src/checks/cfg.md
+++ b/docs/src/checks/cfg.md
@@ -1,6 +1,6 @@
 # config
 
-The top level config for cargo-deny, by default called `deny.toml`.
+The top level config for cargo-deny, by default called `deny.toml`.  The config can also live in the `.config` directory, i.e. `.config/deny.toml`.
 
 ## Example - cargo-deny's own configuration
 

--- a/docs/src/cli/check.md
+++ b/docs/src/cli/check.md
@@ -4,7 +4,7 @@ The check command is the primary subcommand of cargo-deny as it is what actually
 
 ## Args
 
-### `<WHICH>`
+### `[WHICH...]`
 
 The check(s) to perform. By default, **all** checks will be performed, unless one or more checks are specified here.
 


### PR DESCRIPTION
## Summary
- Make clear that you can check for multiple things (using common one-or-many CLI syntax)
- Clarify that the config can also be located in the `.cargo` directory